### PR TITLE
docs: Add PR Template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,14 @@
 
 ## 🚀 Description
 
-<!-- Please write a thoughtful description of what this PR is accomplishing. Are you adding a new feature? Fixing a bug? Writing documentation? Is there a GitHub issue that can be closed if this merges? -->
+<!-- Please write a thoughtful description of what this PR is accomplishing. Are you adding a new feature? Fixing a bug? Writing documentation? Is there a GitHub issue that can be closed if this merges?
+
+Another acceptable option is to put the summary of the changes in list form:
+
+- [x] added: new styles in {filename}
+- [x] fixed: addressed flicker in {filename}
+
+-->
 
 ---
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+<!-- Hello! This template is automatically added to help write up your pull request. Feel free to delete these comments, although they won't show up in the rendered markdown! This is only a template, feel free to adjust as you please! -->
+
+## 🚀 Description
+
+<!-- Please write a thoughtful description of what this PR is accomplishing. Are you adding a new feature? Fixing a bug? Writing documentation? Is there a GitHub issue that can be closed if this merges? -->
+
+---
+
+## 🔬 How to Test
+
+<!-- Please provide steps to test the functionality added/removed. Preview URLs are generated with each build.  We normally use the preview URLs and ask folks to review specific functionality based on them (e.g., "go to this page, view the new CSS changes"). -->
+
+---
+
+## 📸 Images/Videos of Functionality
+
+<!-- For visual changes, it's extremely helpful to include screenshots, gifs, or videos of what has changed.  Before and After images are also super helpful! -->


### PR DESCRIPTION
## 📚  Description

This PR adds a standardized pull request template so that we can prompt external users (non-CS folks) on what we expect when reviewing PRs.  It may also save some of us time writing up PR descriptions!  Feel free to offer any suggestions.

I followed https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository to make this.

---

## 🔬 How to Test

There is no way to test this until it merges!

---

## 📸 Images/Videos of Functionality

N/A