### PR TITLE
#51: Add shadow-error-outline to Textarea

### DIFF
--- a/docs/components/textarea/index.md
+++ b/docs/components/textarea/index.md
@@ -43,3 +43,7 @@ export default class extends Component {
 ## Disabled State
 
 Set the `@isDisabled` argument to disable the `<textarea>`.
+
+## Error State
+
+Set the `@hasError` argument to apply an error box shadow to the `<textarea>`.

--- a/ember-toucan-core/src/components/form/controls/textarea.hbs
+++ b/ember-toucan-core/src/components/form/controls/textarea.hbs
@@ -1,6 +1,7 @@
 <textarea
-  class="min-h-6 bg-overlay-1 focus:outline-none shadow-focusable-outline focus:shadow-focus-outline block h-20 rounded-sm p-1
-    {{if @isDisabled 'text-disabled' 'text-titles-and-attributes'}}"
+  class="min-h-6 bg-overlay-1 focus:outline-none focus:shadow-focus-outline block h-20 rounded-sm p-1
+    {{if @isDisabled 'text-disabled' 'text-titles-and-attributes'}}
+    {{if @hasError 'shadow-error-outline' 'shadow-focusable-outline'}}"
   disabled={{@isDisabled}}
   ...attributes
   {{on "input" this.handleInput}}

--- a/ember-toucan-core/src/components/form/controls/textarea.ts
+++ b/ember-toucan-core/src/components/form/controls/textarea.ts
@@ -7,6 +7,7 @@ import type { OnChangeCallback } from '../../../-private/types';
 export interface ToucanFormTextareaControlComponentSignature {
   Element: HTMLTextAreaElement;
   Args: {
+    hasError?: boolean;
     isDisabled?: boolean;
     onChange?: OnChangeCallback<string>;
     value?: string;

--- a/ember-toucan-core/src/components/form/textarea-field.hbs
+++ b/ember-toucan-core/src/components/form/textarea-field.hbs
@@ -17,6 +17,7 @@
         @isDisabled={{@isDisabled}}
         @value={{@value}}
         @onChange={{@onChange}}
+        @hasError={{this.hasError}}
         ...attributes
       />
     </field.Control>

--- a/ember-toucan-core/src/components/form/textarea-field.ts
+++ b/ember-toucan-core/src/components/form/textarea-field.ts
@@ -27,4 +27,8 @@ export default class ToucanFormTextareaFieldComponent extends Component<ToucanFo
     assert('A "@label" argument is required', args.label);
     super(owner, args);
   }
+
+  get hasError() {
+    return Boolean(this.args?.error);
+  }
 }

--- a/test-app/tests/integration/components/textarea-field-test.gts
+++ b/test-app/tests/integration/components/textarea-field-test.gts
@@ -76,6 +76,9 @@ module('Integration | Component | TextareaField', function (hooks) {
     );
 
     assert.dom('[data-textarea]').hasAttribute('aria-invalid', 'true');
+
+    assert.dom('[data-textarea]').hasClass('shadow-error-outline');
+    assert.dom('[data-textarea]').doesNotHaveClass('shadow-focusable-outline');
   });
 
   test('it sets aria-describedby when both a hint and error are provided using the hint and errorIds', async function (assert) {

--- a/test-app/tests/integration/components/textarea-test.gts
+++ b/test-app/tests/integration/components/textarea-test.gts
@@ -19,6 +19,7 @@ module('Integration | Component | Textarea', function (hooks) {
 
     assert.dom('[data-textarea]').hasTagName('textarea');
     assert.dom('[data-textarea]').hasClass('text-titles-and-attributes');
+    assert.dom('[data-textarea]').hasClass('shadow-focusable-outline');
     assert.dom('[data-textarea]').doesNotHaveClass('text-disabled');
   });
 
@@ -79,5 +80,16 @@ module('Integration | Component | Textarea', function (hooks) {
     await fillIn('[data-textarea]', 'test');
 
     assert.verifySteps(['handleChange']);
+  });
+
+  test('it applies the error shadow when `@hasError={{true}}`', async function (assert) {
+    await render(<template>
+      {{! we do not require a label, but instead suggest using Field / TextareaField }}
+      {{! template-lint-disable require-input-label }}
+      <TextareaControl @hasError={{true}} data-textarea />
+    </template>);
+
+    assert.dom('[data-textarea]').hasClass('shadow-error-outline');
+    assert.dom('[data-textarea]').doesNotHaveClass('shadow-focusable-outline');
   });
 });


### PR DESCRIPTION
## 🐛  Description

Adds the error box-shadow to the `<textarea>` element and wires it up with `<TextField>`.

I noticed this when building the Checkbox component(s) and thought it'd be good to fix now before I forget.

Closes #51

---

## 🔬 How to Test

- Visit https://dc969626.ember-toucan-core.pages.dev/docs/components/textarea-field
- Scroll down and verify the error shadow is present on the text areas with an error

---

## 📸 Images/Videos of Functionality

<img width="1752" alt="Screenshot 2023-02-23 at 3 58 40 PM" src="https://user-images.githubusercontent.com/8069555/221029566-8db4fd9f-fe4d-4c0f-a114-faf0248a7dde.png">

