### PR TITLE
Pin pnpm version to 7.30.0 for now

### DIFF
--- a/.github/actions/pnpm/action.yml
+++ b/.github/actions/pnpm/action.yml
@@ -5,10 +5,11 @@ runs:
   steps:
     - uses: pnpm/action-setup@v2.2.4
       with:
-        version: 7
+        # TODO: Pinning this for now due to https://github.com/CrowdStrike/ember-toucan-core/issues/99
+        version: 7.30.0
     - uses: actions/setup-node@v3
       with:
         cache: 'pnpm'
     - name: 'Install dependencies'
       shell: 'bash'
-      run: pnpm install --fix-lockfile
+      run: pnpm install

--- a/.github/actions/pnpm/action.yml
+++ b/.github/actions/pnpm/action.yml
@@ -11,4 +11,4 @@ runs:
         cache: 'pnpm'
     - name: 'Install dependencies'
       shell: 'bash'
-      run: pnpm install
+      run: pnpm install --fix-lockfile


### PR DESCRIPTION
## 🐛  Description
This PR pins the version of `pnpm` to 7.30.0.  With 7.30.1 we are getting test issues as mentioned over on https://github.com/embroider-build/embroider/issues/1378.  This is causing `main` to fail and all open PRs to also fail.


I filed https://github.com/CrowdStrike/ember-toucan-core/issues/99 so we don't forget.

---

## 🔬 How to Test

- Green build!

---

## 📸 Images/Videos of Functionality

N/A