### PR TITLE
docs: Update docs-app content with installation instructions

### DIFF
--- a/docs-app/app/templates/application.hbs
+++ b/docs-app/app/templates/application.hbs
@@ -5,7 +5,7 @@
     <TopBar>
       <:title>
         <span class="lowercase h-full">
-          to
+          ember-toucan-core
         </span>
       </:title>
 

--- a/docs-app/app/templates/index.hbs
+++ b/docs-app/app/templates/index.hbs
@@ -4,11 +4,17 @@
     <h1 class="type-3xl">ember-toucan-core</h1>
 
     <p class="type-lg">
-      Coming up!
+      Toucan provides a set of simple, accessible, and reusable components that
+      make it easy to create visually consistent and efficient Ember
+      applications.
     </p>
 
     <span>
-      <Toucan::Link @variant="brand" class="px-6 py-1 flex gap-3" @href="/docs">
+      <Toucan::Link
+        @variant="brand"
+        class="px-6 py-1 flex gap-3"
+        @href="/docs/installation"
+      >
         Read the Docs
         <svg
           class="w-4 ml-2"
@@ -34,11 +40,11 @@
 <Main>
   <ContentSection>
     <:header>
-      Use any markup or styles
+      Build entire Ember applications using Toucan
     </:header>
     <:content>
-      <span>
-      </span>
+      Our goal is to provide building blocks to help you focus on creating your
+      application, rather than having to build a design system from scratch.
     </:content>
   </ContentSection>
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,1 +1,0 @@
-This is the index page.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,17 @@
+# Installation
+
+To use Toucan in your project, run one of the following commands in your terminal:
+
+```bash
+pnpm add @crowdstrike/ember-toucan-core
+# or
+yarn add @crowdstrike/ember-toucan-core
+# or
+npm install @crowdstrike/ember-toucan-core
+# or
+ember install @crowdstrike/ember-toucan-core
+```
+
+## Setup Tailwind
+
+Toucan is built using [TailwindCSS](https://tailwindcss.com). CrowdStrike has built a few other open source packages to assist with using our Tailwind configuration. It is recommended to follow [the instructions for ember-toucan-styles](https://github.com/CrowdStrike/ember-toucan-styles#setup) to finish setup of your Ember application.


### PR DESCRIPTION
## 🚀 Description
Updates the docs-app with less TODO/Coming Soon text and a bit more info.  In particular, an installation section.  Since this is still a private repo, this isn't actually valid yet, as we aren't releasing, but soon™.

---

## 🔬 How to Test

**CI**
CI (Actions) should all be green 🟢 .  CI tests linting and tests!

**Docs App**

Pull down this repo and run the following:

```bash
pnpm i
cd docs-app
pnpm start
```

Go to the docs page and behold all of their glory.

---

## 📸 Images/Videos of Functionality

<img width="1470" alt="Screenshot 2023-01-26 at 1 33 41 PM" src="https://user-images.githubusercontent.com/8069555/214920459-9149f3ba-dacc-4247-9956-0a5cf2f669eb.png">

<img width="1470" alt="Screenshot 2023-01-26 at 1 33 44 PM" src="https://user-images.githubusercontent.com/8069555/214920457-da8d634d-3af1-42da-bf4f-3042ab28301c.png">
