### PR TITLE
fix: FileInputField, remove multiple helper

### DIFF
--- a/docs/components/file-input-field/index.md
+++ b/docs/components/file-input-field/index.md
@@ -2,6 +2,11 @@
 
 Provides an underlying `<input type="file">` element building on top of the Field component.
 
+## Accepts
+
+Optional.
+Used to specify the types of files allowed. [See related documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/accept).
+
 ## Label
 
 Required.
@@ -33,6 +38,11 @@ Optional.
 Provide an array of [File](https://developer.mozilla.org/en-US/docs/Web/API/File) objects to the File input via `@files`.
 
 **Note:** To make things easier, the `@files` argument is an array. This makes it convenient to use existing Array methods like `find` and `filter`.
+
+## Multiple
+
+Optional.
+If true, allows users to upload multiple files. If false, the `multiple` attribute is not added to the underlying input.
 
 ## Value and onChange
 

--- a/ember-toucan-core/src/components/form/controls/file-input.ts
+++ b/ember-toucan-core/src/components/form/controls/file-input.ts
@@ -14,6 +14,7 @@ interface ToucanFormControlsFileInputComponentSignature {
     onChange?: (files: File[] | [], event: FileEvent) => void;
     multiple?: boolean;
     files?: File[];
+    accept?: string;
   };
 }
 
@@ -28,6 +29,10 @@ export default class ToucanFormControlsFileInputComponent extends Component<Touc
     );
 
     super(owner, args);
+  }
+
+  get accept() {
+    return this.args.accept ?? '*';
   }
 
   get multiple() {

--- a/ember-toucan-core/src/components/form/file-input-field.hbs
+++ b/ember-toucan-core/src/components/form/file-input-field.hbs
@@ -13,8 +13,8 @@
         <Form::Controls::FileInput
           aria-describedby={{if this.hasError field.errorId}}
           aria-invalid={{if this.hasError "true"}}
-          accept={{this.accept}}
           id={{field.id}}
+          @accept={{@accept}}
           @files={{@files}}
           @hasError={{this.hasError}}
           @multiple={{@multiple}}

--- a/ember-toucan-core/src/components/form/file-input-field.hbs
+++ b/ember-toucan-core/src/components/form/file-input-field.hbs
@@ -17,7 +17,7 @@
           id={{field.id}}
           @files={{@files}}
           @hasError={{this.hasError}}
-          @multiple={{this.multiple}}
+          @multiple={{@multiple}}
           @onChange={{@onChange}}
           @trigger={{@trigger}}
           @isDisabled={{@isDisabled}}

--- a/ember-toucan-core/src/components/form/file-input-field.ts
+++ b/ember-toucan-core/src/components/form/file-input-field.ts
@@ -50,10 +50,6 @@ export default class ToucanFormFileInputFieldComponent extends Component<ToucanF
     return this.args.accept ?? '*';
   }
 
-  get multiple() {
-    return this.args.multiple ?? true;
-  }
-
   get hasError() {
     return Boolean(this.args?.error);
   }

--- a/ember-toucan-core/src/components/form/file-input-field.ts
+++ b/ember-toucan-core/src/components/form/file-input-field.ts
@@ -46,10 +46,6 @@ export default class ToucanFormFileInputFieldComponent extends Component<ToucanF
     super(owner, args);
   }
 
-  get accept() {
-    return this.args.accept ?? '*';
-  }
-
   get hasError() {
     return Boolean(this.args?.error);
   }


### PR DESCRIPTION
The multiple helper in FileInputField already exists in controls/file-input.

Deleting this and passing along the @multiple arg works and is simpler.

Fixes: https://github.com/CrowdStrike/ember-toucan-core/issues/91

- [x] move `accept` over as well, see comment: https://github.com/CrowdStrike/ember-toucan-core/pull/64/files#r1144078795
- [x] add @multiple to the docs 