### PR TITLE
fix: Update tests step to use test-app

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/pnpm
       - uses: ./.github/actions/download-built-package
-      - run: pnpm --filter ember-app test:ember
+      - run: pnpm --filter test-app test:ember
 
   # floating_tests:
   #   name: Floating Deps Test
@@ -100,7 +100,7 @@ jobs:
   #     - name: Install Dependencies (without lockfile)
   #       run: rm pnpm-lock.yaml && pnpm install
   #     - uses: ./.github/actions/download-built-package
-  #     - run: pnpm --filter ember-app test:ember
+  #     - run: pnpm --filter test-app test:ember
 
 
   # try_scenarios:


### PR DESCRIPTION
## 🚀 Description
There was a typo in the workflow so tests weren't running at all! Now they should be.

https://github.com/CrowdStrike/ember-toucan-core/actions/runs/4019176517/jobs/6905719083

```bash
2023-01-26T21:11:48.3267269Z ##[group]Run pnpm --filter test-app test:ember
2023-01-26T21:11:48.3267578Z [36;1mpnpm --filter test-app test:ember[0m
2023-01-26T21:11:48.3320745Z shell: /usr/bin/bash -e {0}
2023-01-26T21:11:48.3320952Z env:
2023-01-26T21:11:48.3321120Z   CI: true
2023-01-26T21:11:48.3321324Z   dist: ember-toucan-core/dist
2023-01-26T21:11:48.3321625Z   PNPM_HOME: /home/runner/setup-pnpm/node_modules/.bin
2023-01-26T21:11:48.3321876Z ##[endgroup]
2023-01-26T21:11:48.9140102Z 
2023-01-26T21:11:48.9141267Z > test-app@0.0.0 test:ember /home/runner/work/ember-toucan-core/ember-toucan-core/test-app
2023-01-26T21:11:48.9141674Z > ember test
2023-01-26T21:11:48.9141796Z 
2023-01-26T21:11:51.1951919Z Building
2023-01-26T21:11:51.1955265Z Environment: test
2023-01-26T21:11:52.3398127Z building... 
2023-01-26T21:12:06.4169697Z cleaning up
2023-01-26T21:12:06.4171804Z cleaning up...
2023-01-26T21:12:06.4805215Z Built project successfully. Stored in "/tmp/tests-dist-2023026-1930-262x4z.zztok".
2023-01-26T21:12:08.1684623Z ok 1 Chrome 109.0 - [78 ms] - Integration | Component | button: it renders
2023-01-26T21:12:08.1687680Z ok 2 Chrome 109.0 - [37 ms] - Integration | Component | button: it yields a loading named block when `@isLoading={{true}}
2023-01-26T21:12:08.1729481Z ok 3 Chrome 109.0 - [40 ms] - Integration | Component | button: it does not render the content in the loading named block when `@isLoading={{false}}
2023-01-26T21:12:08.2099702Z ok 4 Chrome 109.0 - [36 ms] - Integration | Component | button: it sets `aria-disabled="true"` when `@isDisabled={{true}}
2023-01-26T21:12:08.2461265Z ok 5 Chrome 109.0 - [36 ms] - Integration | Component | button: it yields a disabled named block when `@isDisabled={{true}}
2023-01-26T21:12:08.2835188Z ok 6 Chrome 109.0 - [37 ms] - Integration | Component | button: it does not render the content in the disabled named block when `@isDisabled={{false}}
2023-01-26T21:12:08.3275313Z ok 7 Chrome 109.0 - [44 ms] - Integration | Component | button: it calls the provided `@onClick`
2023-01-26T21:12:08.3684596Z ok 8 Chrome 109.0 - [40 ms] - Integration | Component | button: it does NOT call the provided `@onClick` if `@isDisabled={{true}}
2023-01-26T21:12:08.4209547Z ok 9 Chrome 109.0 - [37 ms] - Integration | Component | button: it throws an assertion error if provided with an unsupported `@variant`
2023-01-26T21:12:08.4210525Z     ---
2023-01-26T21:12:08.4211178Z         browser log: |
2023-01-26T21:12:08.4211999Z             {"type":"error","text":"\n\nError occurred:\n\n- While rendering:\n  -top-level\n    application\n      index\n        _buttonTest9\n          Button\n\n"}
2023-01-26T21:12:08.4212665Z             {"type":"error","text":"\n\nError occurred:\n\n\n\n"}
2023-01-26T21:12:08.4213072Z     ...
2023-01-26T21:12:08.4218618Z ok 10 Chrome 109.0 - [1 ms] - ember-qunit: Ember.onerror validation: Ember.onerror is functioning properly
2023-01-26T21:12:08.4540119Z 
2023-01-26T21:12:08.4540571Z 1..10
2023-01-26T21:12:08.4541085Z # tests 10
2023-01-26T21:12:08.4541339Z # pass  10
2023-01-26T21:12:08.4541540Z # skip  0
2023-01-26T21:12:08.4541719Z # todo  0
2023-01-26T21:12:08.4541891Z # fail  0
2023-01-26T21:12:08.4541993Z 
2023-01-26T21:12:08.4542063Z # ok
```

---

## 🔬 How to Test

**CI**
CI (Actions) should all be green 🟢 .  CI tests linting and tests!
