### PR TITLE
#99: Revert pnpm version pinning to use latest again after 7.30.3 fixes our issue

### DIFF
--- a/.github/actions/pnpm/action.yml
+++ b/.github/actions/pnpm/action.yml
@@ -5,8 +5,7 @@ runs:
   steps:
     - uses: pnpm/action-setup@v2.2.4
       with:
-        # TODO: Pinning this for now due to https://github.com/CrowdStrike/ember-toucan-core/issues/99
-        version: 7.30.0
+        version: 7
     - uses: actions/setup-node@v3
       with:
         cache: 'pnpm'


### PR DESCRIPTION
## 🚀 Description
pnpm v7.30.3 has been merged and our issue is closed! https://github.com/pnpm/pnpm/releases/tag/v7.30.3 (https://github.com/pnpm/pnpm/issues/6271)

Confirmed the action is now using 7.30.3! https://github.com/CrowdStrike/ember-toucan-core/actions/runs/4516067783/jobs/7954046644?pr=101#step:3:28

Closes #99 

---

## 🔬 How to Test

- Green build

---

## 📸 Images/Videos of Functionality

N/A