### PR TITLE
feat: Use new shadow-error-focus-outline

### DIFF
--- a/docs-app/package.json
+++ b/docs-app/package.json
@@ -26,8 +26,8 @@
   "devDependencies": {
     "@babel/core": "^7.19.6",
     "@babel/eslint-parser": "^7.19.1",
-    "@crowdstrike/ember-toucan-styles": "^2.0.0",
-    "@crowdstrike/tailwind-toucan-base": "^3.3.1",
+    "@crowdstrike/ember-toucan-styles": "^2.0.1",
+    "@crowdstrike/tailwind-toucan-base": "^3.4.0",
     "@docfy/core": "^0.6.0",
     "@docfy/ember": "^0.6.0",
     "@ember/optional-features": "^2.0.0",

--- a/ember-toucan-core/package.json
+++ b/ember-toucan-core/package.json
@@ -32,7 +32,7 @@
     "format": "prettier -w ."
   },
   "peerDependencies": {
-    "@crowdstrike/ember-toucan-styles": "^1.0.5",
+    "@crowdstrike/ember-toucan-styles": "^2.0.1",
     "@ember/test-helpers": "^2.8.1",
     "@glimmer/tracking": "^1.1.2",
     "autoprefixer": "^10.0.2",
@@ -52,7 +52,7 @@
     "@babel/plugin-proposal-decorators": "^7.17.0",
     "@babel/plugin-syntax-decorators": "^7.17.0",
     "@babel/preset-typescript": "^7.18.6",
-    "@crowdstrike/ember-toucan-styles": "^2.0.0",
+    "@crowdstrike/ember-toucan-styles": "^2.0.1",
     "@ember/test-helpers": "^2.8.1",
     "@embroider/addon-dev": "^3.0.0",
     "@glimmer/component": "^1.1.2",

--- a/ember-toucan-core/src/components/form/controls/input.hbs
+++ b/ember-toucan-core/src/components/form/controls/input.hbs
@@ -1,7 +1,11 @@
 <input
-  class="bg-overlay-1 focus:outline-none focus:shadow-focus-outline block rounded-sm p-1
+  class="bg-overlay-1 focus:outline-none focus:shadow-focus-outline block rounded-sm p-1 transition-shadow
     {{if @isDisabled 'text-disabled' 'text-titles-and-attributes'}}
-    {{if @hasError 'shadow-error-outline' 'shadow-focusable-outline'}}"
+    {{if
+      @hasError
+      'shadow-error-outline focus:shadow-error-focus-outline'
+      'shadow-focusable-outline'
+    }}"
   disabled={{@isDisabled}}
   value={{@value}}
   ...attributes

--- a/ember-toucan-core/src/components/form/controls/textarea.hbs
+++ b/ember-toucan-core/src/components/form/controls/textarea.hbs
@@ -1,7 +1,11 @@
 <textarea
-  class="min-h-6 bg-overlay-1 focus:outline-none focus:shadow-focus-outline block h-20 rounded-sm p-1
+  class="min-h-6 bg-overlay-1 focus:outline-none focus:shadow-focus-outline block h-20 rounded-sm p-1 transition-shadow
     {{if @isDisabled 'text-disabled' 'text-titles-and-attributes'}}
-    {{if @hasError 'shadow-error-outline' 'shadow-focusable-outline'}}"
+    {{if
+      @hasError
+      'shadow-error-outline focus:shadow-error-focus-outline'
+      'shadow-focusable-outline'
+    }}"
   disabled={{@isDisabled}}
   ...attributes
   {{on "input" this.handleInput}}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,8 +23,8 @@ importers:
       '@babel/eslint-parser': ^7.19.1
       '@crowdstrike/ember-oss-docs': ^1.1.3
       '@crowdstrike/ember-toucan-core': workspace:../ember-toucan-core
-      '@crowdstrike/ember-toucan-styles': ^2.0.0
-      '@crowdstrike/tailwind-toucan-base': ^3.3.1
+      '@crowdstrike/ember-toucan-styles': ^2.0.1
+      '@crowdstrike/tailwind-toucan-base': ^3.4.0
       '@docfy/core': ^0.6.0
       '@docfy/ember': ^0.6.0
       '@ember/optional-features': ^2.0.0
@@ -120,8 +120,8 @@ importers:
       typescript: ^5.0.0
       webpack: ^5.74.0
     dependencies:
-      '@crowdstrike/ember-oss-docs': 1.1.3_fvkafazzlwllk7evawf3liompq
-      '@crowdstrike/ember-toucan-core': file:ember-toucan-core_c62kkjskxqbpmxwcikoriz42fm
+      '@crowdstrike/ember-oss-docs': 1.1.3_v6w3ttlr5tgzhirycmizipk2w4
+      '@crowdstrike/ember-toucan-core': file:ember-toucan-core_tsl23gieylnuee6e2ygn7tbtzq
       '@ember/test-waiters': 3.0.2
       '@embroider/router': 2.0.0_htqm3qg3nmvfkwq4ngma65xhmi
       dompurify: 3.0.0
@@ -135,8 +135,8 @@ importers:
     devDependencies:
       '@babel/core': 7.20.12
       '@babel/eslint-parser': 7.19.1_b3mcivpi6zqbotlvqqcfprcnry
-      '@crowdstrike/ember-toucan-styles': 2.0.0_mfv5drjkgyacqn3e4obtqf67r4
-      '@crowdstrike/tailwind-toucan-base': 3.3.1_gbtt6ss3tbiz4yjtvdr6fbrj44
+      '@crowdstrike/ember-toucan-styles': 2.0.1_mfv5drjkgyacqn3e4obtqf67r4
+      '@crowdstrike/tailwind-toucan-base': 3.4.0_gbtt6ss3tbiz4yjtvdr6fbrj44
       '@docfy/core': 0.6.0
       '@docfy/ember': 0.6.0
       '@ember/optional-features': 2.0.0
@@ -234,7 +234,7 @@ importers:
       '@babel/plugin-syntax-decorators': ^7.17.0
       '@babel/preset-typescript': ^7.18.6
       '@babel/runtime': ^7.20.7
-      '@crowdstrike/ember-toucan-styles': ^2.0.0
+      '@crowdstrike/ember-toucan-styles': ^2.0.1
       '@ember/test-helpers': ^2.8.1
       '@embroider/addon-dev': ^3.0.0
       '@embroider/addon-shim': ^1.0.0
@@ -295,7 +295,7 @@ importers:
       '@babel/plugin-proposal-decorators': 7.20.13_@babel+core@7.20.12
       '@babel/plugin-syntax-decorators': 7.19.0_@babel+core@7.20.12
       '@babel/preset-typescript': 7.18.6_@babel+core@7.20.12
-      '@crowdstrike/ember-toucan-styles': 2.0.0_s65i42ght5puaytfxzkqtgip7a
+      '@crowdstrike/ember-toucan-styles': 2.0.1_s65i42ght5puaytfxzkqtgip7a
       '@ember/test-helpers': 2.9.3_7vtd5myfhclgvpdk736clxxu5q
       '@embroider/addon-dev': 3.0.0_rollup@3.12.1
       '@glimmer/component': 1.1.2_@babel+core@7.20.12
@@ -351,7 +351,7 @@ importers:
       '@babel/core': ^7.0.0
       '@babel/eslint-parser': ^7.19.1
       '@crowdstrike/ember-toucan-core': workspace:../ember-toucan-core
-      '@crowdstrike/ember-toucan-styles': ^2.0.0
+      '@crowdstrike/ember-toucan-styles': ^2.0.1
       '@ember/optional-features': ^2.0.0
       '@ember/string': ^3.0.1
       '@ember/test-helpers': ^2.8.1
@@ -439,8 +439,8 @@ importers:
     devDependencies:
       '@babel/core': 7.20.12
       '@babel/eslint-parser': 7.19.1_b3mcivpi6zqbotlvqqcfprcnry
-      '@crowdstrike/ember-toucan-core': file:ember-toucan-core_4whx7nwvnx5634tbg3sfu4evmq
-      '@crowdstrike/ember-toucan-styles': 2.0.0_s65i42ght5puaytfxzkqtgip7a
+      '@crowdstrike/ember-toucan-core': file:ember-toucan-core_jynjp5ztsn6lybkenvnshv5ndu
+      '@crowdstrike/ember-toucan-styles': 2.0.1_s65i42ght5puaytfxzkqtgip7a
       '@ember/optional-features': 2.0.0
       '@ember/string': 3.0.1
       '@ember/test-helpers': 2.9.3_7vtd5myfhclgvpdk736clxxu5q
@@ -1998,7 +1998,7 @@ packages:
     dev: true
     optional: true
 
-  /@crowdstrike/ember-oss-docs/1.1.3_fvkafazzlwllk7evawf3liompq:
+  /@crowdstrike/ember-oss-docs/1.1.3_v6w3ttlr5tgzhirycmizipk2w4:
     resolution: {integrity: sha512-2GiPPy4G4BDP+4BZpFd8dJ3CQSCrp2FobrxUE9uszSaPyF2wTim5ZH46IwKzrozF+fHB6EaDZG/hls7S8nyhQg==}
     peerDependencies:
       '@crowdstrike/tailwind-toucan-base': ^3.3.1
@@ -2012,7 +2012,7 @@ packages:
       highlightjs-glimmer: ^1.4.1 || ^2.0.0
     dependencies:
       '@babel/runtime': 7.20.13
-      '@crowdstrike/tailwind-toucan-base': 3.3.1_gbtt6ss3tbiz4yjtvdr6fbrj44
+      '@crowdstrike/tailwind-toucan-base': 3.4.0_gbtt6ss3tbiz4yjtvdr6fbrj44
       '@docfy/core': 0.6.0
       '@docfy/ember': 0.6.0
       '@embroider/addon-shim': 1.8.4
@@ -2032,14 +2032,14 @@ packages:
       - supports-color
     dev: false
 
-  /@crowdstrike/ember-toucan-styles/2.0.0_mfv5drjkgyacqn3e4obtqf67r4:
-    resolution: {integrity: sha512-mOHsNEW63FhCR2+c1Fdp4vOqv6HYRtfU85aZlLc82NhkTguz6NSS5DwYelhfDIxLERm5iktxBmBOyiXGHkk0Mg==}
+  /@crowdstrike/ember-toucan-styles/2.0.1_mfv5drjkgyacqn3e4obtqf67r4:
+    resolution: {integrity: sha512-Gwf7j/JzJzpONu3Qg2BK3InAvDgLIxAFzxf2a4oHD+3IbLUSPLhCFzpQ6+kqSg20cA0+4oVMiCdtMq/Xx005tw==}
     peerDependencies:
       '@glimmer/tracking': ^1.1.2
       ember-source: ^3.24.0 || >= 4.0.0
       tailwindcss: ^2.2.15 || ^3.0.0
     dependencies:
-      '@crowdstrike/tailwind-toucan-base': 3.3.1_gbtt6ss3tbiz4yjtvdr6fbrj44
+      '@crowdstrike/tailwind-toucan-base': 3.4.0_gbtt6ss3tbiz4yjtvdr6fbrj44
       '@embroider/addon-shim': 1.8.4
       '@glimmer/tracking': 1.1.2
       ember-browser-services: 4.0.4
@@ -2051,14 +2051,14 @@ packages:
       - supports-color
       - ts-node
 
-  /@crowdstrike/ember-toucan-styles/2.0.0_s65i42ght5puaytfxzkqtgip7a:
-    resolution: {integrity: sha512-mOHsNEW63FhCR2+c1Fdp4vOqv6HYRtfU85aZlLc82NhkTguz6NSS5DwYelhfDIxLERm5iktxBmBOyiXGHkk0Mg==}
+  /@crowdstrike/ember-toucan-styles/2.0.1_s65i42ght5puaytfxzkqtgip7a:
+    resolution: {integrity: sha512-Gwf7j/JzJzpONu3Qg2BK3InAvDgLIxAFzxf2a4oHD+3IbLUSPLhCFzpQ6+kqSg20cA0+4oVMiCdtMq/Xx005tw==}
     peerDependencies:
       '@glimmer/tracking': ^1.1.2
       ember-source: ^3.24.0 || >= 4.0.0
       tailwindcss: ^2.2.15 || ^3.0.0
     dependencies:
-      '@crowdstrike/tailwind-toucan-base': 3.3.1_gbtt6ss3tbiz4yjtvdr6fbrj44
+      '@crowdstrike/tailwind-toucan-base': 3.4.0_gbtt6ss3tbiz4yjtvdr6fbrj44
       '@embroider/addon-shim': 1.8.4
       '@glimmer/tracking': 1.1.2
       ember-browser-services: 4.0.4
@@ -2071,8 +2071,8 @@ packages:
       - ts-node
     dev: true
 
-  /@crowdstrike/tailwind-toucan-base/3.3.1_gbtt6ss3tbiz4yjtvdr6fbrj44:
-    resolution: {integrity: sha512-DGjFKPK7Y0UNJaaWBjE6M0PT/0bgJe3craBrbmI46hzRXMqwsWBZVlk98Sj5pl3pM2N8xldC94W9BpdLDoxrOg==}
+  /@crowdstrike/tailwind-toucan-base/3.4.0_gbtt6ss3tbiz4yjtvdr6fbrj44:
+    resolution: {integrity: sha512-WXWnXn5RIFDJQ2FtjgIqshiilPqv8xslEpTvTnduqnxE+4tJPhiP1FXrGPjo8g42W3l4RXa9Ml5wKSBXvSffVQ==}
     engines: {node: '>=14.15.0'}
     dependencies:
       tailwindcss: 2.2.19_gbtt6ss3tbiz4yjtvdr6fbrj44
@@ -16008,13 +16008,13 @@ packages:
   /zwitch/1.0.5:
     resolution: {integrity: sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw==}
 
-  file:ember-toucan-core_4whx7nwvnx5634tbg3sfu4evmq:
+  file:ember-toucan-core_jynjp5ztsn6lybkenvnshv5ndu:
     resolution: {directory: ember-toucan-core, type: directory}
     id: file:ember-toucan-core
     name: '@crowdstrike/ember-toucan-core'
     version: 0.0.0
     peerDependencies:
-      '@crowdstrike/ember-toucan-styles': ^1.0.5
+      '@crowdstrike/ember-toucan-styles': ^2.0.1
       '@ember/test-helpers': ^2.8.1
       '@glimmer/tracking': ^1.1.2
       autoprefixer: ^10.0.2
@@ -16024,7 +16024,7 @@ packages:
       tailwindcss: ^2.2.15 || ^3.0.0
     dependencies:
       '@babel/runtime': 7.20.13
-      '@crowdstrike/ember-toucan-styles': 2.0.0_s65i42ght5puaytfxzkqtgip7a
+      '@crowdstrike/ember-toucan-styles': 2.0.1_s65i42ght5puaytfxzkqtgip7a
       '@ember/test-helpers': 2.9.3_7vtd5myfhclgvpdk736clxxu5q
       '@embroider/addon-shim': 1.8.4
       '@glimmer/tracking': 1.1.2
@@ -16037,13 +16037,13 @@ packages:
       - supports-color
     dev: true
 
-  file:ember-toucan-core_c62kkjskxqbpmxwcikoriz42fm:
+  file:ember-toucan-core_tsl23gieylnuee6e2ygn7tbtzq:
     resolution: {directory: ember-toucan-core, type: directory}
     id: file:ember-toucan-core
     name: '@crowdstrike/ember-toucan-core'
     version: 0.0.0
     peerDependencies:
-      '@crowdstrike/ember-toucan-styles': ^1.0.5
+      '@crowdstrike/ember-toucan-styles': ^2.0.1
       '@ember/test-helpers': ^2.8.1
       '@glimmer/tracking': ^1.1.2
       autoprefixer: ^10.0.2
@@ -16053,7 +16053,7 @@ packages:
       tailwindcss: ^2.2.15 || ^3.0.0
     dependencies:
       '@babel/runtime': 7.20.13
-      '@crowdstrike/ember-toucan-styles': 2.0.0_mfv5drjkgyacqn3e4obtqf67r4
+      '@crowdstrike/ember-toucan-styles': 2.0.1_mfv5drjkgyacqn3e4obtqf67r4
       '@ember/test-helpers': 2.9.3_7vtd5myfhclgvpdk736clxxu5q
       '@embroider/addon-shim': 1.8.4
       '@glimmer/tracking': 1.1.2

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -30,7 +30,7 @@
     "@babel/core": "^7.0.0",
     "@babel/eslint-parser": "^7.19.1",
     "@crowdstrike/ember-toucan-core": "workspace:../ember-toucan-core",
-    "@crowdstrike/ember-toucan-styles": "^2.0.0",
+    "@crowdstrike/ember-toucan-styles": "^2.0.1",
     "@ember/optional-features": "^2.0.0",
     "@ember/string": "^3.0.1",
     "@ember/test-helpers": "^2.8.1",

--- a/test-app/tests/integration/components/input-field-test.gts
+++ b/test-app/tests/integration/components/input-field-test.gts
@@ -6,20 +6,15 @@ import { module, test } from 'qunit';
 import InputField from '@crowdstrike/ember-toucan-core/components/form/input-field';
 import { setupRenderingTest } from 'test-app/tests/helpers';
 
-
 module('Integration | Component | InputField', function (hooks) {
   setupRenderingTest(hooks);
 
   test('it renders', async function (assert) {
     await render(<template>
-      <InputField
-        @label="Label"
-        type="text"
-        data-input
-        />
+      <InputField @label="Label" type="text" data-input />
     </template>);
 
-    const label = '[data-label]'
+    const label = '[data-label]';
     const input = '[data-input]';
     const inputId = find(input)?.getAttribute('id') || '';
 
@@ -34,19 +29,20 @@ module('Integration | Component | InputField', function (hooks) {
   });
 
   test('it encourages @label via assert', async function (assert) {
-    assert.expect(1)
+    assert.expect(1);
 
-    setupOnerror((e:Error) => {
-      assert.strictEqual(e.message, 'Assertion Failed: input field requires a label', 'Expected an error message if @label is not provided')
-    })
+    setupOnerror((e: Error) => {
+      assert.strictEqual(
+        e.message,
+        'Assertion Failed: input field requires a label',
+        'Expected an error message if @label is not provided'
+      );
+    });
     await render(<template>
       {{! @glint-expect-error: should have an error here for missing @label }}
-      <InputField
-        type="text"
-        />
+      <InputField type="text" />
     </template>);
-
-  })
+  });
 
   test('it renders an error', async function (assert) {
     await render(<template>
@@ -55,23 +51,29 @@ module('Integration | Component | InputField', function (hooks) {
         type="text"
         @error="There is an error"
         data-input
-        />
+      />
     </template>);
 
     const input = '[data-input]';
     const error = '[data-error]';
 
     assert.dom(error).exists('Expected to have error component rendered');
-    assert.dom(error).hasText('There is an error', 'Expected to have error text "error"');
+    assert
+      .dom(error)
+      .hasText('There is an error', 'Expected to have error text "error"');
     assert.dom(error).hasAttribute('id');
 
     const errorId = find(error)?.getAttribute('id') || '';
     const describedby = find(input)?.getAttribute('aria-describedby') || '';
 
-    assert.ok(describedby.includes(errorId), 'Expected errorId to be included in the aria-describedby');
+    assert.ok(
+      describedby.includes(errorId),
+      'Expected errorId to be included in the aria-describedby'
+    );
     assert.dom(input).hasAttribute('aria-invalid', 'true');
 
     assert.dom(input).hasClass('shadow-error-outline');
+    assert.dom(input).hasClass('focus:shadow-error-focus-outline');
   });
 
   test('it renders hint text', async function (assert) {
@@ -81,10 +83,10 @@ module('Integration | Component | InputField', function (hooks) {
         type="text"
         @hint="Hint text visible here"
         data-input
-        />
+      />
     </template>);
 
-    const label = '[data-label]'
+    const label = '[data-label]';
     const input = '[data-input]';
     const hint = '[data-hint]';
 
@@ -95,15 +97,20 @@ module('Integration | Component | InputField', function (hooks) {
     assert.dom(input).hasAttribute('type', 'text');
 
     assert.dom(hint).exists('Expected to have hint component rendered');
-    assert.dom(hint).hasText('Hint text visible here', 'Expected to have hint text "error"');
+    assert
+      .dom(hint)
+      .hasText('Hint text visible here', 'Expected to have hint text "error"');
     assert.dom(hint).hasAttribute('id');
     const hintId = find(hint)?.getAttribute('id') || '';
     const describedby = find(input)?.getAttribute('aria-describedby') || '';
 
-    assert.ok(describedby.includes(hintId), 'Expected hintId to be included in the aria-describedby');
+    assert.ok(
+      describedby.includes(hintId),
+      'Expected hintId to be included in the aria-describedby'
+    );
   });
 
-  test('it sets aria-describedby when both a hint and error are provided using the hint and error ids', async function(assert) {
+  test('it sets aria-describedby when both a hint and error are provided using the hint and error ids', async function (assert) {
     await render(<template>
       <InputField
         @label="Label"
@@ -111,7 +118,7 @@ module('Integration | Component | InputField', function (hooks) {
         @hint="Hint text visible here"
         @error="Error text"
         data-input
-        />
+      />
     </template>);
 
     const errorId = find('[data-error]')?.getAttribute('id') || '';
@@ -120,7 +127,9 @@ module('Integration | Component | InputField', function (hooks) {
     const hintId = find('[data-hint]')?.getAttribute('id') || '';
     assert.ok(hintId, 'Expected hintId to be truthy');
 
-    assert.dom('[data-input]').hasAttribute('aria-describedby', `${hintId} ${errorId}`);
+    assert
+      .dom('[data-input]')
+      .hasAttribute('aria-describedby', `${hintId} ${errorId}`);
   });
 
   test('it accepts @value and @onChange', async function (assert) {
@@ -134,18 +143,20 @@ module('Integration | Component | InputField', function (hooks) {
     };
 
     await render(<template>
-        <InputField
-          @label="Label"
-          type="text"
-          @value="Avocado"
-          @onChange={{onChangeCallback}}
-          data-input
-          />
-      </template>);
+      <InputField
+        @label="Label"
+        type="text"
+        @value="Avocado"
+        @onChange={{onChangeCallback}}
+        data-input
+      />
+    </template>);
 
     assert.verifySteps([]);
 
-    assert.dom('[data-input]').hasValue('Avocado', 'input has the original value');
+    assert
+      .dom('[data-input]')
+      .hasValue('Avocado', 'input has the original value');
 
     await fillIn('[data-input]', 'Banana');
 
@@ -156,13 +167,8 @@ module('Integration | Component | InputField', function (hooks) {
 
   test('it applies the provided `@rootTestSelector` to the data-root-field attribute', async function (assert) {
     await render(<template>
-      <InputField
-        @label="Label"
-        @rootTestSelector="selector"
-        data-input
-      />
+      <InputField @label="Label" @rootTestSelector="selector" data-input />
     </template>);
     assert.dom('[data-root-field="selector"]').exists();
   });
-
 });

--- a/test-app/tests/integration/components/input-test.gts
+++ b/test-app/tests/integration/components/input-test.gts
@@ -21,6 +21,10 @@ module('Integration | Component | Input', function (hooks) {
     assert.dom('[data-input]').hasTagName('input');
     assert.dom('[data-input]').hasClass('text-titles-and-attributes');
     assert.dom('[data-input]').doesNotHaveClass('text-disabled');
+    assert.dom('[data-input]').doesNotHaveClass('shadow-error-outline');
+    assert
+      .dom('[data-input]')
+      .doesNotHaveClass('focus:shadow-error-focus-outline');
   });
 
   test('it disables the input using `@isDisabled`', async function (assert) {
@@ -32,9 +36,7 @@ module('Integration | Component | Input', function (hooks) {
 
     assert.dom('[data-input]').isDisabled();
     assert.dom('[data-input]').hasClass('text-disabled');
-    assert
-      .dom('[data-input]')
-      .doesNotHaveClass('text-titles-and-attributes');
+    assert.dom('[data-input]').doesNotHaveClass('text-titles-and-attributes');
   });
 
   test('it spreads attributes to the underlying input', async function (assert) {
@@ -44,9 +46,7 @@ module('Integration | Component | Input', function (hooks) {
       <InputControl placeholder="Placeholder text" data-input />
     </template>);
 
-    assert
-      .dom('[data-input]')
-      .hasAttribute('placeholder', 'Placeholder text');
+    assert.dom('[data-input]').hasAttribute('placeholder', 'Placeholder text');
   });
 
   test('it sets the value attribute via `@value`', async function (assert) {
@@ -80,5 +80,17 @@ module('Integration | Component | Input', function (hooks) {
     await fillIn('[data-input]', 'test');
 
     assert.verifySteps(['handleChange']);
+  });
+
+  test('it applies the error shadow when `@hasError={{true}}`', async function (assert) {
+    await render(<template>
+      {{! we do not require a label, but instead suggest using Field / TextareaField }}
+      {{! template-lint-disable require-input-label }}
+      <InputControl @hasError={{true}} data-input />
+    </template>);
+
+    assert.dom('[data-input]').hasClass('shadow-error-outline');
+    assert.dom('[data-input]').hasClass('focus:shadow-error-focus-outline');
+    assert.dom('[data-input]').doesNotHaveClass('shadow-focusable-outline');
   });
 });

--- a/test-app/tests/integration/components/textarea-field-test.gts
+++ b/test-app/tests/integration/components/textarea-field-test.gts
@@ -78,6 +78,7 @@ module('Integration | Component | TextareaField', function (hooks) {
     assert.dom('[data-textarea]').hasAttribute('aria-invalid', 'true');
 
     assert.dom('[data-textarea]').hasClass('shadow-error-outline');
+    assert.dom('[data-textarea]').hasClass('focus:shadow-error-focus-outline');
     assert.dom('[data-textarea]').doesNotHaveClass('shadow-focusable-outline');
   });
 

--- a/test-app/tests/integration/components/textarea-test.gts
+++ b/test-app/tests/integration/components/textarea-test.gts
@@ -21,6 +21,10 @@ module('Integration | Component | Textarea', function (hooks) {
     assert.dom('[data-textarea]').hasClass('text-titles-and-attributes');
     assert.dom('[data-textarea]').hasClass('shadow-focusable-outline');
     assert.dom('[data-textarea]').doesNotHaveClass('text-disabled');
+    assert.dom('[data-textarea]').doesNotHaveClass('shadow-error-outline');
+    assert
+      .dom('[data-textarea]')
+      .doesNotHaveClass('focus:shadow-error-focus-outline');
   });
 
   test('it disables the textarea using `@isDisabled`', async function (assert) {
@@ -90,6 +94,7 @@ module('Integration | Component | Textarea', function (hooks) {
     </template>);
 
     assert.dom('[data-textarea]').hasClass('shadow-error-outline');
+    assert.dom('[data-textarea]').hasClass('focus:shadow-error-focus-outline');
     assert.dom('[data-textarea]').doesNotHaveClass('shadow-focusable-outline');
   });
 });


### PR DESCRIPTION
## 💅  Description

This PR consumes the new changes from `tailwind-toucan-base` and `ember-toucan-styles` so that we can use our new error+focus shadow:

- https://github.com/CrowdStrike/tailwind-toucan-base/releases/tag/v3.4.0
- https://github.com/CrowdStrike/ember-toucan-styles/releases/tag/%40crowdstrike%2Fember-toucan-styles%402.0.1

---

## 🔬 How to Test

- Visit https://2f323160.ember-toucan-core.pages.dev/docs/components/textarea-field
- Start typing "textarea" into the field and verify you see the focus+error shadow
- Upon completing typing "textarea", the error shadow should be removed and only the focus shadow remains
- Deleting a single character should re-add the focus+error shadow
- Visit https://2f323160.ember-toucan-core.pages.dev/docs/components/input-field#inputfield-with-label-and-error
- Click into input field with label and error example
- Verify the focus+error shadow is shown

See videos below for help!

---

## 📸 Images/Videos of Functionality


### Input
https://user-images.githubusercontent.com/8069555/226701952-ef2f62a5-97f7-47e2-a254-f5a75390c43e.mov


### Textarea
https://user-images.githubusercontent.com/8069555/226701674-36d06f25-b4e3-4787-ae8c-58fccdac1b0e.mov

