### PR TITLE
#48: Add Checkbox component

### DIFF
--- a/docs/components/checkbox-field/demo/base-demo.md
+++ b/docs/components/checkbox-field/demo/base-demo.md
@@ -13,7 +13,6 @@ import { tracked } from '@glimmer/tracking';
 
 export default class extends Component {
   @tracked value = false;
-  @tracked errorMessage;
 
   @action
   updateValue(value) {

--- a/docs/components/checkbox-field/demo/base-demo.md
+++ b/docs/components/checkbox-field/demo/base-demo.md
@@ -1,0 +1,23 @@
+```hbs template
+<Form::CheckboxField
+  @label='Label'
+  @value={{this.value}}
+  @onChange={{this.updateValue}}
+/>
+```
+
+```js component
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+
+export default class extends Component {
+  @tracked value = false;
+  @tracked errorMessage;
+
+  @action
+  updateValue(value) {
+    this.value = value;
+  }
+}
+```

--- a/docs/components/checkbox-field/index.md
+++ b/docs/components/checkbox-field/index.md
@@ -16,13 +16,14 @@ Provide a string to `@error` to render the text into the Error section of the Fi
 
 ## Value and onChange
 
-To tie into the input event, provide `@onChange`. `@onChange` will return three arguments:
+To tie into the input event, provide `@onChange`. `@onChange` will return two arguments:
 
 1. the checked attribute from the target
 2. the raw event object
-3. the indeterminate property from the target
 
 It's most common to use this in combination with `@value` which will set the `checked` attribute for the Checkbox.
+
+To access the indeterminate property of the checkbox, use `e.target.indeterminate`.
 
 ```hbs
 <Form::CheckboxField
@@ -41,8 +42,8 @@ export default class extends Component {
   @tracked value;
 
   @action
-  handleChange(value, e, indeterminate) {
-    console.log({ e, indeterminate, value });
+  handleChange(value, e) {
+    console.log({ e, indeterminate: e.target.indeterminate, value });
     this.value = value;
   }
 }

--- a/docs/components/checkbox-field/index.md
+++ b/docs/components/checkbox-field/index.md
@@ -20,7 +20,7 @@ To tie into the input event, provide `@onChange`. `@onChange` will return three 
 
 1. the checked attribute from the target
 2. the raw event object
-3. the indeterminate attribute from the target
+3. the indeterminate property from the target
 
 It's most common to use this in combination with `@value` which will set the `checked` attribute for the Checkbox.
 

--- a/docs/components/checkbox-field/index.md
+++ b/docs/components/checkbox-field/index.md
@@ -1,0 +1,158 @@
+# Checkbox Field
+
+Provides an underlying checkbox element building on top of the Field component.
+
+## Label
+
+Provide a string to `@label` to render the text into the `<label>` of the Field.
+
+## Hint
+
+Provide a string to `@hint` to render the text into the Hint section of the Field. This is optional.
+
+## Error
+
+Provide a string to `@error` to render the text into the Error section of the Field. This is optional.
+
+## Value and onChange
+
+To tie into the input event, provide `@onChange`. `@onChange` will return three arguments:
+
+1. the checked attribute from the target
+2. the raw event object
+3. the indeterminate attribute from the target
+
+It's most common to use this in combination with `@value` which will set the `checked` attribute for the Checkbox.
+
+```hbs
+<Form::CheckboxField
+  @label='Label'
+  @value={{this.value}}
+  @onChange={{this.handleChange}}
+/>
+```
+
+```js
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+
+export default class extends Component {
+  @tracked value;
+
+  @action
+  handleChange(value, e, indeterminate) {
+    console.log({ e, indeterminate, value });
+    this.value = value;
+  }
+}
+```
+
+## Disabled State
+
+Set the `@isDisabled` argument to disable the checkbox.
+
+## Indeterminate State
+
+Set the `@isIndeterminate` argument. To learn more, view the documentation Checkbox documentation.
+
+## Attributes and Modifiers
+
+Consumers have direct access to the underlying [checkbox element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox), so all attributes are supported. Modifiers can also be added directly to the Checkbox as shown in the demo.
+
+## Test Selectors
+
+### Root Element
+
+Provide a custom selector via `@rootTestSelector`. This test selector will be used as the value for the `data-root-field` attribute. The Field can be targeted via:
+
+```hbs
+<Form::CheckboxField @label='Label' @rootTestSelector='example' />
+```
+
+```js
+assert.dom('[data-root-field="example"]');
+
+// targeting this field's specific label
+assert.dom('[data-root-field="example"] > [data-label]');
+```
+
+### Label
+
+Target the label element via `data-label`.
+
+### Hint
+
+Target the hint block via `data-hint`.
+
+### Error
+
+Target the error block via `data-error`.
+
+## All UI States
+
+<div class="flex flex-col space-y-4" style="max-width: 14rem">
+<Form::CheckboxField
+@label='Label'
+/>
+
+<Form::CheckboxField
+@label='Label'
+@error="With error"
+/>
+
+<Form::CheckboxField
+@label='Label'
+@hint='With hint text'
+/>
+
+<Form::CheckboxField
+@label='Label'
+@hint='With hint text'
+@error="With error"
+/>
+
+<Form::CheckboxField
+@label='Label'
+@hint='Checked'
+@value={{true}}
+/>
+
+<Form::CheckboxField
+@label='Label'
+@hint='Indeterminate'
+@isIndeterminate={{true}}
+/>
+
+<Form::CheckboxField
+@label='This is an option that expands to multiple lines'
+/>
+
+<Form::CheckboxField
+@label='This is an option that expands to multiple lines'
+@hint="Here is helper text that overflows onto multiple lines"
+/>
+
+<Form::CheckboxField
+@label='This is an option that expands to multiple lines'
+@error="With error"
+/>
+
+<Form::CheckboxField
+@label='Disabled'
+@isDisabled={{true}}
+/>
+
+<Form::CheckboxField
+@label='Disabled'
+@hint="With hint"
+@isDisabled={{true}}
+/>
+
+<Form::CheckboxField
+@label='Disabled + checked'
+@value={{true}}
+@isDisabled={{true}}
+/>
+
+</div>

--- a/docs/components/checkbox-field/index.md
+++ b/docs/components/checkbox-field/index.md
@@ -54,7 +54,7 @@ Set the `@isDisabled` argument to disable the checkbox.
 
 ## Indeterminate State
 
-Set the `@isIndeterminate` argument. To learn more, view the documentation Checkbox documentation.
+Set the `@isIndeterminate` argument. To learn more, view the [Checkbox documentation](./checkbox).
 
 ## Attributes and Modifiers
 

--- a/docs/components/checkbox-field/index.md
+++ b/docs/components/checkbox-field/index.md
@@ -89,6 +89,10 @@ Target the hint block via `data-hint`.
 
 Target the error block via `data-error`.
 
+### Control
+
+The checkbox control is wrapped in a `<div>` so that an error box shadow can be added. Target the control block via `data-control`.
+
 ## All UI States
 
 <div class="flex flex-col space-y-4" style="max-width: 14rem">

--- a/docs/components/checkbox-field/index.md
+++ b/docs/components/checkbox-field/index.md
@@ -89,10 +89,6 @@ Target the hint block via `data-hint`.
 
 Target the error block via `data-error`.
 
-### Control
-
-The checkbox control is wrapped in a `<div>` so that an error box shadow can be added. Target the control block via `data-control`.
-
 ## All UI States
 
 <div class="flex flex-col space-y-4" style="max-width: 14rem">

--- a/docs/components/checkbox/demo/base-demo.md
+++ b/docs/components/checkbox/demo/base-demo.md
@@ -1,0 +1,9 @@
+```hbs template
+<Form::Controls::Checkbox @value={{true}} />
+```
+
+```js component
+import Component from '@glimmer/component';
+
+export default class extends Component {}
+```

--- a/docs/components/checkbox/index.md
+++ b/docs/components/checkbox/index.md
@@ -7,19 +7,29 @@ Provides a Toucan-styled [checkbox element](https://developer.mozilla.org/en-US/
 To set the `checked` attribute of the checkbox, provide `@value`.
 
 ```hbs
-<Form::Controls::Checkbox @value={{true}} />
-<Form::Controls::Checkbox @value={{false}} />
+<Form::Controls::Checkbox @value={{true}} data-checkbox-1 />
+<Form::Controls::Checkbox @value={{false}} data-checkbox-2 />
 ```
 
-- When `@value={{true}}` the `data-checked` attribute will be set to "true".
-- When `@value={{false}}` the `data-checked` attribute will be set to "false".
+To check the checked attribute in tests, use:
+
+```js
+assert.dom('[data-checkbox-1]').isChecked();
+assert.dom('[data-checkbox-2]').isNotChecked();
+```
 
 ## Indeterminate
 
-Checkboxes have the ability to be in the [indeterminate state](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox#indeterminate_state_checkboxes). This is accomplished with `@isIndeterminate`. It is up to the consumer to decide what will force the checkbox into the indeterminate state. The `data-checked` attribute will be set to "mixed".
+Checkboxes have the ability to be in the [indeterminate state](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox#indeterminate_state_checkboxes). This is accomplished with `@isIndeterminate`. It is up to the consumer to decide what will force the checkbox into the indeterminate state.
 
 ```hbs
-<Form::Controls::Checkbox @isIndeterminate={{true}} />
+<Form::Controls::Checkbox @isIndeterminate={{true}} data-checkbox />
+```
+
+To check the indeterminate property in tests, use:
+
+```js
+assert.dom('[data-checkbox]').hasProperty('indeterminate', true);
 ```
 
 ## onChange

--- a/docs/components/checkbox/index.md
+++ b/docs/components/checkbox/index.md
@@ -13,7 +13,7 @@ To set the `checked` attribute of the checkbox, provide `@value`.
 
 ## Indeterminate
 
-Checkboxes have the ability to be in the [indeterminate state](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox#indeterminate_state_checkboxes). This is accomplished with `@isIndeterminate`. It is up to the consumer to decide what will force the checkbox into the indeterminate state. The [aria-checked](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-checked) attribute is set to either "true", "false", or "mixed" depending on the state (where "mixed" is set if `@isIndeterminate={{true}}`).
+Checkboxes have the ability to be in the [indeterminate state](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox#indeterminate_state_checkboxes). This is accomplished with `@isIndeterminate`. It is up to the consumer to decide what will force the checkbox into the indeterminate state. The [data-checked](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-checked) attribute is set to either "true", "false", or "mixed" depending on the state (where "mixed" is set if `@isIndeterminate={{true}}`).
 
 ```hbs
 <Form::Controls::Checkbox @isIndeterminate={{true}} />

--- a/docs/components/checkbox/index.md
+++ b/docs/components/checkbox/index.md
@@ -1,0 +1,55 @@
+# Checkbox
+
+Provides a Toucan-styled [checkbox element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox). If you are building forms, you may be interested in the CheckboxField component instead.
+
+## Checked Value
+
+To set the `checked` attribute of the checkbox, provide `@value`.
+
+```hbs
+<Form::Controls::Checkbox @value={{true}} />
+<Form::Controls::Checkbox @value={{false}} />
+```
+
+## Indeterminate
+
+Checkboxes have the ability to be in the [indeterminate state](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox#indeterminate_state_checkboxes). This is accomplished with `@isIndeterminate`. It is up to the consumer to decide what will force the checkbox into the indeterminate state. The [aria-checked](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-checked) attribute is set to either "true", "false", or "mixed" depending on the state (where "mixed" is set if `@isIndeterminate={{true}}`).
+
+```hbs
+<Form::Controls::Checkbox @isIndeterminate={{true}} />
+```
+
+## onChange
+
+To tie into the input event, provide `@onChange`. `@onChange` will return three arguments:
+
+1. the checked attribute from the target
+2. the raw event object
+3. the indeterminate attribute from the target
+
+```hbs
+<Form::Controls::Checkbox
+  @value={{this.value}}
+  @onChange={{this.handleChange}}
+/>
+```
+
+```js
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+
+export default class extends Component {
+  @tracked value = false;
+
+  @action
+  handleChange(value, e, indeterminate) {
+    console.log({ e, indeterminate, value });
+    this.value = value;
+  }
+}
+```
+
+## Disabled State
+
+Set the `@isDisabled` argument to disable the checkbox.

--- a/docs/components/checkbox/index.md
+++ b/docs/components/checkbox/index.md
@@ -11,9 +11,12 @@ To set the `checked` attribute of the checkbox, provide `@value`.
 <Form::Controls::Checkbox @value={{false}} />
 ```
 
+- When `@value={{true}}` the `data-checked` attribute will be set to "true".
+- When `@value={{false}}` the `data-checked` attribute will be set to "false".
+
 ## Indeterminate
 
-Checkboxes have the ability to be in the [indeterminate state](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox#indeterminate_state_checkboxes). This is accomplished with `@isIndeterminate`. It is up to the consumer to decide what will force the checkbox into the indeterminate state. The [data-checked](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-checked) attribute is set to either "true", "false", or "mixed" depending on the state (where "mixed" is set if `@isIndeterminate={{true}}`).
+Checkboxes have the ability to be in the [indeterminate state](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox#indeterminate_state_checkboxes). This is accomplished with `@isIndeterminate`. It is up to the consumer to decide what will force the checkbox into the indeterminate state. The `data-checked` attribute will be set to "mixed".
 
 ```hbs
 <Form::Controls::Checkbox @isIndeterminate={{true}} />
@@ -23,7 +26,7 @@ Checkboxes have the ability to be in the [indeterminate state](https://developer
 
 To tie into the input event, provide `@onChange`. `@onChange` will return three arguments:
 
-1. the checked attribute from the target
+1. the checked attribute from the target (e.target.checked directly)
 2. the raw event object
 3. the indeterminate attribute from the target
 

--- a/docs/components/checkbox/index.md
+++ b/docs/components/checkbox/index.md
@@ -28,7 +28,7 @@ To tie into the input event, provide `@onChange`. `@onChange` will return three 
 
 1. the checked attribute from the target (e.target.checked directly)
 2. the raw event object
-3. the indeterminate attribute from the target
+3. the indeterminate property from the target
 
 ```hbs
 <Form::Controls::Checkbox

--- a/docs/components/checkbox/index.md
+++ b/docs/components/checkbox/index.md
@@ -24,11 +24,12 @@ Checkboxes have the ability to be in the [indeterminate state](https://developer
 
 ## onChange
 
-To tie into the input event, provide `@onChange`. `@onChange` will return three arguments:
+To tie into the input event, provide `@onChange`. `@onChange` will return two arguments:
 
-1. the checked attribute from the target (e.target.checked directly)
+1. the checked attribute from the target (e.target.checked)
 2. the raw event object
-3. the indeterminate property from the target
+
+To access the indeterminate property of the checkbox, use `e.target.indeterminate`.
 
 ```hbs
 <Form::Controls::Checkbox
@@ -46,8 +47,8 @@ export default class extends Component {
   @tracked value = false;
 
   @action
-  handleChange(value, e, indeterminate) {
-    console.log({ e, indeterminate, value });
+  handleChange(value, e) {
+    console.log({ e, indeterminate: e.target.indeterminate, value });
     this.value = value;
   }
 }

--- a/ember-toucan-core/package.json
+++ b/ember-toucan-core/package.json
@@ -115,6 +115,7 @@
     "main": "addon-main.cjs",
     "app-js": {
       "./components/button.js": "./dist/_app_/components/button.js",
+      "./components/form/checkbox-field.js": "./dist/_app_/components/form/checkbox-field.js",
       "./components/form/controls/checkbox.js": "./dist/_app_/components/form/controls/checkbox.js",
       "./components/form/controls/textarea.js": "./dist/_app_/components/form/controls/textarea.js",
       "./components/form/field.js": "./dist/_app_/components/form/field.js",

--- a/ember-toucan-core/package.json
+++ b/ember-toucan-core/package.json
@@ -115,6 +115,7 @@
     "main": "addon-main.cjs",
     "app-js": {
       "./components/button.js": "./dist/_app_/components/button.js",
+      "./components/form/controls/checkbox.js": "./dist/_app_/components/form/controls/checkbox.js",
       "./components/form/controls/textarea.js": "./dist/_app_/components/form/controls/textarea.js",
       "./components/form/field.js": "./dist/_app_/components/form/field.js",
       "./components/form/textarea-field.js": "./dist/_app_/components/form/textarea-field.js"

--- a/ember-toucan-core/src/components/form/checkbox-field.hbs
+++ b/ember-toucan-core/src/components/form/checkbox-field.hbs
@@ -4,7 +4,7 @@
 >
   <Form::Field as |field|>
     <field.Control
-      class="focus-within:shadow-focus-outline flex flex-row items-start space-x-3 rounded-sm p-1
+      class="flex flex-row items-start space-x-3 rounded-sm p-1
         {{if @error 'shadow-error-outline'}}"
       data-control
     >

--- a/ember-toucan-core/src/components/form/checkbox-field.hbs
+++ b/ember-toucan-core/src/components/form/checkbox-field.hbs
@@ -1,0 +1,38 @@
+<div
+  class="flex flex-col"
+  data-root-field={{if @rootTestSelector @rootTestSelector}}
+>
+  <Form::Field as |field|>
+    <field.Control
+      class="focus-within:shadow-focus-outline flex flex-row items-start space-x-3 p-1
+        {{if @error 'shadow-error-outline'}}"
+    >
+      <Form::Controls::Checkbox
+        aria-invalid={{if @error "true"}}
+        aria-describedby="{{if @error field.errorId}} {{if @hint field.hintId}}"
+        id={{field.id}}
+        @isDisabled={{@isDisabled}}
+        @isIndeterminate={{@isIndeterminate}}
+        @value={{@value}}
+        @onChange={{@onChange}}
+        ...attributes
+      />
+
+      <div class="flex flex-col">
+        <field.Label
+          class="leading-4"
+          for={{field.id}}
+          data-label
+        >{{@label}}</field.Label>
+
+        {{#if @hint}}
+          <field.Hint id={{field.hintId}} data-hint>{{@hint}}</field.Hint>
+        {{/if}}
+      </div>
+    </field.Control>
+
+    {{#if @error}}
+      <field.Error id={{field.errorId}} data-error>{{@error}}</field.Error>
+    {{/if}}
+  </Form::Field>
+</div>

--- a/ember-toucan-core/src/components/form/checkbox-field.hbs
+++ b/ember-toucan-core/src/components/form/checkbox-field.hbs
@@ -20,11 +20,11 @@
       />
 
       <div class="flex flex-col">
-        <field.Label
-          class="leading-4"
+        <label
+          class="type-md-tight text-titles-and-attributes block leading-4"
           for={{field.id}}
           data-label
-        >{{@label}}</field.Label>
+        >{{@label}}</label>
 
         {{#if @hint}}
           <field.Hint id={{field.hintId}} data-hint>{{@hint}}</field.Hint>

--- a/ember-toucan-core/src/components/form/checkbox-field.hbs
+++ b/ember-toucan-core/src/components/form/checkbox-field.hbs
@@ -4,8 +4,9 @@
 >
   <Form::Field as |field|>
     <field.Control
-      class="focus-within:shadow-focus-outline flex flex-row items-start space-x-3 p-1
+      class="focus-within:shadow-focus-outline flex flex-row items-start space-x-3 rounded-sm p-1
         {{if @error 'shadow-error-outline'}}"
+      data-control
     >
       <Form::Controls::Checkbox
         aria-invalid={{if @error "true"}}

--- a/ember-toucan-core/src/components/form/checkbox-field.hbs
+++ b/ember-toucan-core/src/components/form/checkbox-field.hbs
@@ -4,32 +4,34 @@
 >
   <Form::Field as |field|>
     <field.Control
-      class="flex flex-row items-start space-x-3 rounded-sm p-1
-        {{if @error 'shadow-error-outline'}}"
+      class="rounded-sm p-1 {{if @error 'shadow-error-outline'}}"
       data-control
     >
-      <Form::Controls::Checkbox
-        aria-invalid={{if @error "true"}}
-        aria-describedby="{{if @error field.errorId}} {{if @hint field.hintId}}"
-        id={{field.id}}
-        @isDisabled={{@isDisabled}}
-        @isIndeterminate={{@isIndeterminate}}
-        @value={{@value}}
-        @onChange={{@onChange}}
-        ...attributes
-      />
 
-      <div class="flex flex-col">
-        <label
-          class="type-md-tight text-titles-and-attributes block leading-4"
-          for={{field.id}}
-          data-label
-        >{{@label}}</label>
+      <label class="flex flex-row space-x-3" for={{field.id}}>
+        <Form::Controls::Checkbox
+          aria-invalid={{if @error "true"}}
+          aria-describedby="{{if @error field.errorId}}"
+          id={{field.id}}
+          @isDisabled={{@isDisabled}}
+          @isIndeterminate={{@isIndeterminate}}
+          @value={{@value}}
+          @onChange={{@onChange}}
+          ...attributes
+        />
 
-        {{#if @hint}}
-          <field.Hint id={{field.hintId}} data-hint>{{@hint}}</field.Hint>
-        {{/if}}
-      </div>
+        <div class="flex flex-col">
+          <span
+            class="type-md-tight block leading-4
+              {{if @isDisabled 'text-disabled' 'text-titles-and-attributes'}}"
+            data-label
+          >{{@label}}</span>
+
+          {{#if @hint}}
+            <field.Hint data-hint>{{@hint}}</field.Hint>
+          {{/if}}
+        </div>
+      </label>
     </field.Control>
 
     {{#if @error}}

--- a/ember-toucan-core/src/components/form/checkbox-field.ts
+++ b/ember-toucan-core/src/components/form/checkbox-field.ts
@@ -1,0 +1,31 @@
+import Component from '@glimmer/component';
+import { assert } from '@ember/debug';
+
+import type { ToucanFormCheckboxControlComponentSignature } from './controls/checkbox';
+
+export interface ToucanFormCheckboxFieldComponentSignature {
+  Element: HTMLInputElement;
+  Args: {
+    error?: string;
+    hint?: string;
+    isDisabled?: boolean;
+    isIndeterminate?: ToucanFormCheckboxControlComponentSignature['Args']['isIndeterminate'];
+    label: string;
+    onChange?: ToucanFormCheckboxControlComponentSignature['Args']['onChange'];
+    /**
+     * A test selector for targeting the root element of the field. In this case, the wrapping div element.
+     */
+    rootTestSelector?: string;
+    value?: ToucanFormCheckboxControlComponentSignature['Args']['value'];
+  };
+}
+
+export default class ToucanFormCheckboxFieldComponent extends Component<ToucanFormCheckboxFieldComponentSignature> {
+  constructor(
+    owner: unknown,
+    args: ToucanFormCheckboxFieldComponentSignature['Args']
+  ) {
+    assert('A "@label" argument is required', args.label);
+    super(owner, args);
+  }
+}

--- a/ember-toucan-core/src/components/form/controls/checkbox.hbs
+++ b/ember-toucan-core/src/components/form/controls/checkbox.hbs
@@ -1,4 +1,4 @@
-<div class="min-h-6 min-w-6 relative flex h-6 w-6 items-center justify-center">
+<div class="min-w-4 min-h-4 relative flex h-4 w-4 items-center justify-center">
   {{! I think this is only valid if role="checkbox" (https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-checked) - maybe we should use our own data attribute instead? }}
   {{! template-lint-disable no-unsupported-role-attributes }}
   <input

--- a/ember-toucan-core/src/components/form/controls/checkbox.hbs
+++ b/ember-toucan-core/src/components/form/controls/checkbox.hbs
@@ -1,6 +1,6 @@
 <div class="min-w-4 min-h-4 relative flex h-4 w-4 items-center justify-center">
   <input
-    class="border-body-and-labels focus:outline-none inline-block h-4 w-4 appearance-none rounded-sm border p-0 align-middle
+    class="border-body-and-labels focusable-outer focus:outline-none inline-block h-4 w-4 appearance-none rounded-sm border p-0 align-middle
       {{this.styles}}"
     type="checkbox"
     checked={{this.isChecked}}

--- a/ember-toucan-core/src/components/form/controls/checkbox.hbs
+++ b/ember-toucan-core/src/components/form/controls/checkbox.hbs
@@ -6,7 +6,6 @@
     checked={{this.isChecked}}
     indeterminate={{this.isIndeterminate}}
     disabled={{@isDisabled}}
-    data-checked={{this.checkedState}}
     ...attributes
     {{on "click" this.handleInput}}
   />

--- a/ember-toucan-core/src/components/form/controls/checkbox.hbs
+++ b/ember-toucan-core/src/components/form/controls/checkbox.hbs
@@ -12,9 +12,7 @@
   />
 
   {{#if this.isCheckedOrIndeterminate}}
-    <div
-      class="pointer-events-none absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 transform-gpu"
-    >
+    <div class="pointer-events-none absolute">
       {{#if this.isIndeterminate}}
         {{! TODO: https://github.com/CrowdStrike/ember-toucan-core/issues/49 - Placeholder icon }}
         <svg

--- a/ember-toucan-core/src/components/form/controls/checkbox.hbs
+++ b/ember-toucan-core/src/components/form/controls/checkbox.hbs
@@ -1,14 +1,12 @@
 <div class="min-w-4 min-h-4 relative flex h-4 w-4 items-center justify-center">
-  {{! I think this is only valid if role="checkbox" (https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-checked) - maybe we should use our own data attribute instead? }}
-  {{! template-lint-disable no-unsupported-role-attributes }}
   <input
-    aria-checked={{this.ariaChecked}}
     class="border-body-and-labels focus:outline-none inline-block h-4 w-4 appearance-none rounded-sm border p-0 align-middle
       {{this.styles}}"
     type="checkbox"
     checked={{this.isChecked}}
     indeterminate={{this.isIndeterminate}}
     disabled={{@isDisabled}}
+    data-checked={{this.checkedState}}
     ...attributes
     {{on "click" this.handleInput}}
   />

--- a/ember-toucan-core/src/components/form/controls/checkbox.hbs
+++ b/ember-toucan-core/src/components/form/controls/checkbox.hbs
@@ -1,0 +1,55 @@
+<div class="min-h-6 min-w-6 relative flex h-6 w-6 items-center justify-center">
+  {{! I think this is only valid if role="checkbox" (https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-checked) - maybe we should use our own data attribute instead? }}
+  {{! template-lint-disable no-unsupported-role-attributes }}
+  <input
+    aria-checked={{this.ariaChecked}}
+    class="border-body-and-labels focus:outline-none inline-block h-4 w-4 appearance-none rounded-sm border p-0 align-middle
+      {{this.styles}}"
+    type="checkbox"
+    checked={{this.isChecked}}
+    indeterminate={{this.isIndeterminate}}
+    disabled={{@isDisabled}}
+    ...attributes
+    {{on "click" this.handleInput}}
+  />
+
+  {{#if this.isCheckedOrIndeterminate}}
+    <div
+      class="pointer-events-none absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 transform-gpu"
+    >
+      {{#if this.isIndeterminate}}
+        {{! TODO: https://github.com/CrowdStrike/ember-toucan-core/issues/49 - Placeholder icon }}
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="24"
+          height="24"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          class="text-ground-floor h-3 w-3"
+        ><path
+            d="M20 12H4"
+            fill="none"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+          ></path></svg>
+      {{else}}
+        {{! TODO: https://github.com/CrowdStrike/ember-toucan-core/issues/49 - Placeholder icon }}
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="24"
+          height="24"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          class="text-ground-floor h-3 w-3"
+        ><path
+            d="M3 14.7l2.7 2.45 2.7 2.45 6.3-7.6L21 4.4"
+            fill="none"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+          ></path></svg>
+      {{/if}}
+    </div>
+  {{/if}}
+</div>

--- a/ember-toucan-core/src/components/form/controls/checkbox.ts
+++ b/ember-toucan-core/src/components/form/controls/checkbox.ts
@@ -1,0 +1,72 @@
+import Component from '@glimmer/component';
+import { assert } from '@ember/debug';
+import { action } from '@ember/object';
+
+export interface ToucanFormCheckboxControlComponentSignature {
+  Element: HTMLInputElement;
+  Args: {
+    isDisabled?: boolean;
+    onChange?: (
+      isChecked: boolean,
+      e: Event | InputEvent,
+      isIndeterminate: boolean
+    ) => void;
+    isIndeterminate?: boolean;
+    value?: boolean;
+  };
+}
+
+export default class ToucanFormCheckboxControlComponent extends Component<ToucanFormCheckboxControlComponentSignature> {
+  get isChecked() {
+    return this.args.value ?? false;
+  }
+
+  get isIndeterminate() {
+    return this.args.isIndeterminate ?? false;
+  }
+
+  /**
+   * Used in our template so we don't need to pull in ember-truth-helpers (yet).
+   */
+  get isCheckedOrIndeterminate() {
+    return this.isChecked || this.isIndeterminate;
+  }
+
+  /**
+   * We use the aria-checked attribute to help signal what state the checkbox is in.
+   * This is most helpful in tests. The "mixed" value is used for the indeterminate state.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-checked
+   */
+  get ariaChecked() {
+    if (this.isIndeterminate) {
+      return 'mixed';
+    }
+
+    if (this.isChecked) {
+      return 'true';
+    }
+
+    return 'false';
+  }
+
+  get styles() {
+    let { isDisabled } = this.args;
+    let isCheckedOrIndeterminate = this.isCheckedOrIndeterminate;
+
+    return isCheckedOrIndeterminate && !isDisabled
+      ? ['bg-primary-idle border-none']
+      : isCheckedOrIndeterminate && isDisabled
+      ? ['bg-disabled border-none']
+      : !isCheckedOrIndeterminate && isDisabled
+      ? ['bg-transparent border-disabled']
+      : ['bg-normal-idle'];
+  }
+
+  @action
+  handleInput(e: Event | InputEvent): void {
+    assert('Expected HTMLInputElement', e.target instanceof HTMLInputElement);
+
+    this.args.onChange?.(e.target?.checked, e, e.target?.indeterminate);
+  }
+}

--- a/ember-toucan-core/src/components/form/controls/checkbox.ts
+++ b/ember-toucan-core/src/components/form/controls/checkbox.ts
@@ -33,12 +33,14 @@ export default class ToucanFormCheckboxControlComponent extends Component<Toucan
   }
 
   /**
-   * We use the aria-checked attribute to help signal what state the checkbox is in.
+   * We use the data-checked attribute to help signal what state the checkbox is in.
    * This is most helpful in tests. The "mixed" value is used for the indeterminate state.
+   * We don't use aria-checked directly, as we are a valid <input type="checkbox", but
+   * we follow the possible states outlined by aria-checked.
    *
    * @see https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-checked
    */
-  get ariaChecked() {
+  get checkedState() {
     if (this.isIndeterminate) {
       return 'mixed';
     }

--- a/ember-toucan-core/src/components/form/controls/checkbox.ts
+++ b/ember-toucan-core/src/components/form/controls/checkbox.ts
@@ -30,26 +30,6 @@ export default class ToucanFormCheckboxControlComponent extends Component<Toucan
     return this.isChecked || this.isIndeterminate;
   }
 
-  /**
-   * We use the data-checked attribute to help signal what state the checkbox is in.
-   * This is most helpful in tests. The "mixed" value is used for the indeterminate state.
-   * We don't use aria-checked directly, as we are a valid <input type="checkbox", but
-   * we follow the possible states outlined by aria-checked.
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-checked
-   */
-  get checkedState() {
-    if (this.isIndeterminate) {
-      return 'mixed';
-    }
-
-    if (this.isChecked) {
-      return 'true';
-    }
-
-    return 'false';
-  }
-
   get styles() {
     let { isDisabled } = this.args;
     let isCheckedOrIndeterminate = this.isCheckedOrIndeterminate;

--- a/ember-toucan-core/src/components/form/controls/checkbox.ts
+++ b/ember-toucan-core/src/components/form/controls/checkbox.ts
@@ -69,6 +69,6 @@ export default class ToucanFormCheckboxControlComponent extends Component<Toucan
   handleInput(e: Event | InputEvent): void {
     assert('Expected HTMLInputElement', e.target instanceof HTMLInputElement);
 
-    this.args.onChange?.(e.target?.checked, e, e.target?.indeterminate);
+    this.args.onChange?.(e.target.checked, e, e.target.indeterminate);
   }
 }

--- a/ember-toucan-core/src/components/form/controls/checkbox.ts
+++ b/ember-toucan-core/src/components/form/controls/checkbox.ts
@@ -2,15 +2,13 @@ import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
 import { action } from '@ember/object';
 
+import type { OnChangeCallback } from '../../../-private/types';
+
 export interface ToucanFormCheckboxControlComponentSignature {
   Element: HTMLInputElement;
   Args: {
     isDisabled?: boolean;
-    onChange?: (
-      isChecked: boolean,
-      e: Event | InputEvent,
-      isIndeterminate: boolean
-    ) => void;
+    onChange?: OnChangeCallback<boolean>;
     isIndeterminate?: boolean;
     value?: boolean;
   };
@@ -69,6 +67,6 @@ export default class ToucanFormCheckboxControlComponent extends Component<Toucan
   handleInput(e: Event | InputEvent): void {
     assert('Expected HTMLInputElement', e.target instanceof HTMLInputElement);
 
-    this.args.onChange?.(e.target.checked, e, e.target.indeterminate);
+    this.args.onChange?.(e.target.checked, e);
   }
 }

--- a/ember-toucan-core/src/template-registry.ts
+++ b/ember-toucan-core/src/template-registry.ts
@@ -1,4 +1,5 @@
 import type ButtonComponent from './components/button';
+import type CheckboxConrolComponent from './components/form/controls/checkbox';
 import type TextareaControlComponent from './components/form/controls/textarea';
 import type FieldComponent from './components/form/field';
 import type TextareaFieldComponent from './components/form/textarea-field';
@@ -7,5 +8,6 @@ export default interface Registry {
   Button: typeof ButtonComponent;
   'Form::Field': typeof FieldComponent;
   'Form::TextareaField': typeof TextareaFieldComponent;
+  'Form::Controls::Checkbox': typeof CheckboxConrolComponent;
   'Form::Controls::Textarea': typeof TextareaControlComponent;
 }

--- a/ember-toucan-core/src/template-registry.ts
+++ b/ember-toucan-core/src/template-registry.ts
@@ -1,4 +1,5 @@
 import type ButtonComponent from './components/button';
+import type CheckboxFieldComponent from './components/form/checkbox-field';
 import type CheckboxConrolComponent from './components/form/controls/checkbox';
 import type TextareaControlComponent from './components/form/controls/textarea';
 import type FieldComponent from './components/form/field';
@@ -7,6 +8,7 @@ import type TextareaFieldComponent from './components/form/textarea-field';
 export default interface Registry {
   Button: typeof ButtonComponent;
   'Form::Field': typeof FieldComponent;
+  'Form::CheckboxField': typeof CheckboxFieldComponent;
   'Form::TextareaField': typeof TextareaFieldComponent;
   'Form::Controls::Checkbox': typeof CheckboxConrolComponent;
   'Form::Controls::Textarea': typeof TextareaControlComponent;

--- a/ember-toucan-core/unpublished-development-types/index.d.ts
+++ b/ember-toucan-core/unpublished-development-types/index.d.ts
@@ -3,6 +3,7 @@
 
 import '@glint/environment-ember-loose';
 
+import type CheckboxConrolComponent from '../src/components/form/controls/checkbox';
 import type TextareaControlComponent from '../src/components/form/controls/textarea';
 import type FieldComponent from '../src/components/form/field';
 
@@ -10,6 +11,7 @@ declare module '@glint/environment-ember-loose/registry' {
   export default interface Registry /* extends EmberPageTitle, etc, other addon registries */ {
     // local entries
     'Form::Field': typeof FieldComponent;
+    'Form::Controls::Checkbox': typeof CheckboxConrolComponent;
     'Form::Controls::Textarea': typeof TextareaControlComponent;
   }
 }

--- a/ember-toucan-core/unpublished-development-types/index.d.ts
+++ b/ember-toucan-core/unpublished-development-types/index.d.ts
@@ -3,15 +3,10 @@
 
 import '@glint/environment-ember-loose';
 
-import type CheckboxConrolComponent from '../src/components/form/controls/checkbox';
-import type TextareaControlComponent from '../src/components/form/controls/textarea';
-import type FieldComponent from '../src/components/form/field';
+import type ToucanCoreRegistry from '../src/template-registry';
 
 declare module '@glint/environment-ember-loose/registry' {
-  export default interface Registry /* extends EmberPageTitle, etc, other addon registries */ {
+  export default interface Registry extends ToucanCoreRegistry {
     // local entries
-    'Form::Field': typeof FieldComponent;
-    'Form::Controls::Checkbox': typeof CheckboxConrolComponent;
-    'Form::Controls::Textarea': typeof TextareaControlComponent;
   }
 }

--- a/test-app/tests/integration/components/checkbox-field-test.gts
+++ b/test-app/tests/integration/components/checkbox-field-test.gts
@@ -123,23 +123,15 @@ module('Integration | Component | CheckboxField', function (hooks) {
   });
 
   test('it calls `@onChange` when clicked with the expected checked state', async function (assert) {
-    assert.expect(8);
+    assert.expect(7);
 
-    let handleChange = (
-      checked: boolean,
-      e: Event | InputEvent,
-      isIndeterminate: boolean
-    ) => {
+    let handleChange = (checked: boolean, e: Event | InputEvent) => {
       assert.true(
         checked,
         'Expected to be checked since we started un-checked'
       );
       assert.ok(e, 'Expected `e` to be available as the second argument');
       assert.ok(e.target, 'Expected direct access to target from `e`');
-      assert.false(
-        isIndeterminate,
-        'Expected indeterminate state to be false as we did not provide `@isIndeterminate={{true}}`'
-      );
       assert.step('handleChange');
     };
 
@@ -164,13 +156,9 @@ module('Integration | Component | CheckboxField', function (hooks) {
   test('it calls `@onChange` when clicked with the expected indeterminate state', async function (assert) {
     assert.expect(4);
 
-    let handleChange = (
-      _checked: boolean,
-      _e: Event | InputEvent,
-      isIndeterminate: boolean
-    ) => {
+    let handleChange = (_checked: boolean, e: Event | InputEvent) => {
       assert.false(
-        isIndeterminate,
+        (e.target as HTMLInputElement).indeterminate,
         'Expected indeterminate state to be false as the indeterminate property on the input element was changed by clicking it'
       );
       assert.step('handleChange');

--- a/test-app/tests/integration/components/checkbox-field-test.gts
+++ b/test-app/tests/integration/components/checkbox-field-test.gts
@@ -83,6 +83,22 @@ module('Integration | Component | CheckboxField', function (hooks) {
       .hasClass('shadow-error-outline');
   });
 
+  test('it sets the "for" attribute on the label to the "id" attribute of the checkbox', async function (assert) {
+    await render(<template>
+      <CheckboxField @label="Label" data-checkbox />
+    </template>);
+
+    let labelFor = find('[data-control] > label')?.getAttribute('for') || '';
+    assert.ok(labelFor, 'Expected the id attribute of the label to be truthy');
+
+    let checkboxId = find('[data-checkbox]')?.getAttribute('id') || '';
+    assert.strictEqual(
+      checkboxId,
+      labelFor,
+      'Expected the for attribute on the label to match the id attribute on the checkbox'
+    );
+  });
+
   test('it disables the checkbox using `@isDisabled`', async function (assert) {
     await render(<template>
       <CheckboxField @label="Label" @isDisabled={{true}} data-checkbox />

--- a/test-app/tests/integration/components/checkbox-field-test.gts
+++ b/test-app/tests/integration/components/checkbox-field-test.gts
@@ -45,17 +45,6 @@ module('Integration | Component | CheckboxField', function (hooks) {
     let hint = find('[data-hint]');
 
     assert.dom(hint).hasText('Hint text');
-    assert.dom(hint).hasAttribute('id');
-
-    let hintId = hint?.getAttribute('id') || '';
-    assert.ok(hintId, 'Expected hintId to be truthy');
-
-    let describedby =
-      find('[data-checkbox]')?.getAttribute('aria-describedby') || '';
-    assert.ok(
-      describedby.includes(hintId),
-      'Expected hintId to be included in the aria-describedby'
-    );
   });
 
   test('it renders with an error', async function (assert) {
@@ -76,6 +65,10 @@ module('Integration | Component | CheckboxField', function (hooks) {
     let errorId = error?.getAttribute('id') || '';
     assert.ok(errorId, 'Expected errorId to be truthy');
 
+    // For the checkbox-field component, the only aria-describedby
+    // value should be the errorId.  This is due to the way the component
+    // is structured, where the label+hint are rendered inside of the
+    // wrapping <label> element
     let describedby =
       find('[data-checkbox]')?.getAttribute('aria-describedby') || '';
     assert.ok(
@@ -88,27 +81,6 @@ module('Integration | Component | CheckboxField', function (hooks) {
     assert
       .dom('[data-root-field="test"] > [data-control]')
       .hasClass('shadow-error-outline');
-  });
-
-  test('it sets aria-describedby when both a hint and error are provided using the hint and errorIds', async function (assert) {
-    await render(<template>
-      <CheckboxField
-        @label="Label"
-        @error="Error text"
-        @hint="Hint text"
-        data-checkbox
-      />
-    </template>);
-
-    let errorId = find('[data-error]')?.getAttribute('id') || '';
-    assert.ok(errorId, 'Expected errorId to be truthy');
-
-    let hintId = find('[data-hint]')?.getAttribute('id') || '';
-    assert.ok(hintId, 'Expected hintId to be truthy');
-
-    assert
-      .dom('[data-checkbox]')
-      .hasAttribute('aria-describedby', `${errorId} ${hintId}`);
   });
 
   test('it disables the checkbox using `@isDisabled`', async function (assert) {

--- a/test-app/tests/integration/components/checkbox-field-test.gts
+++ b/test-app/tests/integration/components/checkbox-field-test.gts
@@ -172,7 +172,7 @@ module('Integration | Component | CheckboxField', function (hooks) {
     ) => {
       assert.false(
         isIndeterminate,
-        'Expected indeterminate state to be false as we did not provide `@isIndeterminate={{true}}`'
+        'Expected indeterminate state to be false as the indeterminate property on the input element was changed by clicking it'
       );
       assert.step('handleChange');
     };

--- a/test-app/tests/integration/components/checkbox-field-test.gts
+++ b/test-app/tests/integration/components/checkbox-field-test.gts
@@ -42,9 +42,7 @@ module('Integration | Component | CheckboxField', function (hooks) {
       <CheckboxField @label="Label" @hint="Hint text" data-checkbox />
     </template>);
 
-    let hint = find('[data-hint]');
-
-    assert.dom(hint).hasText('Hint text');
+    assert.dom('[data-hint]').hasText('Hint text');
   });
 
   test('it renders with an error', async function (assert) {
@@ -91,12 +89,13 @@ module('Integration | Component | CheckboxField', function (hooks) {
     let labelFor = find('[data-control] > label')?.getAttribute('for') || '';
     assert.ok(labelFor, 'Expected the id attribute of the label to be truthy');
 
-    let checkboxId = find('[data-checkbox]')?.getAttribute('id') || '';
-    assert.strictEqual(
-      checkboxId,
-      labelFor,
-      'Expected the for attribute on the label to match the id attribute on the checkbox'
-    );
+    assert
+      .dom('[data-checkbox]')
+      .hasAttribute(
+        'id',
+        labelFor,
+        'Expected the for attribute on the label to match the id attribute on the checkbox'
+      );
   });
 
   test('it disables the checkbox using `@isDisabled`', async function (assert) {

--- a/test-app/tests/integration/components/checkbox-field-test.gts
+++ b/test-app/tests/integration/components/checkbox-field-test.gts
@@ -1,0 +1,235 @@
+/* eslint-disable no-undef -- Until https://github.com/ember-cli/eslint-plugin-ember/issues/1747 is resolved... */
+/* eslint-disable simple-import-sort/imports,padding-line-between-statements,decorator-position/decorator-position -- Can't fix these manually, without --fix working in .gts */
+
+import { click, find, render, setupOnerror } from '@ember/test-helpers';
+import { module, test } from 'qunit';
+
+import CheckboxField from '@crowdstrike/ember-toucan-core/components/form/checkbox-field';
+import { setupRenderingTest } from 'test-app/tests/helpers';
+
+module('Integration | Component | CheckboxField', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function (assert) {
+    await render(<template>
+      <CheckboxField @label="Label" @rootTestSelector="test" data-checkbox />
+    </template>);
+
+    assert.dom('[data-label]').hasText('Label');
+
+    assert
+      .dom('[data-hint]')
+      .doesNotExist(
+        'Expected hint block not to be displayed as a hint was not provided'
+      );
+
+    assert.dom('[data-checkbox]').hasTagName('input');
+    assert.dom('[data-checkbox]').hasAttribute('id');
+    assert.dom('[data-checkbox]').hasNoAttribute('aria-invalid');
+
+    assert
+      .dom('[data-error]')
+      .doesNotExist(
+        'Expected error block not to be displayed as an error was not provided'
+      );
+    assert
+      .dom('[data-root-field="test"] > [data-control]')
+      .hasNoClass('shadow-error-outline');
+  });
+
+  test('it renders with a hint', async function (assert) {
+    await render(<template>
+      <CheckboxField @label="Label" @hint="Hint text" data-checkbox />
+    </template>);
+
+    let hint = find('[data-hint]');
+
+    assert.dom(hint).hasText('Hint text');
+    assert.dom(hint).hasAttribute('id');
+
+    let hintId = hint?.getAttribute('id') || '';
+    assert.ok(hintId, 'Expected hintId to be truthy');
+
+    let describedby =
+      find('[data-checkbox]')?.getAttribute('aria-describedby') || '';
+    assert.ok(
+      describedby.includes(hintId),
+      'Expected hintId to be included in the aria-describedby'
+    );
+  });
+
+  test('it renders with an error', async function (assert) {
+    await render(<template>
+      <CheckboxField
+        @label="Label"
+        @error="Error text"
+        @rootTestSelector="test"
+        data-checkbox
+      />
+    </template>);
+
+    let error = find('[data-error]');
+
+    assert.dom(error).hasText('Error text');
+    assert.dom(error).hasAttribute('id');
+
+    let errorId = error?.getAttribute('id') || '';
+    assert.ok(errorId, 'Expected errorId to be truthy');
+
+    let describedby =
+      find('[data-checkbox]')?.getAttribute('aria-describedby') || '';
+    assert.ok(
+      describedby.includes(errorId),
+      'Expected errorId to be included in the aria-describedby'
+    );
+
+    assert.dom('[data-checkbox]').hasAttribute('aria-invalid', 'true');
+
+    assert
+      .dom('[data-root-field="test"] > [data-control]')
+      .hasClass('shadow-error-outline');
+  });
+
+  test('it sets aria-describedby when both a hint and error are provided using the hint and errorIds', async function (assert) {
+    await render(<template>
+      <CheckboxField
+        @label="Label"
+        @error="Error text"
+        @hint="Hint text"
+        data-checkbox
+      />
+    </template>);
+
+    let errorId = find('[data-error]')?.getAttribute('id') || '';
+    assert.ok(errorId, 'Expected errorId to be truthy');
+
+    let hintId = find('[data-hint]')?.getAttribute('id') || '';
+    assert.ok(hintId, 'Expected hintId to be truthy');
+
+    assert
+      .dom('[data-checkbox]')
+      .hasAttribute('aria-describedby', `${errorId} ${hintId}`);
+  });
+
+  test('it disables the checkbox using `@isDisabled`', async function (assert) {
+    await render(<template>
+      <CheckboxField @label="Label" @isDisabled={{true}} data-checkbox />
+    </template>);
+
+    assert.dom('[data-checkbox]').isDisabled();
+  });
+
+  test('it spreads attributes to the underlying checkbox', async function (assert) {
+    await render(<template>
+      <CheckboxField @label="Label" name="checkbox-name" data-checkbox />
+    </template>);
+
+    assert.dom('[data-checkbox]').hasAttribute('name', 'checkbox-name');
+  });
+
+  test('it sets the checked-state via `@value`', async function (assert) {
+    await render(<template>
+      <CheckboxField @label="Label" @value={{true}} data-checkbox />
+    </template>);
+
+    assert.dom('[data-checkbox]').isChecked();
+  });
+
+  test('it calls `@onChange` when clicked with the expected checked state', async function (assert) {
+    assert.expect(8);
+
+    let handleChange = (
+      checked: boolean,
+      e: Event | InputEvent,
+      isIndeterminate: boolean
+    ) => {
+      assert.true(
+        checked,
+        'Expected to be checked since we started un-checked'
+      );
+      assert.ok(e, 'Expected `e` to be available as the second argument');
+      assert.ok(e.target, 'Expected direct access to target from `e`');
+      assert.false(
+        isIndeterminate,
+        'Expected indeterminate state to be false as we did not provide `@isIndeterminate={{true}}`'
+      );
+      assert.step('handleChange');
+    };
+
+    await render(<template>
+      <CheckboxField
+        @label="Label"
+        @onChange={{handleChange}}
+        @value={{false}}
+        data-checkbox
+      />
+    </template>);
+
+    assert.verifySteps([]);
+
+    await click('[data-checkbox]');
+
+    assert.verifySteps(['handleChange']);
+
+    assert.dom('[data-checkbox]').isChecked();
+  });
+
+  test('it calls `@onChange` when clicked with the expected indeterminate state', async function (assert) {
+    assert.expect(4);
+
+    let handleChange = (
+      _checked: boolean,
+      _e: Event | InputEvent,
+      isIndeterminate: boolean
+    ) => {
+      assert.false(
+        isIndeterminate,
+        'Expected indeterminate state to be false as we did not provide `@isIndeterminate={{true}}`'
+      );
+      assert.step('handleChange');
+    };
+
+    await render(<template>
+      <CheckboxField
+        @label="Label"
+        @onChange={{handleChange}}
+        @isIndeterminate={{true}}
+        data-checkbox
+      />
+    </template>);
+
+    assert.verifySteps([]);
+
+    await click('[data-checkbox]');
+
+    assert.verifySteps(['handleChange']);
+  });
+
+  test('it applies the provided `@rootTestSelector` to the data-root-field attribute', async function (assert) {
+    await render(<template>
+      <CheckboxField
+        @label="Label"
+        @rootTestSelector="selector"
+        data-checkbox
+      />
+    </template>);
+
+    assert.dom('[data-root-field="selector"]').exists();
+  });
+
+  test('it throws an assertion error if no `@label` is provided', async function (assert) {
+    assert.expect(1);
+
+    setupOnerror((e: Error) => {
+      assert.ok(
+        e.message.includes('A "@label" argument is required'),
+        'Expected assertion error message'
+      );
+    });
+
+    await render(<template>
+      {{! @glint-expect-error: we are not providing @label, so this is expected }}
+      <CheckboxField />
+    </template>);
+  });
+});

--- a/test-app/tests/integration/components/checkbox-test.gts
+++ b/test-app/tests/integration/components/checkbox-test.gts
@@ -21,7 +21,7 @@ module('Integration | Component | Checkbox', function (hooks) {
     assert.dom('[data-checkbox]').hasAttribute('type', 'checkbox');
 
     assert.dom('[data-checkbox]').isNotChecked();
-    assert.dom('[data-checkbox]').hasAttribute('data-checked', 'false');
+    assert.dom('[data-checkbox]').hasProperty('indeterminate', false);
 
     assert.dom('[data-checkbox]').hasClass('bg-normal-idle');
     assert.dom('[data-checkbox]').doesNotHaveClass('border-disabled');
@@ -50,7 +50,6 @@ module('Integration | Component | Checkbox', function (hooks) {
     </template>);
 
     assert.dom('[data-checkbox]').isChecked();
-    assert.dom('[data-checkbox]').hasAttribute('data-checked', 'true');
   });
 
   test('it makes the checkbox indeterminate using `@isIndeterminate`', async function (assert) {
@@ -60,7 +59,6 @@ module('Integration | Component | Checkbox', function (hooks) {
       <CheckboxControl @isIndeterminate={{true}} data-checkbox />
     </template>);
 
-    assert.dom('[data-checkbox]').hasAttribute('data-checked', 'mixed');
     assert.dom('[data-checkbox]').hasProperty('indeterminate', true);
 
     assert.dom('[data-checkbox]').hasClass('bg-primary-idle');

--- a/test-app/tests/integration/components/checkbox-test.gts
+++ b/test-app/tests/integration/components/checkbox-test.gts
@@ -21,7 +21,7 @@ module('Integration | Component | Checkbox', function (hooks) {
     assert.dom('[data-checkbox]').hasAttribute('type', 'checkbox');
 
     assert.dom('[data-checkbox]').isNotChecked();
-    assert.dom('[data-checkbox]').hasAria('checked', 'false');
+    assert.dom('[data-checkbox]').hasAttribute('data-checked', 'false');
 
     assert.dom('[data-checkbox]').hasClass('bg-normal-idle');
     assert.dom('[data-checkbox]').doesNotHaveClass('border-disabled');
@@ -50,6 +50,7 @@ module('Integration | Component | Checkbox', function (hooks) {
     </template>);
 
     assert.dom('[data-checkbox]').isChecked();
+    assert.dom('[data-checkbox]').hasAttribute('data-checked', 'true');
   });
 
   test('it makes the checkbox indeterminate using `@isIndeterminate`', async function (assert) {
@@ -59,7 +60,7 @@ module('Integration | Component | Checkbox', function (hooks) {
       <CheckboxControl @isIndeterminate={{true}} data-checkbox />
     </template>);
 
-    assert.dom('[data-checkbox]').hasAttribute('aria-checked', 'mixed');
+    assert.dom('[data-checkbox]').hasAttribute('data-checked', 'mixed');
 
     assert.dom('[data-checkbox]').hasClass('bg-primary-idle');
     assert.dom('[data-checkbox]').hasClass('border-none');

--- a/test-app/tests/integration/components/checkbox-test.gts
+++ b/test-app/tests/integration/components/checkbox-test.gts
@@ -108,23 +108,15 @@ module('Integration | Component | Checkbox', function (hooks) {
   });
 
   test('it calls `@onChange` when clicked with the expected checked state', async function (assert) {
-    assert.expect(7);
+    assert.expect(6);
 
-    let handleChange = (
-      checked: boolean,
-      e: Event | InputEvent,
-      isIndeterminate: boolean
-    ) => {
+    let handleChange = (checked: boolean, e: Event | InputEvent) => {
       assert.true(
         checked,
         'Expected to be checked since we started un-checked'
       );
       assert.ok(e, 'Expected `e` to be available as the second argument');
       assert.ok(e.target, 'Expected direct access to target from `e`');
-      assert.false(
-        isIndeterminate,
-        'Expected indeterminate state to be false as we did not provide `@isIndeterminate={{true}}`'
-      );
       assert.step('handleChange');
     };
 
@@ -144,14 +136,10 @@ module('Integration | Component | Checkbox', function (hooks) {
   test('it calls `@onChange` when clicked with the expected indeterminate state', async function (assert) {
     assert.expect(4);
 
-    let handleChange = (
-      _checked: boolean,
-      _e: Event | InputEvent,
-      isIndeterminate: boolean
-    ) => {
+    let handleChange = (_checked: boolean, e: Event | InputEvent) => {
       assert.false(
-        isIndeterminate,
-        'Expected indeterminate state to be false since we started as true'
+        (e.target as HTMLInputElement).indeterminate,
+        'Expected indeterminate state to be false since we started as true and the element was clicked'
       );
       assert.step('handleChange');
     };

--- a/test-app/tests/integration/components/checkbox-test.gts
+++ b/test-app/tests/integration/components/checkbox-test.gts
@@ -1,0 +1,173 @@
+/* eslint-disable no-undef -- Until https://github.com/ember-cli/eslint-plugin-ember/issues/1747 is resolved... */
+/* eslint-disable simple-import-sort/imports,padding-line-between-statements,decorator-position/decorator-position -- Can't fix these manually, without --fix working in .gts */
+
+import { click, render } from '@ember/test-helpers';
+import { module, test } from 'qunit';
+
+import CheckboxControl from '@crowdstrike/ember-toucan-core/components/form/controls/checkbox';
+import { setupRenderingTest } from 'test-app/tests/helpers';
+
+module('Integration | Component | Checkbox', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function (assert) {
+    await render(<template>
+      {{! we do not require a label, but instead suggest using Field / TextareaField }}
+      {{! template-lint-disable require-input-label }}
+      <CheckboxControl data-checkbox />
+    </template>);
+
+    assert.dom('[data-checkbox]').hasTagName('input');
+    assert.dom('[data-checkbox]').hasAttribute('type', 'checkbox');
+
+    assert.dom('[data-checkbox]').isNotChecked();
+    assert.dom('[data-checkbox]').hasAria('checked', 'false');
+
+    assert.dom('[data-checkbox]').hasClass('bg-normal-idle');
+    assert.dom('[data-checkbox]').doesNotHaveClass('border-disabled');
+  });
+
+  test('it disables the checkbox using `@isDisabled`', async function (assert) {
+    await render(<template>
+      {{! we do not require a label, but instead suggest using Field / TextareaField }}
+      {{! template-lint-disable require-input-label }}
+      <CheckboxControl @isDisabled={{true}} data-checkbox />
+    </template>);
+
+    assert.dom('[data-checkbox]').isDisabled();
+
+    assert.dom('[data-checkbox]').hasClass('border-disabled');
+    assert.dom('[data-checkbox]').hasClass('bg-transparent');
+    assert.dom('[data-checkbox]').doesNotHaveClass('bg-primary-idle');
+    assert.dom('[data-checkbox]').doesNotHaveClass('border-none');
+  });
+
+  test('it makes the checkbox checked using `@value`', async function (assert) {
+    await render(<template>
+      {{! we do not require a label, but instead suggest using Field / TextareaField }}
+      {{! template-lint-disable require-input-label }}
+      <CheckboxControl @value={{true}} data-checkbox />
+    </template>);
+
+    assert.dom('[data-checkbox]').isChecked();
+  });
+
+  test('it makes the checkbox indeterminate using `@isIndeterminate`', async function (assert) {
+    await render(<template>
+      {{! we do not require a label, but instead suggest using Field / TextareaField }}
+      {{! template-lint-disable require-input-label }}
+      <CheckboxControl @isIndeterminate={{true}} data-checkbox />
+    </template>);
+
+    assert.dom('[data-checkbox]').hasAttribute('aria-checked', 'mixed');
+
+    assert.dom('[data-checkbox]').hasClass('bg-primary-idle');
+    assert.dom('[data-checkbox]').hasClass('border-none');
+    assert.dom('[data-checkbox]').hasNoClass('border-disabled');
+    assert.dom('[data-checkbox]').hasNoClass('bg-transparent');
+  });
+
+  test('it applies the expected classes when `@isIndeterminate={{true}}` and `@isDisabled={{true}}', async function (assert) {
+    await render(<template>
+      {{! we do not require a label, but instead suggest using Field / TextareaField }}
+      {{! template-lint-disable require-input-label }}
+      <CheckboxControl
+        @isIndeterminate={{true}}
+        @isDisabled={{true}}
+        data-checkbox
+      />
+    </template>);
+
+    assert.dom('[data-checkbox]').hasClass('bg-disabled');
+    assert.dom('[data-checkbox]').hasClass('border-none');
+    assert.dom('[data-checkbox]').hasNoClass('bg-primary-idle');
+  });
+
+  test('it applies the expected classes when `@value={{true}}` and `@isDisabled={{true}}', async function (assert) {
+    await render(<template>
+      {{! we do not require a label, but instead suggest using Field / TextareaField }}
+      {{! template-lint-disable require-input-label }}
+      <CheckboxControl @value={{true}} @isDisabled={{true}} data-checkbox />
+    </template>);
+
+    assert.dom('[data-checkbox]').hasClass('bg-disabled');
+    assert.dom('[data-checkbox]').hasClass('border-none');
+    assert.dom('[data-checkbox]').hasNoClass('bg-primary-idle');
+  });
+
+  test('it spreads attributes to the underlying checkbox', async function (assert) {
+    await render(<template>
+      {{! we do not require a label, but instead suggest using Field / TextareaField }}
+      {{! template-lint-disable require-input-label }}
+      <CheckboxControl name="a-name" data-checkbox />
+    </template>);
+
+    assert.dom('[data-checkbox]').hasAttribute('name', 'a-name');
+  });
+
+  test('it calls `@onChange` when clicked with the expected checked state', async function (assert) {
+    assert.expect(7);
+
+    let handleChange = (
+      checked: boolean,
+      e: Event | InputEvent,
+      isIndeterminate: boolean
+    ) => {
+      assert.true(
+        checked,
+        'Expected to be checked since we started un-checked'
+      );
+      assert.ok(e, 'Expected `e` to be available as the second argument');
+      assert.ok(e.target, 'Expected direct access to target from `e`');
+      assert.false(
+        isIndeterminate,
+        'Expected indeterminate state to be false as we did not provide `@isIndeterminate={{true}}`'
+      );
+      assert.step('handleChange');
+    };
+
+    await render(<template>
+      {{! we do not require a label, but instead suggest using Field / TextareaField }}
+      {{! template-lint-disable require-input-label }}
+      <CheckboxControl @onChange={{handleChange}} data-checkbox />
+    </template>);
+
+    assert.verifySteps([]);
+
+    await click('[data-checkbox]');
+
+    assert.verifySteps(['handleChange']);
+  });
+
+  test('it calls `@onChange` when clicked with the expected indeterminate state', async function (assert) {
+    assert.expect(4);
+
+    let handleChange = (
+      _checked: boolean,
+      _e: Event | InputEvent,
+      isIndeterminate: boolean
+    ) => {
+      assert.false(
+        isIndeterminate,
+        'Expected indeterminate state to be false since we started as true'
+      );
+      assert.step('handleChange');
+    };
+
+    await render(<template>
+      {{! we do not require a label, but instead suggest using Field / TextareaField }}
+      {{! template-lint-disable require-input-label }}
+      <CheckboxControl
+        @onChange={{handleChange}}
+        @isIndeterminate={{true}}
+        data-checkbox
+      />
+    </template>);
+
+    assert.verifySteps([]);
+
+    await click('[data-checkbox]');
+
+    assert.verifySteps(['handleChange']);
+  });
+});

--- a/test-app/tests/integration/components/checkbox-test.gts
+++ b/test-app/tests/integration/components/checkbox-test.gts
@@ -61,6 +61,7 @@ module('Integration | Component | Checkbox', function (hooks) {
     </template>);
 
     assert.dom('[data-checkbox]').hasAttribute('data-checked', 'mixed');
+    assert.dom('[data-checkbox]').hasProperty('indeterminate', true);
 
     assert.dom('[data-checkbox]').hasClass('bg-primary-idle');
     assert.dom('[data-checkbox]').hasClass('border-none');


### PR DESCRIPTION
## 🚀 Description
This PR introduces a `Checkbox` control component and `CheckboxField` component. 

**NOTE:** These components are not 100% styled yet, as we are still figuring out where to land on a few things. This is about ~75% close though.

Closes #48 

---

## 🔬 How to Test

- These are only presentational components, so test should pass
- View the checkbox link at https://48034b83.ember-toucan-core.pages.dev/docs/components/checkbox and review the documentation
  - **NOTE:** This checkbox does not toggle on click! It is presentational only
- View the link at https://48034b83.ember-toucan-core.pages.dev/docs/components/checkbox-field  and review the documentation
  - **NOTE:** These components are not 100% styled yet, as we are still figuring out where to land on a few things.  This is about ~75% close though.

---

## 📸 Images/Videos of Functionality

**UI States**
<img width="1612" alt="Screenshot 2023-02-24 at 10 12 02 AM" src="https://user-images.githubusercontent.com/8069555/221214784-a11bc413-9851-42dc-8b86-9a59cff4e6d4.png">

**Focus State**

https://user-images.githubusercontent.com/8069555/221663299-f39a228d-c505-4bca-abfb-3f7dddc25ce2.mov

**A11y**

Showing the screenreader picking up:

1. Checkbox state
2. aria-invalid
3. hint text
4. error text
5. hint + error text



https://user-images.githubusercontent.com/8069555/221663069-85e1efe8-6add-4380-8e5f-c169bca8804f.mov


