### PR TITLE
changeset: exit prerelease mode

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,5 +1,5 @@
 {
-  "mode": "pre",
+  "mode": "exit",
   "tag": "beta",
   "initialVersions": {
     "docs-app": "0.0.0",
@@ -7,5 +7,7 @@
     "@crowdstrike/ember-toucan-form": "0.0.0",
     "test-app": "0.0.0"
   },
-  "changesets": ["rude-taxis-eat"]
+  "changesets": [
+    "rude-taxis-eat"
+  ]
 }


### PR DESCRIPTION
<!-- Hello! This template is automatically added to help write up your pull request. Feel free to delete these comments, although they won't show up in the rendered markdown! This is only a template, feel free to adjust as you please! -->

## 🚀 Description

<!-- Please write a thoughtful description of what this PR is accomplishing. Are you adding a new feature? Fixing a bug? Writing documentation? Is there a GitHub issue that can be closed if this merges?

Another acceptable option is to put the summary of the changes in list form:

- [x] added: new styles in {filename}
- [x] fixed: addressed flicker in {filename}

-->

This is the result of running `changeset pre exit`, to switch to doing regular `latest` 0.1.x releases instead of `0.1.0-beta.x` releases, see https://github.com/CrowdStrike/ember-toucan-core/pull/127#discussion_r1163227412