### PR TITLE
fix: Add aria-invalid + role="radiogroup" to RadioGroupField

### DIFF
--- a/ember-toucan-core/src/components/form/radio-group-field.hbs
+++ b/ember-toucan-core/src/components/form/radio-group-field.hbs
@@ -4,6 +4,7 @@
   @error={{@error}}
   @isDisabled={{@isDisabled}}
   aria-invalid={{if @error "true"}}
+  aria-required="true"
   role="radiogroup"
   ...attributes
 >

--- a/ember-toucan-core/src/components/form/radio-group-field.hbs
+++ b/ember-toucan-core/src/components/form/radio-group-field.hbs
@@ -3,6 +3,8 @@
   @hint={{@hint}}
   @error={{@error}}
   @isDisabled={{@isDisabled}}
+  aria-invalid={{if @error "true"}}
+  role="radiogroup"
   ...attributes
 >
   {{yield

--- a/test-app/tests/integration/components/radio-group-field-test.gts
+++ b/test-app/tests/integration/components/radio-group-field-test.gts
@@ -16,8 +16,17 @@ module('Integration | Component | RadioGroupField', function (hooks) {
     </template>);
 
     assert.dom('[data-group-field]').exists();
+    assert.dom('[data-group-field]').hasNoAttribute('aria-invalid');
 
     assert.dom('[data-label]').hasText('Label');
+  });
+
+  test('it sets "role" by default', async function (assert) {
+    await render(<template>
+      <RadioGroupField @label="Label" @name="group" data-group-field />
+    </template>);
+
+    assert.dom('[data-group-field]').hasAttribute('role', 'radiogroup');
   });
 
   test('it renders yielded RadioFields', async function (assert) {
@@ -133,5 +142,18 @@ module('Integration | Component | RadioGroupField', function (hooks) {
     assert.verifySteps(['handleChange']);
 
     assert.dom('[data-radio-1]').isChecked();
+  });
+
+  test('it sets "aria-invalid" when provided with `@error`', async function (assert) {
+    await render(<template>
+      <RadioGroupField
+        @label="Label"
+        @name="group"
+        @error="Error message"
+        data-group-field
+      />
+    </template>);
+
+    assert.dom('[data-group-field]').hasAttribute('aria-invalid', 'true');
   });
 });

--- a/test-app/tests/integration/components/radio-group-field-test.gts
+++ b/test-app/tests/integration/components/radio-group-field-test.gts
@@ -17,6 +17,7 @@ module('Integration | Component | RadioGroupField', function (hooks) {
 
     assert.dom('[data-group-field]').exists();
     assert.dom('[data-group-field]').hasNoAttribute('aria-invalid');
+    assert.dom('[data-group-field]').hasAttribute('aria-required');
 
     assert.dom('[data-label]').hasText('Label');
   });


### PR DESCRIPTION
## 🚀 Description

For accessibility and after reading through https://adrianroselli.com/2022/02/support-for-marking-radio-buttons-required-invalid.html#R6 again, it seems like this is valid and helps Voice Over announcing the error state.

---

## 🔬 How to Test

- Tests should pass!

---

## 📸 Images/Videos of Functionality

N/A - no visual changes
