### PR TITLE
feat: Adjust checkbox styling based on designs

### DIFF
--- a/docs/components/checkbox-group-field/demo/base-demo.md
+++ b/docs/components/checkbox-group-field/demo/base-demo.md
@@ -28,7 +28,7 @@ import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 
 export default class extends Component {
-  @tracked groupValue = [];
+  @tracked groupValue = ['option-1'];
 
   @action
   updateValue(value) {

--- a/ember-toucan-core/src/components/form/controls/checkbox.hbs
+++ b/ember-toucan-core/src/components/form/controls/checkbox.hbs
@@ -1,6 +1,6 @@
 <div class="min-w-4 min-h-4 relative flex h-4 w-4 items-center justify-center">
   <input
-    class="border-body-and-labels focusable-outer focus:outline-none inline-block h-4 w-4 appearance-none rounded-sm border p-0 align-middle
+    class="border-body-and-labels focusable-outer focus:outline-none inline-block h-4 w-4 transform-gpu appearance-none rounded-sm border p-0 align-middle focus-visible:scale-75
       {{this.styles}}"
     type="checkbox"
     checked={{this.isChecked}}


### PR DESCRIPTION
## 💅  Description
This PR adjusts the checkbox focus-visible style to match the designs and what was discussed yesterday.  This matches what was done at https://github.com/CrowdStrike/ember-toucan-core/pull/93.

---

## 🔬 How to Test

This is a visual test and would benefit from something like Percy to see the difference between what is in `main` today versus this PR.  For now you can compare with `main` at https://ember-toucan-core.pages.dev/docs/components/checkbox-group-field.

- View https://d137f197.ember-toucan-core.pages.dev/docs/components/checkbox-group-field
- Click checkbox options and verify no focus state is applied
- Use the keyboard and TAB into the checkbox, verify the new focus-visible state is applied
- Use the TAB to toggle between checkbox options and verify the focus-visible state changes to the selected-option

---

## 📸 Images/Videos of Functionality

**No Error Outline**

https://user-images.githubusercontent.com/8069555/227292411-a259d690-6a59-4aa7-ad65-6866dd83effc.mov

--- 

**No Error Outline Image**

<img width="255" alt="Screenshot 2023-03-23 at 1 37 02 PM" src="https://user-images.githubusercontent.com/8069555/227291924-8469b7c4-ec4b-4adf-ab57-de74154eccfb.png">

---

**With Error Outline**

https://user-images.githubusercontent.com/8069555/227292901-384b571d-e643-4299-8a7c-37e883b19229.mov



---

**With Error Outline Image**

<img width="254" alt="Screenshot 2023-03-23 at 1 38 22 PM" src="https://user-images.githubusercontent.com/8069555/227292636-a668a871-3578-4fc3-bb0f-ae9543c35ead.png">

