### PR TITLE
feat: Use different ports for test/docs apps

### DIFF
--- a/docs-app/.ember-cli
+++ b/docs-app/.ember-cli
@@ -11,5 +11,6 @@
   Setting `isTypeScriptProject` to true will force the blueprint generators to generate TypeScript
   rather than JavaScript by default, when a TypeScript version of a given blueprint is available.
   */
-  "isTypeScriptProject": false
+  "isTypeScriptProject": false,
+  "port": 4201
 }

--- a/test-app/.ember-cli
+++ b/test-app/.ember-cli
@@ -11,5 +11,6 @@
     Setting `isTypeScriptProject` to true will force the blueprint generators to generate TypeScript
     rather than JavaScript by default, when a TypeScript version of a given blueprint is available.
   */
-  "isTypeScriptProject": true
+  "isTypeScriptProject": true,
+  "port": 4200
 }


### PR DESCRIPTION
## 🚀 Description

Set specific ports for the docs and test apps so you can run them both at the same time.

---

## 📚 Documentation

- https://guides.emberjs.com/release/configuring-ember/configuring-ember-cli/

---

## 🔬 How to Test

If you want to manually check:

```
# pull down this repo
cd test-app
pnpm i
pnpm start
# verify it runs on port 4200

cd docs-app
pnpm i
pnpm start
# verify it runs on port 4201
```

---

## 📸 Images/Videos of Functionality

N/A
