### PR TITLE
feat(#44): Add ability to render multiple errors

### DIFF
--- a/docs/components/checkbox-field/index.md
+++ b/docs/components/checkbox-field/index.md
@@ -12,7 +12,18 @@ Provide a string to `@hint` to render the text into the Hint section of the Fiel
 
 ## Error
 
-Provide a string to `@error` to render the text into the Error section of the Field. This is optional.
+Provide a string or array of strings to `@error` to render the text into the Error section of the Field. This is optional.
+
+```hbs
+<Form::CheckboxField @label='Single error' @error='Error' />
+```
+
+```hbs
+<Form::CheckboxField
+  @label='Multiple errors'
+  @error={{(array 'Error 1' 'Error 2')}}
+/>
+```
 
 ## Value and onChange
 
@@ -154,6 +165,11 @@ Target the error block via `data-error`.
 @label='Disabled + checked'
 @value={{true}}
 @isDisabled={{true}}
+/>
+
+<Form::CheckboxField
+@label='Multiple errors'
+@error={{(array "With error 1" "With error 2" "With error 3")}}
 />
 
 </div>

--- a/docs/components/field/demo/base-demo.md
+++ b/docs/components/field/demo/base-demo.md
@@ -12,7 +12,7 @@
         ...attributes
       />
     </field.Control>
-    <field.Error id={{field.errorId}}>Error message</field.Error>
+    <field.Error id={{field.errorId}} @error='Error message' />
   </div>
 </Form::Field>
 ```

--- a/docs/components/field/index.md
+++ b/docs/components/field/index.md
@@ -10,7 +10,7 @@ Field is a component to aid in creating form components. It provides a label, hi
 - `Label`: Renders a `<label>` element. Form element label text is normally rendered here.
 - `Hint`: Renders a `<div>` element. Help text or supplemental information is normally rendered here.
 - `Control`: A control block where a form element is rendered, for example, an `<input>`, `<textarea>`, etc.
-- `Error`: Renders a `<div>` element. Error information is normally rendered here.
+- `Error`: Renders a `<div>` element. Error information is normally rendered here. It accepts an `@error` argument that is either a string or array of strings. If provided with an array of strings, the errors will be rendered in a `<ul>` + `<li>`.
 
 ## Design Guidelines
 
@@ -49,7 +49,7 @@ The yielded components from Field can be optionally rendered by using the `{{#if
   </field.Control>
 
   {{#if @error}}
-    <field.Error id={{field.errorId}}>{{@error}}</field.Error>
+    <field.Error id={{field.errorId}} @error={{@error}} />
   {{/if}}
 </Form::Field>
 ```

--- a/docs/components/fieldset/index.md
+++ b/docs/components/fieldset/index.md
@@ -20,10 +20,14 @@ Provide a string to `@hint` to render the text into the Hint section of the Fiel
 
 ## Error
 
-Provide a string to `@error` to render the text into the Error section of the Fieldset. This is optional.
+Provide a string or array of strings to `@error` to render the text into the Error section of the Fieldset. This is optional.
 
 ```hbs
 <Form::Fieldset @label='Label' @error='Error' />
+```
+
+```hbs
+<Form::Fieldset @label='Label' @error={{(array 'Error 1' 'Error 2')}} />
 ```
 
 ## Disabled State
@@ -90,6 +94,11 @@ Target the error block via `data-error`.
 </Form::Fieldset>
 
 <Form::Fieldset @label='Label' @hint="With hint text" @error="With error">
+
+  <p class='text-body-and-labels text-xs m-0 italic'>~Fieldset components render here!~</p>
+</Form::Fieldset>
+
+<Form::Fieldset @label='Label' @hint="With hint text" @error={{(array "With error 1" "With error 2" "With error 3")}}>
 
   <p class='text-body-and-labels text-xs m-0 italic'>~Fieldset components render here!~</p>
 </Form::Fieldset>

--- a/docs/components/input-field/index.md
+++ b/docs/components/input-field/index.md
@@ -12,7 +12,22 @@ Provide a string to `@hint` to render the text into the Hint section of the Fiel
 
 ## Error
 
-Provide a string to `@error` to render the text into the Error section of the Field. This is optional.
+Provide a string or array of strings to `@error` to render the text into the Error section of the Field. This is optional.
+
+## Error
+
+Provide a string or array of strings to `@error` to render the text into the Error section of the Field. This is optional.
+
+```hbs
+<Form::InputField @label='Single error' @error='Error' />
+```
+
+```hbs
+<Form::InputField
+  @label='Multiple errors'
+  @error={{(array 'Error 1' 'Error 2')}}
+/>
+```
 
 ## Value and onChange
 
@@ -79,6 +94,7 @@ Target the error block via `data-error`.
 ## UI States
 
 ### InputField with Label
+
 <div class="mb-4 w-64">
   <Form::InputField
     @label="Label"
@@ -87,6 +103,7 @@ Target the error block via `data-error`.
 </div>
 
 ### InputField with Label and hint
+
 <div class="mb-4 w-64">
   <Form::InputField
     @label="Label"
@@ -95,7 +112,7 @@ Target the error block via `data-error`.
   />
 </div>
 
-### InputField with Label and error 
+### InputField with Label and error
 
 <div class="mb-4 w-64">
   <Form::InputField
@@ -105,7 +122,7 @@ Target the error block via `data-error`.
   />
 </div>
 
-### InputField with Label and isDisabled 
+### InputField with Label and isDisabled
 
 <div class="mb-4 w-64">
   <Form::InputField
@@ -116,5 +133,12 @@ Target the error block via `data-error`.
   />
 </div>
 
+### InputField with Multiple Errors
 
-
+<div class="mb-4 w-64">
+  <Form::InputField
+    @label="Label"
+    type="text"
+    @error={{(array "With error 1" "With error 2" "With error 3")}}
+  />
+</div>

--- a/docs/components/radio-group-field/index.md
+++ b/docs/components/radio-group-field/index.md
@@ -16,7 +16,19 @@ Provide a string to `@hint` to render the text into the Hint section of the fiel
 
 ## Error
 
-Provide a string to `@error` to render the text into the Error section of the fieldset. This is optional.
+Provide a string or array of strings to `@error` to render the text into the Error section of the fieldset. This is optional.
+
+```hbs
+<Form::RadioGroupField @label='Label' @name='single-error' @error='Error' />
+```
+
+```hbs
+<Form::RadioGroupField
+  @label='Label'
+  @name='multiple-errors'
+  @error={{(array 'Error 1' 'Error 2')}}
+/>
+```
 
 ## Value and onChange
 
@@ -128,6 +140,12 @@ Consumers have direct access to the underlying [radio element](https://developer
 </Form::RadioGroupField>
 
 <Form::RadioGroupField @label="Label" @name="disabled" @hint="With disabled" @isDisabled={{true}} as |group|>
+<group.RadioField @label="Option 1" @value="option-1" />
+<group.RadioField @label="Option 2" @value="option-2" />
+<group.RadioField @label="Option 3" @value="option-3" />
+</Form::RadioGroupField>
+
+<Form::RadioGroupField @label="Label" @name="multiple-errors" @error={{(array "With error 1" "With error 2" "With error 3")}} as |group|>
 <group.RadioField @label="Option 1" @value="option-1" />
 <group.RadioField @label="Option 2" @value="option-2" />
 <group.RadioField @label="Option 3" @value="option-3" />

--- a/docs/components/textarea-field/index.md
+++ b/docs/components/textarea-field/index.md
@@ -12,7 +12,18 @@ Provide a string to `@hint` to render the text into the Hint section of the Fiel
 
 ## Error
 
-Provide a string to `@error` to render the text into the Error section of the Field. This is optional.
+Provide a string or array of strings to `@error` to render the text into the Error section of the Field. This is optional.
+
+```hbs
+<Form::TextareaField @label='Single error' @error='Error' />
+```
+
+```hbs
+<Form::TextareaField
+  @label='Multiple errors'
+  @error={{(array 'Error 1' 'Error 2')}}
+/>
+```
 
 ## Value and onChange
 
@@ -111,6 +122,12 @@ Target the error block via `data-error`.
 @label='Label'
 @hint='With value'
 @value='a value'
+/>
+
+<Form::TextareaField
+@label='Label'
+@hint='With hint text'
+@error={{(array "With error 1" "With error 2" "With error 3")}}
 />
 
 </div>

--- a/ember-toucan-core/src/-private/components/error.hbs
+++ b/ember-toucan-core/src/-private/components/error.hbs
@@ -1,4 +1,8 @@
-<div class="type-xs-tight text-critical mt-1.5 flex items-center" ...attributes>
+<div
+  class="type-xs-tight text-critical mt-1.5 flex
+    {{if this.hasMoreThanOneError 'items-start' 'items-center'}}"
+  ...attributes
+>
   {{! Icon taken from Tony's open source icon set, this is temporary! }}
   <svg
     xmlns="http://www.w3.org/2000/svg"
@@ -18,5 +22,15 @@
     />
   </svg>
 
-  {{yield}}
+  {{#if this.hasMoreThanOneError}}
+    {{! Unfortunately we need this inline style to help with the ul offset  }}
+    {{! template-lint-disable no-inline-styles}}
+    <ul class="m-0 list-none space-y-1 p-0" style="margin-top: -2px">
+      {{#each this.errors as |error index|}}
+        <li class="m-0 p-0" data-error-item={{index}}>{{error}}</li>
+      {{/each}}
+    </ul>
+  {{else}}
+    <span>{{get this.errors 0}}</span>
+  {{/if}}
 </div>

--- a/ember-toucan-core/src/-private/components/error.hbs
+++ b/ember-toucan-core/src/-private/components/error.hbs
@@ -23,11 +23,9 @@
   </svg>
 
   {{#if this.hasMoreThanOneError}}
-    {{! Unfortunately we need this inline style to help with the ul offset  }}
-    {{! template-lint-disable no-inline-styles}}
-    <ul class="m-0 list-none space-y-1 p-0" style="margin-top: -2px">
+    <ul class="m-0 list-none space-y-1.5 p-0">
       {{#each this.errors as |error index|}}
-        <li class="m-0 p-0" data-error-item={{index}}>{{error}}</li>
+        <li class="m-0 p-0 leading-3" data-error-item={{index}}>{{error}}</li>
       {{/each}}
     </ul>
   {{else}}

--- a/ember-toucan-core/src/-private/components/error.ts
+++ b/ember-toucan-core/src/-private/components/error.ts
@@ -1,11 +1,40 @@
-import templateOnlyComponent from '@ember/component/template-only';
+import Component from '@glimmer/component';
+import { assert } from '@ember/debug';
+
+import type { ErrorMessage } from '../../-private/types';
 
 export interface ToucanFormErrorComponentSignature {
   Element: HTMLDivElement;
-  Args: {};
-  Blocks: {
-    default: [];
+  Args: {
+    /**
+     * Provide a string or array of strings to this argument to render styled errors.
+     */
+    error?: ErrorMessage;
   };
+  Blocks: {};
 }
 
-export default templateOnlyComponent<ToucanFormErrorComponentSignature>();
+export default class ToucanFormErrorComponent extends Component<ToucanFormErrorComponentSignature> {
+  /**
+   * Used to help us determine if we should render a single error
+   * or render a ul list of errors.
+   */
+  get hasMoreThanOneError() {
+    return Array.isArray(this.args.error) && this.args.error?.length > 1;
+  }
+
+  get errors(): Array<string> {
+    let { error } = this.args;
+
+    assert(
+      '"@error" must be either a string or an array of strings',
+      typeof error === 'string' || Array.isArray(error)
+    );
+
+    if (typeof error === 'string') {
+      return [error];
+    }
+
+    return error;
+  }
+}

--- a/ember-toucan-core/src/-private/types.ts
+++ b/ember-toucan-core/src/-private/types.ts
@@ -2,3 +2,12 @@
  * Callback used for input change events.
  */
 export type OnChangeCallback<T> = (value: T, e: Event | InputEvent) => void;
+
+/**
+ * Reusable type for handling error messages. At the moment, we support
+ * either a single string or an array of strings.
+ *
+ * Normally used with the private `Error` component and consumed by
+ * components for their `@error` component argument.
+ */
+export type ErrorMessage = string | Array<string>;

--- a/ember-toucan-core/src/components/form/checkbox-field.hbs
+++ b/ember-toucan-core/src/components/form/checkbox-field.hbs
@@ -35,7 +35,7 @@
     </field.Control>
 
     {{#if @error}}
-      <field.Error id={{field.errorId}} data-error>{{@error}}</field.Error>
+      <field.Error id={{field.errorId}} @error={{@error}} data-error />
     {{/if}}
   </Form::Field>
 </div>

--- a/ember-toucan-core/src/components/form/checkbox-field.ts
+++ b/ember-toucan-core/src/components/form/checkbox-field.ts
@@ -1,15 +1,16 @@
 import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
 
+import type { ErrorMessage } from '../../-private/types';
 import type { ToucanFormCheckboxControlComponentSignature } from './controls/checkbox';
 
 export interface ToucanFormCheckboxFieldComponentSignature {
   Element: HTMLInputElement;
   Args: {
     /**
-     * Provide a string to this argument to render an error message and apply error styling to the Field.
+     * Provide a string or array of strings to this argument to render an error message and apply error styling to the Field.
      */
-    error?: string;
+    error?: ErrorMessage;
 
     /**
      * Provide a string to this argument to render a hint message to help describe the control.

--- a/ember-toucan-core/src/components/form/fieldset.hbs
+++ b/ember-toucan-core/src/components/form/fieldset.hbs
@@ -22,7 +22,7 @@
     </field.Control>
 
     {{#if @error}}
-      <field.Error id={{field.errorId}} data-error>{{@error}}</field.Error>
+      <field.Error id={{field.errorId}} @error={{@error}} data-error />
     {{/if}}
   </fieldset>
 </Form::Field>

--- a/ember-toucan-core/src/components/form/fieldset.ts
+++ b/ember-toucan-core/src/components/form/fieldset.ts
@@ -1,13 +1,15 @@
 import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
 
+import type { ErrorMessage } from '../../-private/types';
+
 interface ToucanFormFieldsetComponentSignature {
   Element: HTMLFieldSetElement;
   Args: {
     /**
-     * Provide a string to this argument to render an error message and apply error styling to the Field.
+     * Provide a string or array of strings to this argument to render an error message and apply error styling to the Field.
      */
-    error?: string;
+    error?: ErrorMessage;
 
     /**
      * Provide a string to this argument to render a hint message to help describe the control.

--- a/ember-toucan-core/src/components/form/input-field.hbs
+++ b/ember-toucan-core/src/components/form/input-field.hbs
@@ -22,7 +22,7 @@
       />
     </field.Control>
     {{#if @error}}
-      <field.Error id={{field.errorId}} data-error>{{@error}}</field.Error>
+      <field.Error id={{field.errorId}} @error={{@error}} data-error />
     {{/if}}
   </Form::Field>
 </div>

--- a/ember-toucan-core/src/components/form/input-field.ts
+++ b/ember-toucan-core/src/components/form/input-field.ts
@@ -1,15 +1,15 @@
 import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
 
-import type { OnChangeCallback } from '../../-private/types';
+import type { ErrorMessage, OnChangeCallback } from '../../-private/types';
 
 interface ToucanFormInputFieldComponentSignature {
   Element: HTMLInputElement;
   Args: {
     /**
-     * Provide a string to this argument to render an error message and apply error styling to the Field.
+     * Provide a string or array of strings to this argument to render an error message and apply error styling to the Field.
      */
-    error?: string;
+    error?: ErrorMessage;
 
     /**
      * Provide a string to this argument to render a hint message to help describe the control.

--- a/ember-toucan-core/src/components/form/radio-group-field.ts
+++ b/ember-toucan-core/src/components/form/radio-group-field.ts
@@ -3,6 +3,7 @@ import { action } from '@ember/object';
 
 import RadioFieldComponent from './radio-field';
 
+import type { ErrorMessage } from '../../-private/types';
 import type { ToucanFormRadioFieldComponentSignature } from './radio-field';
 import type { WithBoundArgs } from '@glint/template';
 
@@ -10,9 +11,9 @@ export interface ToucanFormRadioGroupFieldComponentSignature {
   Element: HTMLFieldSetElement;
   Args: {
     /**
-     * Provide a string to this argument to render an error message and apply error styling to the Field.
+     * Provide a string or array of strings to this argument to render an error message and apply error styling to the Field.
      */
-    error?: string;
+    error?: ErrorMessage;
 
     /**
      * Provide a string to this argument to render a hint message to help describe the control.

--- a/ember-toucan-core/src/components/form/textarea-field.hbs
+++ b/ember-toucan-core/src/components/form/textarea-field.hbs
@@ -23,7 +23,7 @@
     </field.Control>
 
     {{#if @error}}
-      <field.Error id={{field.errorId}} data-error>{{@error}}</field.Error>
+      <field.Error id={{field.errorId}} @error={{@error}} data-error />
     {{/if}}
   </Form::Field>
 </div>

--- a/ember-toucan-core/src/components/form/textarea-field.ts
+++ b/ember-toucan-core/src/components/form/textarea-field.ts
@@ -1,15 +1,16 @@
 import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
 
+import type { ErrorMessage } from '../../-private/types';
 import type { ToucanFormTextareaControlComponentSignature } from './controls/textarea';
 
 export interface ToucanFormTextareaFieldComponentSignature {
   Element: HTMLTextAreaElement;
   Args: {
     /**
-     * Provide a string to this argument to render an error message and apply error styling to the Field.
+     * Provide a string or array of strings to this argument to render an error message and apply error styling to the Field.
      */
-    error?: string;
+    error?: ErrorMessage;
 
     /**
      * Provide a string to this argument to render a hint message to help describe the control.

--- a/test-app/app/templates/application.hbs
+++ b/test-app/app/templates/application.hbs
@@ -32,5 +32,5 @@
   <field.Control>
     <input type="text" />
   </field.Control>
-  <field.Error>error</field.Error>
+  <field.Error @error="error" />
 </Form::Field>

--- a/test-app/tests/integration/components/field-test.gts
+++ b/test-app/tests/integration/components/field-test.gts
@@ -20,7 +20,7 @@ module('Integration | Component | Field', function (hooks) {
         <field.Control>
           <input type="text" data-test-input />
         </field.Control>
-        <field.Error data-test-error>error</field.Error>
+        <field.Error @error="error" data-test-error />
       </Field>
     </template>);
 
@@ -95,5 +95,29 @@ module('Integration | Component | Field', function (hooks) {
     assert.dom('[data-test-id]').hasAnyText();
     assert.dom('[data-test-hintId]').hasAnyText();
     assert.dom('[data-test-errorId]').hasAnyText();
+  });
+
+  test('it renders an array of errors', async function (assert) {
+    let testErrors = ['error 1', 'error 2'];
+
+    await render(<template>
+      <Field as |field|>
+        <field.Error @error={{testErrors}} data-test-error />
+      </Field>
+    </template>);
+
+    assert
+      .dom('[data-test-error]')
+      .exists('Expected error block to be rendered');
+
+    assert.dom('[data-error-item]').exists({ count: 2 });
+
+    assert
+      .dom('[data-error-item="0"]')
+      .hasText('error 1', 'Expected to have first error text rendered');
+
+    assert
+      .dom('[data-error-item="1"]')
+      .hasText('error 2', 'Expected to have first error text rendered');
   });
 });

--- a/test-app/tests/integration/components/fieldset-test.gts
+++ b/test-app/tests/integration/components/fieldset-test.gts
@@ -55,6 +55,28 @@ module('Integration | Component | Fieldset', function (hooks) {
     assert.dom('[data-control]').hasClass('shadow-error-outline');
   });
 
+  test('it renders with multiple errors', async function (assert) {
+    let testErrors = ['error 1', 'error 2'];
+
+    await render(<template>
+      <Fieldset @label="Label" @error={{testErrors}} data-fieldset />
+    </template>);
+
+    assert.dom('[data-control]').hasClass('shadow-error-outline');
+
+    assert.dom('[data-error]').hasAttribute('id');
+
+    assert.dom('[data-error-item]').exists({ count: 2 });
+
+    assert
+      .dom('[data-error-item="0"]')
+      .hasText('error 1', 'Expected to have first error text rendered');
+
+    assert
+      .dom('[data-error-item="1"]')
+      .hasText('error 2', 'Expected to have first error text rendered');
+  });
+
   test('it sets aria-describedby when both a hint and error are provided', async function (assert) {
     await render(<template>
       <Fieldset


### PR DESCRIPTION
## 🚀 Description
This PR allows for having either a single string for an error or an array of errors.  This will allow us to play more nicely with `ember-headless-form`.

Closes #44 

---

## 🔬 How to Test

- View https://aa13bb8f.ember-toucan-core.pages.dev/docs/components/field#yielded-items and review the `Yielded Items` > `Error` section for validity
- Verify can render both a single error and multiple errors by clicking the link and scroll down a bit (should be the last example). Please also verify the "Error" section of each page
  - https://aa13bb8f.ember-toucan-core.pages.dev/docs/components/fieldset#all-ui-states
  - https://aa13bb8f.ember-toucan-core.pages.dev/docs/components/checkbox-field#all-ui-states
  - https://aa13bb8f.ember-toucan-core.pages.dev/docs/components/textarea-field#all-ui-states
  - https://aa13bb8f.ember-toucan-core.pages.dev/docs/components/input-field#inputfield-with-multiple-errors || https://aa13bb8f.ember-toucan-core.pages.dev/docs/components/input-field#inputfield-with-label-and-error
  - https://aa13bb8f.ember-toucan-core.pages.dev/docs/components/radio-group-field#all-ui-states

---

## 📸 Images/Videos of Functionality

<img width="234" alt="Screenshot 2023-03-20 at 10 26 51 AM" src="https://user-images.githubusercontent.com/8069555/226370375-69a2e1df-8bca-4ab9-8413-9891671073de.png">
