### PR TITLE
fix: Update input-field to use hasError and apply the error shadow

### DIFF
--- a/ember-toucan-core/src/components/form/input-field.hbs
+++ b/ember-toucan-core/src/components/form/input-field.hbs
@@ -17,6 +17,7 @@
         @isDisabled={{@isDisabled}}
         @value={{@value}}
         @onChange={{@onChange}}
+        @hasError={{this.hasError}}
         ...attributes
       />
     </field.Control>

--- a/ember-toucan-core/src/components/form/input-field.ts
+++ b/ember-toucan-core/src/components/form/input-field.ts
@@ -27,4 +27,8 @@ export default class ToucanFormInputFieldComponent extends Component<ToucanFormI
     assert('input field requires a label', args.label !== undefined);
     super(owner, args);
   }
+
+  get hasError() {
+    return Boolean(this.args?.error);
+  }
 }

--- a/test-app/tests/integration/components/input-field-test.gts
+++ b/test-app/tests/integration/components/input-field-test.gts
@@ -21,7 +21,7 @@ module('Integration | Component | InputField', function (hooks) {
 
     const label = '[data-label]'
     const input = '[data-input]';
-    const inputId = find(input)?.getAttribute('id') || ''; 
+    const inputId = find(input)?.getAttribute('id') || '';
 
     assert.ok(inputId, 'Expected to have id');
     assert.dom(label).exists('Expected to have label block rendered');
@@ -30,6 +30,7 @@ module('Integration | Component | InputField', function (hooks) {
     assert.dom(input).exists('Expected to have input tag rendered');
     assert.dom(input).hasAttribute('type', 'text');
     assert.dom(input).hasAttribute('id');
+    assert.dom(input).hasNoClass('shadow-error-outline');
   });
 
   test('it encourages @label via assert', async function (assert) {
@@ -39,14 +40,14 @@ module('Integration | Component | InputField', function (hooks) {
       assert.strictEqual(e.message, 'Assertion Failed: input field requires a label', 'Expected an error message if @label is not provided')
     })
     await render(<template>
-      {{! @glint-expect-error: should have an error here for missing @label }} 
+      {{! @glint-expect-error: should have an error here for missing @label }}
       <InputField
         type="text"
         />
     </template>);
 
   })
-  
+
   test('it renders an error', async function (assert) {
     await render(<template>
       <InputField
@@ -69,6 +70,8 @@ module('Integration | Component | InputField', function (hooks) {
 
     assert.ok(describedby.includes(errorId), 'Expected errorId to be included in the aria-describedby');
     assert.dom(input).hasAttribute('aria-invalid', 'true');
+
+    assert.dom(input).hasClass('shadow-error-outline');
   });
 
   test('it renders hint text', async function (assert) {
@@ -90,7 +93,7 @@ module('Integration | Component | InputField', function (hooks) {
 
     assert.dom(input).exists('Expected to have input tag rendered');
     assert.dom(input).hasAttribute('type', 'text');
-   
+
     assert.dom(hint).exists('Expected to have hint component rendered');
     assert.dom(hint).hasText('Hint text visible here', 'Expected to have hint text "error"');
     assert.dom(hint).hasAttribute('id');
@@ -122,14 +125,14 @@ module('Integration | Component | InputField', function (hooks) {
 
   test('it accepts @value and @onChange', async function (assert) {
     assert.expect(8);
-    
+
     const onChangeCallback = (value: string, e: Event | InputEvent) => {
       assert.strictEqual(value, 'Banana', 'Expected input to match');
       assert.ok(e, 'Expected `e` to be available as the second argument');
       assert.ok(e.target, 'Expected direct access to target from `e`');
       assert.step('handleChange');
     };
-  
+
     await render(<template>
         <InputField
           @label="Label"


### PR DESCRIPTION
## 🐛  Description
Fix a styling issue with `input field` that I noticed when doing https://github.com/CrowdStrike/ember-toucan-core/pull/65/files.

Downstream of https://github.com/CrowdStrike/ember-toucan-core/pull/63

| Before  | After |
| ------------- | ------------- |
| <img width="315" alt="Screenshot 2023-03-06 at 3 00 37 PM" src="https://user-images.githubusercontent.com/8069555/223217754-41cb04ae-1f1b-4d05-923a-e6c5b9607e74.png">  | <img width="324" alt="Screenshot 2023-03-06 at 2 56 37 PM" src="https://user-images.githubusercontent.com/8069555/223217656-713b83b0-6c04-4954-9554-9b2a950a1acb.png">  |
| No error border  | With error border  |

---

## 🔬 How to Test

- View https://e963e8f6.ember-toucan-core.pages.dev/docs/components/input-field#inputfield-with-label-and-error
- Verify error shadow on errored input
