### PR TITLE
fix: Skip canary tests for now

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,8 @@ jobs:
           - ember-4.8
           - ember-release
           - ember-beta
-          - ember-canary
+          # @todo enable this again: https://github.com/CrowdStrike/ember-toucan-core/issues/38
+          # - ember-canary
           - "'ember-release + embroider-optimized'"
           - "'ember-lts-4.8 + embroider-optimized'"
 


### PR DESCRIPTION
Related to https://github.com/CrowdStrike/ember-headless-form/pull/55 / https://github.com/CrowdStrike/ember-headless-form/issues/54, we're hitting the same issue here.