### PR TITLE
style: FileInputField, list, add styles

### DIFF
--- a/docs/components/file-input-field/demo/base-demo.md
+++ b/docs/components/file-input-field/demo/base-demo.md
@@ -16,7 +16,7 @@ import { tracked } from '@glimmer/tracking';
 
 export default class extends Component {
   @tracked files = [
-    createFile(['Here is a file'], { name: 'sample-file.txt' }),
+    createFile(['Here is a file'], { name: 'SomeonesUploadedFile.csv' }),
   ];
 
   @action

--- a/ember-toucan-core/src/components/form/file-input-field.hbs
+++ b/ember-toucan-core/src/components/form/file-input-field.hbs
@@ -34,6 +34,7 @@
         @files={{@files}}
         @onDelete={{this.handleDelete}}
         @deleteLabel={{@deleteLabel}}
+        class="mt-1.5"
       />
     {{/if}}
   </Form::Field>

--- a/ember-toucan-core/src/components/form/file-input/delete-button.hbs
+++ b/ember-toucan-core/src/components/form/file-input/delete-button.hbs
@@ -3,7 +3,7 @@
   type="button"
   aria-label={{@deleteLabel}}
   {{! TODO: remove reset-styles https://github.com/CrowdStrike/ember-oss-docs/issues/17 }}
-  class="reset-styles flex-none bg-transparent"
+  class="reset-styles mr-2 flex-none bg-transparent"
   {{on "click" (fn @onDelete @file)}}
   ...attributes
 >

--- a/ember-toucan-core/src/components/form/file-input/delete-button.hbs
+++ b/ember-toucan-core/src/components/form/file-input/delete-button.hbs
@@ -3,7 +3,7 @@
   type="button"
   aria-label={{@deleteLabel}}
   {{! TODO: remove reset-styles https://github.com/CrowdStrike/ember-oss-docs/issues/17 }}
-  class="reset-styles mr-2 flex-none bg-transparent"
+  class="reset-styles flex-none bg-transparent"
   {{on "click" (fn @onDelete @file)}}
   ...attributes
 >

--- a/ember-toucan-core/src/components/form/file-input/list-item.hbs
+++ b/ember-toucan-core/src/components/form/file-input/list-item.hbs
@@ -1,5 +1,11 @@
 <li
-  class="border-lines-light bg-overlay-0.5 shadow-inner-lg m-0 flex items-center rounded-sm border-2 p-0 pr-2"
+  class="bg-overlay-1 focus:outline-none focus:shadow-focus-outline m-0 block flex rounded-sm p-1 transition-shadow
+    {{if @isDisabled 'text-disabled' 'text-titles-and-attributes'}}
+    {{if
+      @hasError
+      'shadow-error-outline focus:shadow-error-focus-outline'
+      'shadow-focusable-outline'
+    }}"
   ...attributes
 >
   <div class="flex-1 px-4 py-1">

--- a/ember-toucan-core/src/components/form/file-input/list-item.hbs
+++ b/ember-toucan-core/src/components/form/file-input/list-item.hbs
@@ -19,6 +19,7 @@
     >{{(this.formatSize @file.size)}}</span>
   </div>
   <Form::FileInput::DeleteButton
+    class="mr-2"
     @deleteLabel={{@deleteLabel}}
     @onDelete={{@onDelete}}
     @file={{@file}}

--- a/ember-toucan-core/src/components/form/file-input/list-item.hbs
+++ b/ember-toucan-core/src/components/form/file-input/list-item.hbs
@@ -1,12 +1,16 @@
-<li class="flex items-center p-0" ...attributes>
-  <div class="flex-1 px-4 py-2">
+<li
+  class="border-lines-light bg-overlay-0.5 shadow-inner-lg m-0 flex items-center rounded-sm border-2 p-0 pr-2"
+  ...attributes
+>
+  <div class="flex-1 px-4 py-1">
     <p
-      class="text-titles-and-attributes m-0 truncate p-0"
+      class="text-titles-and-attributes type-md-tight m-0 truncate p-0"
       data-file-name
     >{{@file.name}}</p>
-    <span class="text-body-and-labels block" data-file-size>{{(this.formatSize
-        @file.size
-      )}}</span>
+    <span
+      class="text-body-and-labels type-xs-tight mt-1 block"
+      data-file-size
+    >{{(this.formatSize @file.size)}}</span>
   </div>
   <Form::FileInput::DeleteButton
     @deleteLabel={{@deleteLabel}}

--- a/ember-toucan-core/src/components/form/file-input/list-item.ts
+++ b/ember-toucan-core/src/components/form/file-input/list-item.ts
@@ -9,6 +9,8 @@ interface ToucanFormFileInputListItemComponentSignature {
     file: File;
     onDelete: onDeleteFileHandler;
     deleteLabel: string;
+    hasError?: boolean;
+    isDisabled?: boolean;
   };
 }
 

--- a/ember-toucan-core/src/components/form/file-input/list.hbs
+++ b/ember-toucan-core/src/components/form/file-input/list.hbs
@@ -1,4 +1,4 @@
-<ul class="list-none" data-files ...attributes>
+<ul class="m-0 list-none space-y-1 p-0" data-files ...attributes>
   {{#each @files as |file|}}
     {{#if (has-block)}}
       {{yield

--- a/test-app/tests/integration/components/file-input-field-test.gts
+++ b/test-app/tests/integration/components/file-input-field-test.gts
@@ -308,19 +308,24 @@ module('Integration | Component | FileInputField', function (hooks) {
   test('it can handle the multiple attribute correctly when multiple=false', async function (assert) {
     class Context {
       @tracked currentFiles: File[] | [] = [];
+      @tracked triggerText = '';
     }
 
     let ctx = new Context();
+    ctx.triggerText = 'Browse Files';
 
-    const realOnChange = (files: File[], event: FileEvent) => {
+    const realOnChange = (files: File[]) => {
       ctx.currentFiles = files;
+      if (ctx.currentFiles.length > 0) {
+        ctx.triggerText = 'Replace files';
+      }
     };
 
     await render(<template>
       <FileInputField
         @deleteLabel="Delete File"
         @label="Label"
-        @trigger="Select Files"
+        @trigger={{ctx.triggerText}}
         @onChange={{realOnChange}}
         @files={{ctx.currentFiles}}
         @multiple={{false}}
@@ -345,6 +350,7 @@ module('Integration | Component | FileInputField', function (hooks) {
     assert
       .dom('li [data-file-name]')
       .hasText('banana.txt', 'Without multiple, files are replaced');
+    assert.dom('[data-trigger]').hasText('Replace files', 'For single file input field, trigger text indicates a replace')
   });
 
   test('it can handle the multiple attribute correctly when multiple=true', async function (assert) {


### PR DESCRIPTION
## Description 🚀 

- [x] style the list item more like the `input` in  the text input field
- [x] **test update**: for `input` without a `multiple attribute` (i.e. single file uploads) we want to be able to change the `triggerText` to indicate that this is a `replace` not just adding more files. I updated the test to reflect this.

Note: this does not change the existing markup of the file input field, that will be done in followup work.

## Before
<img width="809" alt="Screenshot 2023-03-23 at 4 19 23 PM" src="https://user-images.githubusercontent.com/771170/227343051-559b695d-e304-4394-b25b-f03738405aa1.png">


## After
<img width="1036" alt="Screenshot 2023-03-27 at 1 06 22 PM" src="https://user-images.githubusercontent.com/771170/228014677-6a3e016f-0df5-4e4d-883c-4265f5ec932e.png">

