### PR TITLE
(LEGAL): Update package.json license fields

### DIFF
--- a/docs-app/package.json
+++ b/docs-app/package.json
@@ -2,9 +2,9 @@
   "name": "docs-app",
   "version": "0.0.0",
   "private": true,
-  "description": "Small description for docs-app goes here",
+  "description": "docs-app for the ember-toucan-core repo",
   "repository": "",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "author": "",
   "directories": {
     "doc": "doc",

--- a/packages/ember-toucan-core/package.json
+++ b/packages/ember-toucan-core/package.json
@@ -10,7 +10,7 @@
     "url": "git@github.com:CrowdStrike/ember-toucan-core.git",
     "directory": "ember-toucan-core"
   },
-  "license": "MIT",
+  "license": "Apache-2.0",
   "author": "CrowdStrike UX Team",
   "files": [
     "addon-main.cjs",

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -2,9 +2,9 @@
   "name": "test-app",
   "version": "0.0.0",
   "private": true,
-  "description": "Small description for test-app goes here",
+  "description": "test-app for the ember-toucan-core repo",
   "repository": "",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "author": "",
   "directories": {
     "doc": "doc",


### PR DESCRIPTION
## 🚀 Description

- Adds Apache 2.0 to each `package.json` to match our [actual LICENSE](https://github.com/CrowdStrike/ember-toucan-core/blob/main/LICENSE.md) per legal

---

## 🔬 How to Test

N/A

---

## 📸 Images/Videos of Functionality

N/A
