### PR TITLE
Implement design suggested spacing of elements

### DIFF
--- a/docs/components/field/demo/base-demo.md
+++ b/docs/components/field/demo/base-demo.md
@@ -1,17 +1,19 @@
 ```hbs template
 <Form::Field as |field|>
-  <field.Label for={{field.id}}>Label</field.Label>
-  <field.Hint id={{field.hintId}}>Extra information about the field</field.Hint>
-  <field.Control>
-    <input
-      class='border bg-basement text-titles-and-attributes p-1 rounded-sm'
-      id={{field.id}}
-      aria-invalid='true'
-      aria-describedby='{{field.hintId}} {{field.errorId}}'
-      ...attributes
-    />
-  </field.Control>
-  <field.Error id={{field.errorId}}>Error message</field.Error>
+  <div class='space-y-0.5'>
+    <field.Label for={{field.id}}>Label</field.Label>
+    <field.Hint id={{field.hintId}}>Extra information about the field</field.Hint>
+    <field.Control>
+      <input
+        class='border bg-basement text-titles-and-attributes p-1 rounded-sm'
+        id={{field.id}}
+        aria-invalid='true'
+        aria-describedby='{{field.hintId}} {{field.errorId}}'
+        ...attributes
+      />
+    </field.Control>
+    <field.Error id={{field.errorId}}>Error message</field.Error>
+  </div>
 </Form::Field>
 ```
 

--- a/docs/components/field/index.md
+++ b/docs/components/field/index.md
@@ -14,7 +14,7 @@ Field is a component to aid in creating form components. It provides a label, hi
 
 ## Design Guidelines
 
-- All components should have 0.125rem or 2px of spacing between the elements. This is normally applied by using `mt-0.5` or `space-y-0.5`. It is up to consumers to apply these classes themselves. If using our Toucan `*Field` components, we handle this automatically.
+- All components should have 0.125rem or 2px of spacing between the elements. We recommend using `space-y-0.5` or `gap-y-5` with `mt-0.5` being used as a last resort. It is up to consumers to apply these classes themselves. If using our Toucan `*Field` components, we handle this automatically.
 
 ## Accessibility
 

--- a/docs/components/field/index.md
+++ b/docs/components/field/index.md
@@ -12,6 +12,10 @@ Field is a component to aid in creating form components. It provides a label, hi
 - `Control`: A control block where a form element is rendered, for example, an `<input>`, `<textarea>`, etc.
 - `Error`: Renders a `<div>` element. Error information is normally rendered here.
 
+## Design Guidelines
+
+- All components should have 0.125rem or 2px of spacing between the elements. This is normally applied by using `mt-0.5` or `space-y-0.5`. It is up to consumers to apply these classes themselves. If using our Toucan `*Field` components, we handle this automatically.
+
 ## Accessibility
 
 The Field component does not handle accessibility automatically for the label, hint, and error sections of the component; however, it does provide identifiers to assist here. Each code example on this page also shows how to take advantage of these IDs.

--- a/ember-toucan-core/src/-private/components/control.hbs
+++ b/ember-toucan-core/src/-private/components/control.hbs
@@ -1,3 +1,3 @@
-<div class="mt-1" ...attributes>
+<div ...attributes>
   {{yield}}
 </div>

--- a/ember-toucan-core/src/-private/components/error.hbs
+++ b/ember-toucan-core/src/-private/components/error.hbs
@@ -1,4 +1,4 @@
-<div class="type-xs-tight text-critical mt-1 flex items-center" ...attributes>
+<div class="type-xs-tight text-critical flex items-center" ...attributes>
   {{! Icon taken from Tony's open source icon set, this is temporary! }}
   <svg
     xmlns="http://www.w3.org/2000/svg"

--- a/ember-toucan-core/src/components/form/checkbox-field.hbs
+++ b/ember-toucan-core/src/components/form/checkbox-field.hbs
@@ -28,14 +28,18 @@
           >{{@label}}</span>
 
           {{#if @hint}}
-            <field.Hint data-hint>{{@hint}}</field.Hint>
+            <field.Hint class="mt-0.5" data-hint>{{@hint}}</field.Hint>
           {{/if}}
         </div>
       </label>
     </field.Control>
 
     {{#if @error}}
-      <field.Error id={{field.errorId}} data-error>{{@error}}</field.Error>
+      <field.Error
+        class="mt-0.5"
+        id={{field.errorId}}
+        data-error
+      >{{@error}}</field.Error>
     {{/if}}
   </Form::Field>
 </div>

--- a/ember-toucan-core/src/components/form/fieldset.hbs
+++ b/ember-toucan-core/src/components/form/fieldset.hbs
@@ -14,12 +14,12 @@
       <field.Hint id={{field.hintId}} data-hint>{{@hint}}</field.Hint>
     {{/if}}
 
-    <div
+    <field.Control
       class="flex flex-col rounded-sm {{if @error 'shadow-error-outline'}}"
       data-control
     >
       {{yield}}
-    </div>
+    </field.Control>
 
     {{#if @error}}
       <field.Error id={{field.errorId}} data-error>{{@error}}</field.Error>

--- a/ember-toucan-core/src/components/form/fieldset.hbs
+++ b/ember-toucan-core/src/components/form/fieldset.hbs
@@ -2,6 +2,7 @@
   <fieldset
     aria-describedby="{{if @error field.errorId}} {{if @hint field.hintId}}"
     disabled={{@isDisabled}}
+    class="space-y-0.5"
     ...attributes
   >
     <legend
@@ -14,7 +15,7 @@
     {{/if}}
 
     <div
-      class="mt-2 flex flex-col rounded-sm {{if @error 'shadow-error-outline'}}"
+      class="flex flex-col rounded-sm {{if @error 'shadow-error-outline'}}"
       data-control
     >
       {{yield}}

--- a/ember-toucan-core/src/components/form/input-field.hbs
+++ b/ember-toucan-core/src/components/form/input-field.hbs
@@ -1,5 +1,5 @@
 <div
-  class="flex flex-col {{if @isDisabled 'text-disabled'}}"
+  class="flex flex-col space-y-0.5 {{if @isDisabled 'text-disabled'}}"
   data-root-field={{if @rootTestSelector @rootTestSelector null}}
 >
   <Form::Field as |field|>

--- a/ember-toucan-core/src/components/form/textarea-field.hbs
+++ b/ember-toucan-core/src/components/form/textarea-field.hbs
@@ -1,5 +1,5 @@
 <div
-  class="flex flex-col"
+  class="flex flex-col space-y-0.5"
   data-root-field={{if @rootTestSelector @rootTestSelector}}
 >
   <Form::Field as |field|>


### PR DESCRIPTION
## 💅  Description
This implements the styling changes after a design review.

---

## 🔬 How to Test

- View https://35eff113.ember-toucan-core.pages.dev/docs/components/textarea-field
- The hint block + control + error block should all have 0.125rem/2px spacing _above_ the elements
- View https://35eff113.ember-toucan-core.pages.dev/docs/components/checkbox-field
- The hint block + error block should have 0.125rem/2px spacing _above_ the elements
- View https://7bfeb461.ember-toucan-core.pages.dev/docs/components/input-field

---

## 📸 Images/Videos of Functionality

<img width="1470" alt="Screenshot 2023-03-06 at 9 00 45 AM" src="https://user-images.githubusercontent.com/8069555/223131299-f8e24641-aa72-47be-97c2-6feb3dc64376.png">

