### PR TITLE
#41: Add Tailwind prettier plugin+run it

### DIFF
--- a/docs-app/.prettierrc.js
+++ b/docs-app/.prettierrc.js
@@ -11,6 +11,7 @@ module.exports = {
       files: '*.hbs',
       options: {
         singleQuote: false,
+        plugins: ['prettier-plugin-tailwindcss'],
       },
     },
     {

--- a/docs-app/app/templates/application.hbs
+++ b/docs-app/app/templates/application.hbs
@@ -4,7 +4,7 @@
   <:topBar>
     <TopBar>
       <:title>
-        <span class="lowercase h-full">
+        <span class="h-full lowercase">
           ember-toucan-core
         </span>
       </:title>

--- a/docs-app/app/templates/index.hbs
+++ b/docs-app/app/templates/index.hbs
@@ -12,12 +12,12 @@
     <span>
       <Toucan::Link
         @variant="brand"
-        class="px-6 py-1 flex gap-3"
+        class="flex gap-3 px-6 py-1"
         @href="/docs/installation"
       >
         Read the Docs
         <svg
-          class="w-4 ml-2"
+          class="ml-2 w-4"
           viewBox="0 0 14 13"
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
@@ -51,7 +51,7 @@
   <ContentSection>
     <:content>
       <div
-        class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-12 md:gap-16"
+        class="grid grid-cols-1 gap-12 lg:grid-cols-3 sm:grid-cols-2 md:gap-16"
       >
         <FeatureCard @title="Coming Soon">
           Features coming up!

--- a/docs-app/package.json
+++ b/docs-app/package.json
@@ -106,6 +106,7 @@
     "postcss-loader": "^7.0.1",
     "prettier": "^2.8.3",
     "prettier-plugin-ember-template-tag": "^0.3.0",
+    "prettier-plugin-tailwindcss": "^0.2.3",
     "qunit": "^2.19.1",
     "qunit-dom": "^2.0.0",
     "tailwindcss": "^3.1.8",

--- a/ember-toucan-core/.prettierrc.cjs
+++ b/ember-toucan-core/.prettierrc.cjs
@@ -11,6 +11,7 @@ module.exports = {
       files: '*.hbs',
       options: {
         singleQuote: false,
+        plugins: ['prettier-plugin-tailwindcss'],
       },
     },
     {

--- a/ember-toucan-core/package.json
+++ b/ember-toucan-core/package.json
@@ -96,6 +96,7 @@
     "postcss": "^8.2.14",
     "prettier": "^2.8.3",
     "prettier-plugin-ember-template-tag": "^0.3.0",
+    "prettier-plugin-tailwindcss": "^0.2.3",
     "rollup": "^3.12.1",
     "rollup-plugin-copy": "^3.4.0",
     "rollup-plugin-ts": "^3.0.2",

--- a/ember-toucan-core/src/components/form/-private/error.hbs
+++ b/ember-toucan-core/src/components/form/-private/error.hbs
@@ -1,4 +1,4 @@
-<div class="type-xs-tight text-critical flex items-center mt-1" ...attributes>
+<div class="type-xs-tight text-critical mt-1 flex items-center" ...attributes>
   {{! Icon taken from Tony's open source icon set, this is temporary! }}
   <svg
     xmlns="http://www.w3.org/2000/svg"
@@ -7,7 +7,7 @@
     stroke="currentColor"
     viewBox="0 0 24 24"
     aria-hidden="true"
-    class="w-3 h-3 mr-1"
+    class="mr-1 h-3 w-3"
   >
     <path
       d="M12 3a9 9 0 11-6.364 2.636A8.972 8.972 0 0112 3zm0 4.7v5.2m0 3.39v.01"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -112,6 +112,7 @@ importers:
       postcss-loader: ^7.0.1
       prettier: ^2.8.3
       prettier-plugin-ember-template-tag: ^0.3.0
+      prettier-plugin-tailwindcss: ^0.2.3
       qunit: ^2.19.1
       qunit-dom: ^2.0.0
       tailwindcss: ^3.1.8
@@ -214,6 +215,7 @@ importers:
       postcss-loader: 7.0.2_6jdsrmfenkuhhw3gx4zvjlznce
       prettier: 2.8.3
       prettier-plugin-ember-template-tag: 0.3.2
+      prettier-plugin-tailwindcss: 0.2.3_prettier@2.8.3
       qunit: 2.19.4
       qunit-dom: 2.0.0
       tailwindcss: 3.2.4_postcss@8.4.21
@@ -277,6 +279,7 @@ importers:
       postcss: ^8.2.14
       prettier: ^2.8.3
       prettier-plugin-ember-template-tag: ^0.3.0
+      prettier-plugin-tailwindcss: ^0.2.3
       rollup: ^3.12.1
       rollup-plugin-copy: ^3.4.0
       rollup-plugin-ts: ^3.0.2
@@ -336,6 +339,7 @@ importers:
       postcss: 8.4.21
       prettier: 2.8.3
       prettier-plugin-ember-template-tag: 0.3.2
+      prettier-plugin-tailwindcss: 0.2.3_prettier@2.8.3
       rollup: 3.12.1
       rollup-plugin-copy: 3.4.0
       rollup-plugin-ts: 3.2.0_pwgqyj75od6zoiv4dk2aeilbby
@@ -13210,6 +13214,61 @@ packages:
       ts-replace-all: 1.0.0
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /prettier-plugin-tailwindcss/0.2.3_prettier@2.8.3:
+    resolution: {integrity: sha512-s2N5Dh7Ao5KTV1mao5ZBnn8EKtUcDPJEkGViZIjI0Ij9TTI5zgTz4IHOxW33jOdjHKa8CSjM88scelUiC5TNRQ==}
+    engines: {node: '>=12.17.0'}
+    peerDependencies:
+      '@ianvs/prettier-plugin-sort-imports': '*'
+      '@prettier/plugin-php': '*'
+      '@prettier/plugin-pug': '*'
+      '@shopify/prettier-plugin-liquid': '*'
+      '@shufo/prettier-plugin-blade': '*'
+      '@trivago/prettier-plugin-sort-imports': '*'
+      prettier: '>=2.2.0'
+      prettier-plugin-astro: '*'
+      prettier-plugin-css-order: '*'
+      prettier-plugin-import-sort: '*'
+      prettier-plugin-jsdoc: '*'
+      prettier-plugin-organize-attributes: '*'
+      prettier-plugin-organize-imports: '*'
+      prettier-plugin-style-order: '*'
+      prettier-plugin-svelte: '*'
+      prettier-plugin-twig-melody: '*'
+    peerDependenciesMeta:
+      '@ianvs/prettier-plugin-sort-imports':
+        optional: true
+      '@prettier/plugin-php':
+        optional: true
+      '@prettier/plugin-pug':
+        optional: true
+      '@shopify/prettier-plugin-liquid':
+        optional: true
+      '@shufo/prettier-plugin-blade':
+        optional: true
+      '@trivago/prettier-plugin-sort-imports':
+        optional: true
+      prettier-plugin-astro:
+        optional: true
+      prettier-plugin-css-order:
+        optional: true
+      prettier-plugin-import-sort:
+        optional: true
+      prettier-plugin-jsdoc:
+        optional: true
+      prettier-plugin-organize-attributes:
+        optional: true
+      prettier-plugin-organize-imports:
+        optional: true
+      prettier-plugin-style-order:
+        optional: true
+      prettier-plugin-svelte:
+        optional: true
+      prettier-plugin-twig-melody:
+        optional: true
+    dependencies:
+      prettier: 2.8.3
     dev: true
 
   /prettier/2.8.3:


### PR DESCRIPTION
## 💅  Description

This PR adds `prettier-plugin-tailwindcss` to the docs-app + `ember-toucan-core` package.

Closes #41 

---

## 📚 Documentation

- https://tailwindcss.com/blog/automatic-class-sorting-with-prettier

---

## 🔬 How to Test

- Non-visual change, only code formatting so builds need to be green.

---

## 📸 Images/Videos of Functionality

N/A
