### PR TITLE
docs: Stack buttons on mobile

### DIFF
--- a/docs/components/button/index.md
+++ b/docs/components/button/index.md
@@ -6,7 +6,7 @@ Buttons are clickable elements used primarily for actions. Button content expres
 
 You can customize the appearance of the button with the `@variant` component argument.
 
-<div class="flex gap-x-4">
+<div class="flex flex-col gap-4 md:flex-row">
   <Button @variant="primary">Primary</Button>
   <Button @variant="secondary">Secondary</Button>
   <Button @variant="destructive">Destructive</Button>
@@ -59,7 +59,7 @@ A disabled named block is provided so that users can optionally render additiona
 </Button>
 ```
 
-<div class="flex gap-x-4">
+<div class="flex flex-col items-center gap-4 md:flex-row">
   {{#each (array "primary" "secondary" "destructive" "link" "quiet" "bare") as |variant|}}
     <Button @variant={{variant}} @isDisabled={{true}}>
       <:disabled>
@@ -123,7 +123,7 @@ A loading named block is also provided for providing custom loading content.
 </Button>
 ```
 
-<div class="flex gap-x-4">
+<div class="flex flex-col items-center gap-4 md:flex-row">
   {{#each (array "primary" "secondary" "destructive" "link" "quiet" "bare") as |variant|}}
     <Button @variant={{variant}} @isLoading={{true}}>
       <:loading>


### PR DESCRIPTION
## 💅 Description

I noticed the buttons on mobile started to get cutoff due to being horizontal.  Instead, I think it makes sense to stack them vertically when on mobile like other design systems.

<img width="686" alt="Screenshot 2023-02-06 at 11 43 03 AM" src="https://user-images.githubusercontent.com/8069555/217031652-ad4a7574-6ec1-4a2f-9df0-8dd04922d185.png">


---

## 🔬 How to Test

**CI**
CI (Actions) should all be green 🟢 

**Docs App**

- View the docs app via the Preview URL
- Make your browser width small (or view on your mobile device!)
- Verify the buttons don't butt up against one another, but instead are vertical

---

## 📸 Images/Videos of Functionality

<img width="686" alt="Screenshot 2023-02-06 at 11 39 03 AM" src="https://user-images.githubusercontent.com/8069555/217031382-6593efc5-bee1-412c-9c4c-4a4b93d3b6a9.png">

<img width="686" alt="Screenshot 2023-02-06 at 11 39 08 AM" src="https://user-images.githubusercontent.com/8069555/217031391-cac608b3-c06c-4d37-b5cb-109a403266b5.png">

<img width="686" alt="Screenshot 2023-02-06 at 11 39 11 AM" src="https://user-images.githubusercontent.com/8069555/217031397-7e74378b-83e1-4b4d-afcf-1b2de7717141.png">


