### PR TITLE
Support `@isButtonGroup` mode for `<Button>`

### DIFF
--- a/.changeset/gold-steaks-try.md
+++ b/.changeset/gold-steaks-try.md
@@ -1,0 +1,7 @@
+---
+'@crowdstrike/ember-toucan-core': patch
+---
+
+Support `@isButtonGroup` mode for `<Button>`
+
+This is only to be used _internally_ to support buttons being used inside a `<ButtonGroup>`.

--- a/packages/ember-toucan-core/src/components/button.ts
+++ b/packages/ember-toucan-core/src/components/button.ts
@@ -19,7 +19,6 @@ const STYLES = {
     'inline-flex',
     'items-center',
     'justify-center',
-    'rounded-sm',
     'transition',
     'truncate',
     'type-md-medium',
@@ -31,6 +30,10 @@ const STYLES = {
     primary: ['interactive-primary'],
     quiet: ['font-normal', 'interactive-quiet'],
     secondary: ['interactive-normal'],
+  },
+  buttonGroup: {
+    true: ['rounded-none', 'flex-1', 'first:rounded-l-sm', 'last:rounded-r-sm'],
+    false: ['rounded-sm'],
   },
 };
 
@@ -55,6 +58,13 @@ export interface ButtonSignature {
      * Setting the variant of the button changes the styling.
      */
     variant?: ButtonVariant;
+
+    /**
+     * Special styling is applied if a button is inside a button group.
+     *
+     * @internal This is meant to only be used by `<ButtonGroup>`
+     */
+    isButtonGroup?: boolean;
   };
   Blocks: { default: []; disabled: []; loading: [] };
   Element: HTMLButtonElement;
@@ -79,7 +89,11 @@ export default class Button extends Component<ButtonSignature> {
       return STYLES.variants.bare.join(' ');
     }
 
-    const buttonStyles = [...STYLES.base, ...STYLES.variants[this.variant]];
+    const buttonStyles = [
+      ...STYLES.base,
+      ...STYLES.buttonGroup[this.args.isButtonGroup ? 'true' : 'false'],
+      ...STYLES.variants[this.variant],
+    ];
     const disabledStyles = ['interactive-disabled', 'focus:outline-none'];
 
     if (this.variant !== 'link') {

--- a/test-app/tests/integration/components/button-test.gts
+++ b/test-app/tests/integration/components/button-test.gts
@@ -160,4 +160,23 @@ module('Integration | Component | button', function (hooks) {
       </Button>
     </template>);
   });
+
+  test('regular button is rounded', async function (assert) {
+    await render(<template><Button data-button>1</Button></template>);
+
+    assert.dom('[data-button]').hasClass('rounded-sm');
+  });
+
+  test('@isButtonGroup applies proper styles when used inside a button group', async function (assert) {
+    await render(<template>
+      <Button @isButtonGroup={{true}} data-button>1</Button>
+    </template>);
+
+    assert
+      .dom('[data-button]')
+      .hasClass('rounded-none')
+      .hasClass('flex-1')
+      .hasClass('first:rounded-l-sm')
+      .hasClass('last:rounded-r-sm');
+  });
 });


### PR DESCRIPTION
<!-- Hello! This template is automatically added to help write up your pull request. Feel free to delete these comments, although they won't show up in the rendered markdown! This is only a template, feel free to adjust as you please! -->

## 🚀 Description

This is adding an internal/private only(!) argument `@isButtonGroup` to `<Button>` to allow them being rendered as part of a `<ButtonGroup>` with the proper styling (rounded borders only on the outside parts). This is basically replacing some custom CSS we had previously in place to override the Tailwind-based default styling. Now the `<Button>` component "owns" all of its styling concerns, without other parts poking into its styling implementation from the outside. 

This does not feature any documentation updates, as it is _not_ supposed to be used by anything but `<ButtonGroup>` internally.

---

## 🔬 How to Test

<!-- Please provide steps to test the functionality added/removed. Preview URLs are generated with each build.  We normally use the preview URLs and ask folks to review specific functionality based on them (e.g., "go to this page, view the new CSS changes"). -->

We cannot really show the changes live, as the other part of the changes is in `@crowdstrike/ui` as part of another PR. The change here would be more obvious had we `<ButtonGroup>` already extracted into this repo.

---

## 📸 Images/Videos of Functionality

<img width="795" alt="image" src="https://user-images.githubusercontent.com/1325249/231239253-1ea9f771-13bb-470f-85c9-c31a361e2f9b.png">

This is a screenshot of the Toucan Guide's `ButtonGroup`, when using the other PR with these changes (using `yarn link`). See the outer sides of the buttons have rounded borders, while the inner adjacent sides don't.