### PR TITLE
feat: Remove padding when in a checkbox group

### DIFF
--- a/ember-toucan-core/src/components/form/checkbox-field.hbs
+++ b/ember-toucan-core/src/components/form/checkbox-field.hbs
@@ -4,7 +4,9 @@
 >
   <Form::Field as |field|>
     <field.Control
-      class="rounded-sm p-1 {{if @error 'shadow-error-outline'}}"
+      class="rounded-sm
+        {{if @error 'shadow-error-outline'}}
+        {{if @option 'p-0' 'p-1'}}"
       data-control
     >
 

--- a/test-app/tests/integration/components/checkbox-field-test.gts
+++ b/test-app/tests/integration/components/checkbox-field-test.gts
@@ -192,6 +192,28 @@ module('Integration | Component | CheckboxField', function (hooks) {
     assert.dom('[data-root-field="selector"]').exists();
   });
 
+  test('it sets default padding when not provided with "@option"', async function (assert) {
+    // When a checkbox-field is used by itself, we want default padding to account
+    // for the potential error shadow.
+    await render(<template><CheckboxField @label="Label" /></template>);
+
+    assert.dom('[data-control]').doesNotHaveClass('p-0');
+    assert.dom('[data-control]').hasClass('p-1');
+  });
+
+  test('it sets no padding when provided with "@option"', async function (assert) {
+    // When inside of a checkbox-group-field, we do not want the built-in
+    // padding to account for the error shadow as the error shadow is handled
+    // by the Fieldset instead. We can tell if we are in a checkbox-group-field
+    // if an "@option" argument is provided.
+    await render(<template>
+      <CheckboxField @label="Label" @option="option-1" />
+    </template>);
+
+    assert.dom('[data-control]').doesNotHaveClass('p-1');
+    assert.dom('[data-control]').hasClass('p-0');
+  });
+
   test('it throws an assertion error if no `@label` is provided', async function (assert) {
     assert.expect(1);
 


### PR DESCRIPTION
## 🚀 Description
This applies some design feedback from yesterday.

>  in ember toucan core docs is different spacing between the input group:checkboxes and input group: radio buttons. Checkboxes feel more aired out and radio buttons feel more condensed.


The reason this was happening is because we have built-in padding to the checkbox-field component.  This is to account for the error shadow outline.  We can remove that when in a checkbox-group-field by checking if we are rendered in one via the `@option` argument.

---

## 🔬 How to Test

- Visit https://fd9c9fbe.ember-toucan-core.pages.dev/docs/components/checkbox-group-field and verify the spacing is now flush-left
- Compare to https://fd9c9fbe.ember-toucan-core.pages.dev/docs/components/radio-group-field and you should not see any shifting in layout between the two (see below video for an example)
- Comparing `main` to this branch should match with checkbox-field
  - https://fd9c9fbe.ember-toucan-core.pages.dev/docs/components/checkbox-field#all-ui-states
  - https://ember-toucan-core.pages.dev/docs/components/checkbox-field#all-ui-states

---

## 📸 Images/Videos of Functionality

| Before  | After |
| ------------- | ------------- |
| <img width="241" alt="Screenshot 2023-03-24 at 11 16 52 AM" src="https://user-images.githubusercontent.com/8069555/227566691-945babbf-791c-481a-9e6d-2e8aeb289e59.png">  | <img width="228" alt="Screenshot 2023-03-24 at 11 16 56 AM" src="https://user-images.githubusercontent.com/8069555/227566743-a3bed7e2-7211-4a1e-a9ec-644f37f1b6f2.png"> |





Here is comparing the radios to the checkboxes

https://user-images.githubusercontent.com/8069555/227566091-e3b70f4a-ea26-4ed9-99dd-2976b59ee30a.mov

