### PR TITLE
fix: Update error icon to triangle over circle

### DIFF
--- a/ember-toucan-core/src/-private/components/error.hbs
+++ b/ember-toucan-core/src/-private/components/error.hbs
@@ -3,18 +3,17 @@
     {{if this.hasMoreThanOneError 'items-start' 'items-center'}}"
   ...attributes
 >
-  {{! Icon taken from Tony's open source icon set, this is temporary! }}
+  {{! TODO: https://github.com/CrowdStrike/ember-toucan-core/issues/49 - Placeholder icon }}
   <svg
+    class="mr-1 h-3 w-3"
     xmlns="http://www.w3.org/2000/svg"
     width="24"
     height="24"
     stroke="currentColor"
     viewBox="0 0 24 24"
-    aria-hidden="true"
-    class="mr-1 h-3 w-3"
   >
     <path
-      d="M12 3a9 9 0 11-6.364 2.636A8.972 8.972 0 0112 3zm0 4.7v5.2m0 3.39v.01"
+      d="M10.206 4.625l-3.5 6.4-3.5 6.4a2.04 2.04 0 00.038 1.987 2 2 0 001.762 1.013h14a2.007 2.007 0 001.725-.975 2.075 2.075 0 00.075-2.025l-3.5-6.4-3.5-6.4a2.068 2.068 0 00-3.6 0zM12.006 8.825v5.2M12.006 16.99v-.065h0"
       fill="none"
       stroke-linecap="round"
       stroke-linejoin="round"


### PR DESCRIPTION
<!-- Hello! This template is automatically added to help write up your pull request. Feel free to delete these comments, although they won't show up in the rendered markdown! This is only a template, feel free to adjust as you please! -->

## 🚀 Description

This PR updates the existing error icon to match the designs.

<!-- Please write a thoughtful description of what this PR is accomplishing. Are you adding a new feature? Fixing a bug? Writing documentation? Is there a GitHub issue that can be closed if this merges?

Another acceptable option is to put the summary of the changes in list form:

- [x] added: new styles in {filename}
- [x] fixed: addressed flicker in {filename}

-->

---

## 🔬 How to Test

<!-- Please provide steps to test the functionality added/removed. Preview URLs are generated with each build.  We normally use the preview URLs and ask folks to review specific functionality based on them (e.g., "go to this page, view the new CSS changes"). -->

- Visit https://633cb774.ember-toucan-core.pages.dev/docs/components/textarea-field#all-ui-states
- Verify the alert triangle is used over the alert circle

---

## 📸 Images/Videos of Functionality

<!-- For visual changes, it's extremely helpful to include screenshots, gifs, or videos of what has changed.  Before and After images are also super helpful! -->


| BEFORE  | AFTER |
| ------------- | ------------- |
| <img width="201" alt="Screenshot 2023-03-27 at 10 36 26 AM" src="https://user-images.githubusercontent.com/8069555/227972817-d758a87c-7c8d-440e-bed4-a0bf324b092f.png">  | <img width="208" alt="Screenshot 2023-03-27 at 9 30 54 AM" src="https://user-images.githubusercontent.com/8069555/227952538-be32f26d-7829-4c64-8b7b-d83db36f5f16.png"> |
| Circle  | Triangle  |




