### PR TITLE
Add readonly states to all form elements

### DIFF
--- a/.changeset/hot-lions-tie.md
+++ b/.changeset/hot-lions-tie.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/ember-toucan-core': patch
+---
+
+Added the `@isReadOnly` component argument to all form components. It will apply read only styling and the `readonly` attribute. This requires the latest release of [@crowdstrike/tailwind-toucan-base](https://github.com/CrowdStrike/tailwind-toucan-base/releases/tag/%40crowdstrike%2Ftailwind-toucan-base%403.5.0).

--- a/docs-app/package.json
+++ b/docs-app/package.json
@@ -29,7 +29,7 @@
     "@babel/core": "^7.19.6",
     "@babel/eslint-parser": "^7.19.1",
     "@crowdstrike/ember-toucan-styles": "^2.0.1",
-    "@crowdstrike/tailwind-toucan-base": "^3.4.0",
+    "@crowdstrike/tailwind-toucan-base": "^3.5.0",
     "@docfy/core": "^0.6.0",
     "@docfy/ember": "^0.6.0",
     "@ember/optional-features": "^2.0.0",

--- a/docs-app/tailwind.config.js
+++ b/docs-app/tailwind.config.js
@@ -5,6 +5,16 @@ const { tailwindConfig } = require('@crowdstrike/ember-oss-docs/tailwind');
 
 const config = tailwindConfig(__dirname, {
   content: [path.join(__dirname, '../docs/**/*.md')],
+
+  // Temporary for testing for a preview URL.
+  // DO NOT MERGE!
+  theme: {
+    extend: {
+      boxShadow: {
+        'form-read-only': 'inset 0 0 0 1px var(--disabled)',
+      },
+    },
+  },
 });
 
 module.exports = config;

--- a/docs-app/tailwind.config.js
+++ b/docs-app/tailwind.config.js
@@ -5,16 +5,6 @@ const { tailwindConfig } = require('@crowdstrike/ember-oss-docs/tailwind');
 
 const config = tailwindConfig(__dirname, {
   content: [path.join(__dirname, '../docs/**/*.md')],
-
-  // Temporary for testing for a preview URL.
-  // DO NOT MERGE!
-  theme: {
-    extend: {
-      boxShadow: {
-        'form-read-only': 'inset 0 0 0 1px var(--disabled)',
-      },
-    },
-  },
 });
 
 module.exports = config;

--- a/docs/components/checkbox-field/index.md
+++ b/docs/components/checkbox-field/index.md
@@ -120,6 +120,10 @@ export default class extends Component {
 
 Set the `@isDisabled` argument to disable the checkbox.
 
+## Read Only State
+
+Set the `@isReadOnly` argument to put the checkbox in the read only state.
+
 ## Indeterminate State
 
 Set the `@isIndeterminate` argument. To learn more, view the [Checkbox documentation](./checkbox).

--- a/docs/components/checkbox-field/index.md
+++ b/docs/components/checkbox-field/index.md
@@ -308,3 +308,22 @@ Target the error block via `data-error`.
     @isDisabled={{true}}
   />
 </div>
+
+### CheckboxField with isReadOnly
+
+<div class='mb-4 w-64'>
+  <Form::Fields::Checkbox
+    @label='Label'
+    @isReadOnly={{true}}
+  />
+</div>
+
+### CheckboxField with isChecked and isReadOnly
+
+<div class='mb-4 w-64'>
+  <Form::Fields::Checkbox
+    @label='Label'
+    @isChecked={{true}}
+    @isReadOnly={{true}}
+  />
+</div>

--- a/docs/components/checkbox-group-field/index.md
+++ b/docs/components/checkbox-group-field/index.md
@@ -161,7 +161,7 @@ To disable individual checkbox fields, set the `@isDisabled` argument directly o
 
 ### Fieldset
 
-To set the entire checkbox group to readonly, use the `@isReadOnly` argument directly on the Checkbox Group.
+To set all checkbox group options to readonly, use the `@isReadOnly` argument directly on the Checkbox Group.
 
 ```hbs
 <Form::Fields::CheckboxGroup

--- a/docs/components/checkbox-group-field/index.md
+++ b/docs/components/checkbox-group-field/index.md
@@ -157,6 +157,46 @@ To disable individual checkbox fields, set the `@isDisabled` argument directly o
 </Form::Fields::CheckboxGroup>
 ```
 
+## Read Only State
+
+### Fieldset
+
+To set the entire checkbox group to readonly, use the `@isReadOnly` argument directly on the Checkbox Group.
+
+```hbs
+<Form::Fields::CheckboxGroup
+  @label='Label'
+  @name='options'
+  @value={{this.groupValue}}
+  @onChange={{this.updateValue}}
+  @isReadOnly={{true}}
+  as |group|
+>
+  <!-- This will now be readonly as well! -->
+  <group.CheckboxField @label='Option 1' @value='option-1' />
+</Form::Fields::CheckboxGroup>
+```
+
+### Individual Checkboxes
+
+Individual checkboxes can be set to read only by setting the `@isReadOnly` argument directly on the checkbox field.
+
+```hbs
+<Form::Fields::CheckboxGroup
+  @label='Label'
+  @name='options'
+  @value={{this.groupValue}}
+  @onChange={{this.updateValue}}
+  as |group|
+>
+  <group.CheckboxField
+    @label='Option 1'
+    @value='option-1'
+    @isReadOnly={{true}}
+  />
+</Form::Fields::CheckboxGroup>
+```
+
 ## Attributes and Modifiers
 
 Consumers have direct access to the underlying [checkbox element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox), so all attributes are supported. Modifiers can also be added directly to individual radio fields.

--- a/docs/components/checkbox/index.md
+++ b/docs/components/checkbox/index.md
@@ -32,6 +32,22 @@ To check the indeterminate property in tests, use:
 assert.dom('[data-checkbox]').hasProperty('indeterminate', true);
 ```
 
+## Disabled State
+
+Set the `@isDisabled` argument to disable the checkbox.
+
+```hbs
+<Form::Controls::Checkbox @isDisabled={{true}} />
+```
+
+## Read Only State
+
+Set the `@isReadOnly` argument to put the checkbox in the read only state.
+
+```hbs
+<Form::Controls::Checkbox @isReadOnly={{true}} />
+```
+
 ## onChange
 
 To tie into the input event, provide `@onChange`. `@onChange` will return two arguments:
@@ -63,7 +79,3 @@ export default class extends Component {
   }
 }
 ```
-
-## Disabled State
-
-Set the `@isDisabled` argument to disable the checkbox.

--- a/docs/components/file-input-field/index.md
+++ b/docs/components/file-input-field/index.md
@@ -149,6 +149,10 @@ export default class extends Component {
 
 Set the `@isDisabled` argument to disable the `<input type="file">`.
 
+## Read Only State
+
+Set the `@isReadOnly` argument to put the input in the read only state.
+
 ## Attributes and Modifiers
 
 Consumers have direct access to the underlying [input element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input), so all attributes are supported. Modifiers can also be added directly to the input as shown in the demo.

--- a/docs/components/file-input-field/index.md
+++ b/docs/components/file-input-field/index.md
@@ -262,7 +262,7 @@ Target the trash icon button via `data-delete-file`.
     @trigger='Select Files'
   />
 </div>
-  
+
 ## FileInputField with label and isDisabled
 
 <div class='mb-4 w-64'>
@@ -272,4 +272,15 @@ Target the trash icon button via `data-delete-file`.
     @isDisabled={{true}}
     @trigger='Browse Files'
     />
+</div>
+
+### FileInputField with isReadOnly
+
+<div class='mb-4 w-64'>
+  <Form::Fields::FileInput
+    @deleteLabel='Delete file'
+    @label='Label'
+    @isReadOnly={{true}}
+    @trigger='Browse Files'
+  />
 </div>

--- a/docs/components/input-field/index.md
+++ b/docs/components/input-field/index.md
@@ -285,7 +285,7 @@ Target the error block via `data-error`.
 
 </div>
 
-### InputField with read only
+### InputField with isReadOnly
 
 <div class='mb-4 w-64'>
   <Form::Fields::Input
@@ -294,7 +294,7 @@ Target the error block via `data-error`.
   />
 </div>
 
-### InputField with read only and a value
+### InputField with isReadOnly and a value
 
 <div class='mb-4 w-64'>
   <Form::Fields::Input

--- a/docs/components/input-field/index.md
+++ b/docs/components/input-field/index.md
@@ -284,3 +284,22 @@ Target the error block via `data-error`.
 </Form::Fields::Input>
 
 </div>
+
+### InputField with read only
+
+<div class='mb-4 w-64'>
+  <Form::Fields::Input
+    @label='Label'
+    @isReadOnly={{true}}
+  />
+</div>
+
+### InputField with read only and a value
+
+<div class='mb-4 w-64'>
+  <Form::Fields::Input
+    @label='Label'
+    @isReadOnly={{true}}
+    @value="Input value"
+  />
+</div>

--- a/docs/components/input-field/index.md
+++ b/docs/components/input-field/index.md
@@ -115,7 +115,11 @@ export default class extends Component {
 
 ## Disabled State
 
-Set the `@isDisabled` argument to disable the `<input>`.
+Set the `@isDisabled` argument to disable the input.
+
+## Read Only State
+
+Set the `@isReadOnly` argument to put the input in the read only state.
 
 ## Attributes and Modifiers
 

--- a/docs/components/input/index.md
+++ b/docs/components/input/index.md
@@ -34,7 +34,19 @@ export default class extends Component {
 
 ## Disabled State
 
-Set the `@isDisabled` argument to disable the `<input>`.
+Set the `@isDisabled` argument to disable the input.
+
+```hbs
+<Form::Controls::Input @isDisabled={{true}} />
+```
+
+## Read Only State
+
+Set the `@isReadOnly` argument to put the input in the read only state.
+
+```hbs
+<Form::Controls::Input @isReadOnly={{true}} />
+```
 
 ## Error State
 

--- a/docs/components/radio-field/index.md
+++ b/docs/components/radio-field/index.md
@@ -123,6 +123,10 @@ export default class extends Component {
 
 Set the `@isDisabled` argument to disable the radio.
 
+## Read Only State
+
+Set the `@isReadOnly` argument to put the radio in the read only state.
+
 ## Attributes and Modifiers
 
 Consumers have direct access to the underlying [radio element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/radio), so all attributes are supported. Modifiers can also be added directly to the Radio as shown in the demo.

--- a/docs/components/radio-group-field/index.md
+++ b/docs/components/radio-group-field/index.md
@@ -171,6 +171,26 @@ To disable individual radio fields, set the `@isDisabled` argument directly on t
 
 ## Read Only State
 
+### Fieldset
+
+To set the entire radio group to readonly, use the `@isReadOnly` argument directly on the Radio Group.
+
+```hbs
+<Form::Fields::RadioGroup
+  @label='Label'
+  @name='options'
+  @value={{this.groupValue}}
+  @onChange={{this.updateValue}}
+  @isReadOnly={{true}}
+  as |group|
+>
+  <!-- This will now be readonly as well! -->
+  <group.RadioField @label='Option 1' @value='option-1' />
+</Form::Fields::RadioGroup>
+```
+
+### Individual Radios
+
 Individual radio fields can be set to read only by setting the `@isReadOnly` argument directly on the radio field.
 
 ```hbs

--- a/docs/components/radio-group-field/index.md
+++ b/docs/components/radio-group-field/index.md
@@ -169,6 +169,22 @@ To disable individual radio fields, set the `@isDisabled` argument directly on t
 </Form::Fields::RadioGroup>
 ```
 
+## Read Only State
+
+Individual radio fields can be set to read only by setting the `@isReadOnly` argument directly on the radio field.
+
+```hbs
+<Form::Fields::RadioGroup
+  @label='Label'
+  @name='options'
+  @value={{this.groupValue}}
+  @onChange={{this.updateValue}}
+  as |group|
+>
+  <group.RadioField @label='Option 1' @value='option-1' @isReadOnly={{true}} />
+</Form::Fields::RadioGroup>
+```
+
 ## Attributes and Modifiers
 
 Consumers have direct access to the underlying [radio element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/radio), so all attributes are supported. Modifiers can also be added directly to individual radio fields.

--- a/docs/components/radio-group-field/index.md
+++ b/docs/components/radio-group-field/index.md
@@ -263,3 +263,23 @@ Consumers have direct access to the underlying [radio element](https://developer
     <group.RadioField @label='Option 3' @value='option-3' />
   </Form::Fields::RadioGroup>
 </div>
+
+### RadioGroupField with label and all read only
+
+<div class='mb-4 w-64'>
+  <Form::Fields::RadioGroup @label='Label' @name='read-only' as |group|>
+    <group.RadioField @label='Option 1' @value='option-1' @isReadOnly={{true}} />
+    <group.RadioField @label='Option 2' @value='option-2' @isReadOnly={{true}} />
+    <group.RadioField @label='Option 3' @value='option-3' @isReadOnly={{true}} />
+  </Form::Fields::RadioGroup>
+</div>
+
+### RadioGroupField with label and all read only with one checked
+
+<div class='mb-4 w-64'>
+  <Form::Fields::RadioGroup @label='Label' @name='read-only-checked' @value="option-2" as |group|>
+    <group.RadioField @label='Option 1' @value='option-1' @isReadOnly={{true}} />
+    <group.RadioField @label='Option 2' @value='option-2' @isReadOnly={{true}} />
+    <group.RadioField @label='Option 3' @value='option-3' @isReadOnly={{true}} />
+  </Form::Fields::RadioGroup>
+</div>

--- a/docs/components/radio-group-field/index.md
+++ b/docs/components/radio-group-field/index.md
@@ -173,7 +173,7 @@ To disable individual radio fields, set the `@isDisabled` argument directly on t
 
 ### Fieldset
 
-To set the entire radio group to readonly, use the `@isReadOnly` argument directly on the Radio Group.
+To set all radio group options to readonly, use the `@isReadOnly` argument directly on the Radio Group.
 
 ```hbs
 <Form::Fields::RadioGroup

--- a/docs/components/radio/demo/base-demo.md
+++ b/docs/components/radio/demo/base-demo.md
@@ -4,6 +4,8 @@
   <Form::Controls::Radio @value='2' @isChecked={{true}} />
   <Form::Controls::Radio @value='3' @isDisabled={{true}} />
   <Form::Controls::Radio @value='4' @isChecked={{true}} @isDisabled={{true}} />
+  <Form::Controls::Radio @value='5' @isChecked={{false}} @isReadOnly={{true}} />
+  <Form::Controls::Radio @value='6' @isChecked={{true}} @isReadOnly={{true}} />
 </div>
 ```
 

--- a/docs/components/radio/index.md
+++ b/docs/components/radio/index.md
@@ -52,3 +52,15 @@ export default class extends Component {
 ## Disabled State
 
 Set the `@isDisabled` argument to disable the radio.
+
+```hbs
+<Form::Controls::Radio @isDisabled={{true}} />
+```
+
+## Read Only State
+
+Set the `@isReadOnly` argument to put the radio in the read only state.
+
+```hbs
+<Form::Controls::Radio @isReadOnly={{true}} />
+```

--- a/docs/components/textarea-field/index.md
+++ b/docs/components/textarea-field/index.md
@@ -237,3 +237,22 @@ Target the error block via `data-error`.
     @error={{(array 'With error 1' 'With error 2' 'With error 3')}}
   />
 </div>
+
+### TextareaField with isReadOnly
+
+<div class='mb-4 w-64'>
+  <Form::Fields::Textarea
+    @label='Label'
+    @isReadOnly={{true}}
+  />
+</div>
+
+### TextareaField with isReadOnly and a value
+
+<div class='mb-4 w-64'>
+  <Form::Fields::Textarea
+    @label='Label'
+    @isReadOnly={{true}}
+    @value="Input value"
+  />
+</div>

--- a/docs/components/textarea-field/index.md
+++ b/docs/components/textarea-field/index.md
@@ -118,7 +118,11 @@ export default class extends Component {
 
 ## Disabled State
 
-Set the `@isDisabled` argument to disable the `<textarea>`.
+Set the `@isDisabled` argument to disable the textarea.
+
+## Read Only State
+
+Set the `@isReadOnly` argument to put the textarea in the read only state.
 
 ## Attributes and Modifiers
 

--- a/docs/components/textarea/index.md
+++ b/docs/components/textarea/index.md
@@ -42,8 +42,24 @@ export default class extends Component {
 
 ## Disabled State
 
-Set the `@isDisabled` argument to disable the `<textarea>`.
+Set the `@isDisabled` argument to disable the textarea.
+
+```hbs
+<Form::Controls::Textarea @isDisabled={{true}} />
+```
+
+## Read Only State
+
+Set the `@isReadOnly` argument to put the textarea in the read only state.
+
+```hbs
+<Form::Controls::Textarea @isReadOnly={{true}} />
+```
 
 ## Error State
 
-Set the `@hasError` argument to apply an error box shadow to the `<textarea>`.
+Set the `@hasError` argument to apply an error box shadow to the textarea.
+
+```hbs
+<Form::Controls::Textarea @hasError={{true}} />
+```

--- a/packages/ember-toucan-core/src/components/form/controls/checkbox.hbs
+++ b/packages/ember-toucan-core/src/components/form/controls/checkbox.hbs
@@ -6,6 +6,7 @@
     checked={{this.isChecked}}
     indeterminate={{this.isIndeterminate}}
     disabled={{@isDisabled}}
+    readonly={{@isReadOnly}}
     ...attributes
     {{on "click" this.handleInput}}
   />

--- a/packages/ember-toucan-core/src/components/form/controls/checkbox.ts
+++ b/packages/ember-toucan-core/src/components/form/controls/checkbox.ts
@@ -56,19 +56,27 @@ export default class ToucanFormCheckboxControlComponent extends Component<Toucan
     let { isDisabled, isReadOnly } = this.args;
     let isCheckedOrIndeterminate = this.isCheckedOrIndeterminate;
 
-    // TODO: Make this logic better (this is only for testing purposes atm!)
-    // Don't ship it like this 😂
-    return isCheckedOrIndeterminate && !isDisabled && !isReadOnly
-      ? ['bg-primary-idle border-none']
-      : isCheckedOrIndeterminate && isDisabled && !isReadOnly
-      ? ['bg-disabled border-none']
-      : !isCheckedOrIndeterminate && isDisabled && !isReadOnly
-      ? ['bg-transparent border-disabled']
-      : isReadOnly && !isCheckedOrIndeterminate
-      ? ['bg-surface-xl']
-      : isReadOnly && isCheckedOrIndeterminate
-      ? ['bg-titles-and-attributes border-none']
-      : ['bg-normal-idle'];
+    if (isCheckedOrIndeterminate && !isDisabled && !isReadOnly) {
+      return ['bg-primary-idle border-none'];
+    }
+
+    if (isCheckedOrIndeterminate && isDisabled && !isReadOnly) {
+      return ['bg-disabled border-none'];
+    }
+
+    if (isCheckedOrIndeterminate && isReadOnly) {
+      return ['bg-titles-and-attributes border-none'];
+    }
+
+    if (!isCheckedOrIndeterminate && isDisabled && !isReadOnly) {
+      return ['bg-transparent border-disabled'];
+    }
+
+    if (!isCheckedOrIndeterminate && isReadOnly) {
+      return ['bg-surface-xl'];
+    }
+
+    return ['bg-normal-idle'];
   }
 
   @action

--- a/packages/ember-toucan-core/src/components/form/controls/checkbox.ts
+++ b/packages/ember-toucan-core/src/components/form/controls/checkbox.ts
@@ -56,14 +56,18 @@ export default class ToucanFormCheckboxControlComponent extends Component<Toucan
     let { isDisabled, isReadOnly } = this.args;
     let isCheckedOrIndeterminate = this.isCheckedOrIndeterminate;
 
-    return isCheckedOrIndeterminate && !isDisabled
+    // TODO: Make this logic better (this is only for testing purposes atm!)
+    // Don't ship it like this 😂
+    return isCheckedOrIndeterminate && !isDisabled && !isReadOnly
       ? ['bg-primary-idle border-none']
-      : isCheckedOrIndeterminate && isDisabled
+      : isCheckedOrIndeterminate && isDisabled && !isReadOnly
       ? ['bg-disabled border-none']
-      : !isCheckedOrIndeterminate && isDisabled
+      : !isCheckedOrIndeterminate && isDisabled && !isReadOnly
       ? ['bg-transparent border-disabled']
-      : isReadOnly
-      ? null
+      : isReadOnly && !isCheckedOrIndeterminate
+      ? ['bg-surface-xl']
+      : isReadOnly && isCheckedOrIndeterminate
+      ? ['bg-titles-and-attributes border-none']
       : ['bg-normal-idle'];
   }
 

--- a/packages/ember-toucan-core/src/components/form/controls/checkbox.ts
+++ b/packages/ember-toucan-core/src/components/form/controls/checkbox.ts
@@ -13,6 +13,11 @@ export interface ToucanFormCheckboxControlComponentSignature {
     isDisabled?: boolean;
 
     /**
+     * Sets the readonly attribute of the checkbox.
+     */
+    isReadOnly?: boolean;
+
+    /**
      * The function called when the element is clicked.
      */
     onChange?: OnChangeCallback<boolean>;
@@ -48,7 +53,7 @@ export default class ToucanFormCheckboxControlComponent extends Component<Toucan
   }
 
   get styles() {
-    let { isDisabled } = this.args;
+    let { isDisabled, isReadOnly } = this.args;
     let isCheckedOrIndeterminate = this.isCheckedOrIndeterminate;
 
     return isCheckedOrIndeterminate && !isDisabled
@@ -57,6 +62,8 @@ export default class ToucanFormCheckboxControlComponent extends Component<Toucan
       ? ['bg-disabled border-none']
       : !isCheckedOrIndeterminate && isDisabled
       ? ['bg-transparent border-disabled']
+      : isReadOnly
+      ? null
       : ['bg-normal-idle'];
   }
 

--- a/packages/ember-toucan-core/src/components/form/controls/file-input.hbs
+++ b/packages/ember-toucan-core/src/components/form/controls/file-input.hbs
@@ -5,5 +5,6 @@
   type="file"
   {{on "change" this.onChange}}
   multiple={{this.multiple}}
+  readonly={{@isReadOnly}}
   ...attributes
 />

--- a/packages/ember-toucan-core/src/components/form/controls/file-input.ts
+++ b/packages/ember-toucan-core/src/components/form/controls/file-input.ts
@@ -11,6 +11,10 @@ interface ToucanFormControlsFileInputComponentSignature {
     hasError?: boolean;
     trigger: string;
     isDisabled?: boolean;
+    /**
+     * Sets the readonly attribute of the checkbox.
+     */
+    isReadOnly?: boolean;
     onChange?: (files: File[] | [], event: FileEvent) => void;
     multiple?: boolean;
     files?: File[];

--- a/packages/ember-toucan-core/src/components/form/controls/input.hbs
+++ b/packages/ember-toucan-core/src/components/form/controls/input.hbs
@@ -1,12 +1,8 @@
 <input
-  class="bg-overlay-1 focus:outline-none focus:shadow-focus-outline block rounded-sm p-1 transition-shadow
-    {{if @isDisabled 'text-disabled' 'text-titles-and-attributes'}}
-    {{if
-      @hasError
-      'shadow-error-outline focus:shadow-error-focus-outline'
-      'shadow-focusable-outline'
-    }}"
+  class="focus:outline-none block rounded-sm p-1 transition-shadow
+    {{this.styles}}"
   disabled={{@isDisabled}}
+  readonly={{@isReadOnly}}
   value={{@value}}
   ...attributes
   {{on "input" this.handleInput}}

--- a/packages/ember-toucan-core/src/components/form/controls/input.ts
+++ b/packages/ember-toucan-core/src/components/form/controls/input.ts
@@ -43,7 +43,7 @@ export default class ToucanFormControlsInputComponent extends Component<ToucanFo
     }
 
     if (isReadOnly) {
-      return 'focus:shadow-focus-outline bg-surface-xl shadow-form-read-only text-titles-and-attributes';
+      return 'focus:shadow-focus-outline bg-surface-xl shadow-read-only-outline text-titles-and-attributes';
     }
 
     if (hasError) {

--- a/packages/ember-toucan-core/src/components/form/controls/input.ts
+++ b/packages/ember-toucan-core/src/components/form/controls/input.ts
@@ -18,6 +18,11 @@ interface ToucanFormControlsInputComponentSignature {
     isDisabled?: boolean;
 
     /**
+     * Sets the readonly attribute of the input.
+     */
+    isReadOnly?: boolean;
+
+    /**
      * The function called when the element is typed into.
      */
     onChange?: OnChangeCallback<string>;
@@ -30,6 +35,24 @@ interface ToucanFormControlsInputComponentSignature {
 }
 
 export default class ToucanFormControlsInputComponent extends Component<ToucanFormControlsInputComponentSignature> {
+  get styles() {
+    let { isDisabled, isReadOnly, hasError } = this.args;
+
+    if (isDisabled) {
+      return 'shadow-focusable-outline bg-overlay-1 text-disabled';
+    }
+
+    if (isReadOnly) {
+      return 'focus:shadow-focus-outline bg-surface-xl shadow-form-read-only text-titles-and-attributes';
+    }
+
+    if (hasError) {
+      return 'shadow-error-outline focus:shadow-error-focus-outline bg-overlay-1 text-titles-and-attributes';
+    }
+
+    return 'shadow-focusable-outline focus:shadow-focus-outline bg-overlay-1 text-titles-and-attributes';
+  }
+
   @action
   handleInput(e: Event | InputEvent): void {
     assert('Expected HTMLInputElement', e.target instanceof HTMLInputElement);

--- a/packages/ember-toucan-core/src/components/form/controls/radio.hbs
+++ b/packages/ember-toucan-core/src/components/form/controls/radio.hbs
@@ -5,6 +5,7 @@
     type="radio"
     checked={{@isChecked}}
     disabled={{@isDisabled}}
+    readonly={{@isReadOnly}}
     value={{@value}}
     ...attributes
     {{on "change" this.handleInput}}

--- a/packages/ember-toucan-core/src/components/form/controls/radio.ts
+++ b/packages/ember-toucan-core/src/components/form/controls/radio.ts
@@ -18,6 +18,11 @@ export interface ToucanFormRadioControlComponentSignature {
     isDisabled?: boolean;
 
     /**
+     * Sets the readonly attribute of the radio.
+     */
+    isReadOnly?: boolean;
+
+    /**
      * The function called when the element is clicked.
      */
     onChange?: OnChangeCallback<string>;
@@ -39,14 +44,20 @@ export default class ToucanFormRadioControlComponent extends Component<ToucanFor
   }
 
   get styles() {
-    let { isDisabled, isChecked } = this.args;
+    let { isDisabled, isChecked, isReadOnly } = this.args;
 
-    return isChecked && !isDisabled
+    // TODO: Make this logic better (this is only for testing purposes atm!)
+    // Don't ship it like this 😂
+    return isChecked && !isDisabled && !isReadOnly
       ? ['bg-primary-idle border-none']
-      : isChecked && isDisabled
+      : isChecked && isDisabled && !isReadOnly
       ? ['bg-disabled border-none']
-      : !isChecked && isDisabled
+      : !isChecked && isDisabled && !isReadOnly
       ? ['bg-transparent border-disabled']
+      : isReadOnly && !isChecked
+      ? ['bg-surface-xl']
+      : isReadOnly && isChecked
+      ? ['bg-titles-and-attributes border-none']
       : ['bg-normal-idle'];
   }
 

--- a/packages/ember-toucan-core/src/components/form/controls/radio.ts
+++ b/packages/ember-toucan-core/src/components/form/controls/radio.ts
@@ -46,19 +46,27 @@ export default class ToucanFormRadioControlComponent extends Component<ToucanFor
   get styles() {
     let { isDisabled, isChecked, isReadOnly } = this.args;
 
-    // TODO: Make this logic better (this is only for testing purposes atm!)
-    // Don't ship it like this 😂
-    return isChecked && !isDisabled && !isReadOnly
-      ? ['bg-primary-idle border-none']
-      : isChecked && isDisabled && !isReadOnly
-      ? ['bg-disabled border-none']
-      : !isChecked && isDisabled && !isReadOnly
-      ? ['bg-transparent border-disabled']
-      : isReadOnly && !isChecked
-      ? ['bg-surface-xl']
-      : isReadOnly && isChecked
-      ? ['bg-titles-and-attributes border-none']
-      : ['bg-normal-idle'];
+    if (isChecked && !isDisabled && !isReadOnly) {
+      return ['bg-primary-idle border-none'];
+    }
+
+    if (isChecked && isDisabled && !isReadOnly) {
+      return ['bg-disabled border-none'];
+    }
+
+    if (isChecked && isReadOnly) {
+      return ['bg-titles-and-attributes border-none'];
+    }
+
+    if (!isChecked && isDisabled && !isReadOnly) {
+      return ['bg-transparent border-disabled'];
+    }
+
+    if (!isChecked && isReadOnly) {
+      return ['bg-surface-xl'];
+    }
+
+    return ['bg-normal-idle'];
   }
 
   @action

--- a/packages/ember-toucan-core/src/components/form/controls/textarea.hbs
+++ b/packages/ember-toucan-core/src/components/form/controls/textarea.hbs
@@ -1,12 +1,8 @@
 <textarea
-  class="min-h-6 bg-overlay-1 focus:outline-none focus:shadow-focus-outline block h-20 rounded-sm p-1 transition-shadow
-    {{if @isDisabled 'text-disabled' 'text-titles-and-attributes'}}
-    {{if
-      @hasError
-      'shadow-error-outline focus:shadow-error-focus-outline'
-      'shadow-focusable-outline'
-    }}"
+  class="min-h-6 focus:outline-none block h-20 rounded-sm p-1 transition-shadow
+    {{this.styles}}"
   disabled={{@isDisabled}}
+  readonly={{@isReadOnly}}
   ...attributes
   {{on "input" this.handleInput}}
 >{{@value}}</textarea>

--- a/packages/ember-toucan-core/src/components/form/controls/textarea.ts
+++ b/packages/ember-toucan-core/src/components/form/controls/textarea.ts
@@ -18,6 +18,11 @@ export interface ToucanFormTextareaControlComponentSignature {
     isDisabled?: boolean;
 
     /**
+     * Sets the readonly attribute of the textarea.
+     */
+    isReadOnly?: boolean;
+
+    /**
      * The function called when the element is typed into.
      */
     onChange?: OnChangeCallback<string>;
@@ -30,6 +35,24 @@ export interface ToucanFormTextareaControlComponentSignature {
 }
 
 export default class ToucanFormTextareaControlComponent extends Component<ToucanFormTextareaControlComponentSignature> {
+  get styles() {
+    let { isDisabled, isReadOnly, hasError } = this.args;
+
+    if (isDisabled) {
+      return 'shadow-focusable-outline bg-overlay-1 text-disabled';
+    }
+
+    if (isReadOnly) {
+      return 'focus:shadow-focus-outline bg-surface-xl shadow-read-only-outline text-titles-and-attributes';
+    }
+
+    if (hasError) {
+      return 'shadow-error-outline focus:shadow-error-focus-outline bg-overlay-1 text-titles-and-attributes';
+    }
+
+    return 'shadow-focusable-outline focus:shadow-focus-outline bg-overlay-1 text-titles-and-attributes';
+  }
+
   @action
   handleInput(e: Event | InputEvent): void {
     assert(

--- a/packages/ember-toucan-core/src/components/form/fields/checkbox-group.hbs
+++ b/packages/ember-toucan-core/src/components/form/fields/checkbox-group.hbs
@@ -3,7 +3,6 @@
     aria-describedby="{{if @error field.errorId}} {{if @hint field.hintId}}"
     disabled={{@isDisabled}}
     data-root-field={{if @rootTestSelector @rootTestSelector}}
-    readonly={{@isReadOnly}}
     ...attributes
   >
     {{#if

--- a/packages/ember-toucan-core/src/components/form/fields/checkbox-group.hbs
+++ b/packages/ember-toucan-core/src/components/form/fields/checkbox-group.hbs
@@ -3,6 +3,7 @@
     aria-describedby="{{if @error field.errorId}} {{if @hint field.hintId}}"
     disabled={{@isDisabled}}
     data-root-field={{if @rootTestSelector @rootTestSelector}}
+    readonly={{@isReadOnly}}
     ...attributes
   >
     {{#if
@@ -50,6 +51,7 @@
             name=@name
             onChange=this.handleInput
             isDisabled=@isDisabled
+            isReadOnly=@isReadOnly
             selectedValues=@value
           )
         )

--- a/packages/ember-toucan-core/src/components/form/fields/checkbox-group.ts
+++ b/packages/ember-toucan-core/src/components/form/fields/checkbox-group.ts
@@ -27,6 +27,11 @@ export interface ToucanFormCheckboxGroupFieldComponentSignature {
     isDisabled?: boolean;
 
     /**
+     * Sets the readonly attribute of the fieldset.
+     */
+    isReadOnly?: boolean;
+
+    /**
      * Provide a string to this argument to render inside of the label tag.
      */
     label?: string;
@@ -58,7 +63,7 @@ export interface ToucanFormCheckboxGroupFieldComponentSignature {
       {
         CheckboxField: WithBoundArgs<
           typeof CheckboxFieldComponent,
-          'isDisabled' | 'name' | 'onChange' | 'selectedValues'
+          'isDisabled' | 'isReadOnly' | 'name' | 'onChange' | 'selectedValues'
         >;
       }
     ];

--- a/packages/ember-toucan-core/src/components/form/fields/checkbox.hbs
+++ b/packages/ember-toucan-core/src/components/form/fields/checkbox.hbs
@@ -20,6 +20,7 @@
           @isDisabled={{@isDisabled}}
           @isChecked={{this.isChecked}}
           @isIndeterminate={{@isIndeterminate}}
+          @isReadOnly={{@isReadOnly}}
           @onChange={{@onChange}}
           ...attributes
         />

--- a/packages/ember-toucan-core/src/components/form/fields/checkbox.ts
+++ b/packages/ember-toucan-core/src/components/form/fields/checkbox.ts
@@ -26,6 +26,11 @@ export interface ToucanFormCheckboxFieldComponentSignature {
     isDisabled?: boolean;
 
     /**
+     * Sets the readonly attribute of the checkbox.
+     */
+    isReadOnly?: boolean;
+
+    /**
      * Sets the checked state of the checkbox.
      */
     isChecked?: ToucanFormCheckboxControlComponentSignature['Args']['isChecked'];

--- a/packages/ember-toucan-core/src/components/form/fields/file-input.hbs
+++ b/packages/ember-toucan-core/src/components/form/fields/file-input.hbs
@@ -52,7 +52,11 @@
           @isDisabled={{@isDisabled}}
           ...attributes
         />
-        <Button @variant="secondary" @onClick={{(fn this.handleChange field)}}>
+        <Button
+          class="{{if @isReadOnly 'shadow-form-read-only bg-surface-xl'}}"
+          @variant="secondary"
+          @onClick={{(fn this.handleChange field)}}
+        >
           <span data-trigger>{{@trigger}}</span>
           <svg
             aria-hidden="true"

--- a/packages/ember-toucan-core/src/components/form/fields/file-input.hbs
+++ b/packages/ember-toucan-core/src/components/form/fields/file-input.hbs
@@ -50,6 +50,7 @@
           @onChange={{@onChange}}
           @trigger={{@trigger}}
           @isDisabled={{@isDisabled}}
+          @isReadOnly={{@isReadOnly}}
           ...attributes
         />
         <Button

--- a/packages/ember-toucan-core/src/components/form/fields/file-input.hbs
+++ b/packages/ember-toucan-core/src/components/form/fields/file-input.hbs
@@ -53,7 +53,7 @@
           ...attributes
         />
         <Button
-          class="{{if @isReadOnly 'shadow-form-read-only bg-surface-xl'}}"
+          class="{{if @isReadOnly 'shadow-read-only-outline bg-surface-xl'}}"
           @variant="secondary"
           @onClick={{(fn this.handleChange field)}}
         >

--- a/packages/ember-toucan-core/src/components/form/fields/file-input.ts
+++ b/packages/ember-toucan-core/src/components/form/fields/file-input.ts
@@ -112,6 +112,10 @@ export default class ToucanFormFileInputFieldComponent extends Component<ToucanF
 
   @action
   handleChange(field: { id: string }) {
+    if (this.args.isReadOnly) {
+      return;
+    }
+
     const input = document.getElementById(`${field.id}`);
 
     // https://developer.mozilla.org/en-US/docs/Web/API/File_API/Using_files_from_web_applications#using_hidden_file_input_elements_using_the_click_method

--- a/packages/ember-toucan-core/src/components/form/fields/file-input.ts
+++ b/packages/ember-toucan-core/src/components/form/fields/file-input.ts
@@ -53,6 +53,11 @@ interface ToucanFormFileInputFieldComponentSignature {
     isDisabled?: boolean;
 
     /**
+     * Sets the readonly attribute of the checkbox.
+     */
+    isReadOnly?: boolean;
+
+    /**
      * Sets the multiple attribute on the file input.
      * If not set, defaults no multiple attribute. In this case (single file upload) a file upload will REPLACE any existing file that is in the files array.
      * If set as multiple file upload, new files are adding to the existing files array.

--- a/packages/ember-toucan-core/src/components/form/fields/input.hbs
+++ b/packages/ember-toucan-core/src/components/form/fields/input.hbs
@@ -41,6 +41,7 @@
         aria-describedby="{{if @hint field.hintId}} {{if @error field.errorId}}"
         aria-invalid={{if @error "true"}}
         @isDisabled={{@isDisabled}}
+        @isReadOnly={{@isReadOnly}}
         @value={{@value}}
         @onChange={{@onChange}}
         @hasError={{this.hasError}}

--- a/packages/ember-toucan-core/src/components/form/fields/input.ts
+++ b/packages/ember-toucan-core/src/components/form/fields/input.ts
@@ -29,6 +29,11 @@ export interface ToucanFormInputFieldComponentSignature {
     isDisabled?: boolean;
 
     /**
+     * Sets the readonly attribute of the input.
+     */
+    isReadOnly?: boolean;
+
+    /**
      * Provide a string to this argument to render inside of the label tag.
      */
     label?: string;

--- a/packages/ember-toucan-core/src/components/form/fields/radio-group.hbs
+++ b/packages/ember-toucan-core/src/components/form/fields/radio-group.hbs
@@ -1,10 +1,11 @@
 <Form::Field as |field|>
   <fieldset
     aria-describedby="{{if @error field.errorId}} {{if @hint field.hintId}}"
-    disabled={{@isDisabled}}
     aria-invalid={{if @error "true"}}
     aria-required="true"
     data-root-field={{if @rootTestSelector @rootTestSelector}}
+    disabled={{@isDisabled}}
+    readonly={{@isReadOnly}}
     role="radiogroup"
     ...attributes
   >
@@ -54,6 +55,7 @@
             onChange=this.handleInput
             selectedValue=@value
             isDisabled=@isDisabled
+            isReadOnly=@isReadOnly
           )
         )
       }}

--- a/packages/ember-toucan-core/src/components/form/fields/radio-group.hbs
+++ b/packages/ember-toucan-core/src/components/form/fields/radio-group.hbs
@@ -5,7 +5,6 @@
     aria-required="true"
     data-root-field={{if @rootTestSelector @rootTestSelector}}
     disabled={{@isDisabled}}
-    readonly={{@isReadOnly}}
     role="radiogroup"
     ...attributes
   >

--- a/packages/ember-toucan-core/src/components/form/fields/radio-group.ts
+++ b/packages/ember-toucan-core/src/components/form/fields/radio-group.ts
@@ -23,9 +23,14 @@ export interface ToucanFormRadioGroupFieldComponentSignature {
     hint?: string;
 
     /**
-     * Sets the disabled attribute on the control.
+     * Sets the disabled attribute on the fieldset.
      */
     isDisabled?: boolean;
+
+    /**
+     * Sets the readonly attribute of the fieldset.
+     */
+    isReadOnly?: boolean;
 
     /**
      * Provide a string to this argument to render inside of the label tag.
@@ -59,7 +64,7 @@ export interface ToucanFormRadioGroupFieldComponentSignature {
       {
         RadioField: WithBoundArgs<
           typeof RadioFieldComponent,
-          'isDisabled' | 'name' | 'onChange' | 'selectedValue'
+          'isDisabled' | 'isReadOnly' | 'name' | 'onChange' | 'selectedValue'
         >;
       }
     ];

--- a/packages/ember-toucan-core/src/components/form/fields/radio.hbs
+++ b/packages/ember-toucan-core/src/components/form/fields/radio.hbs
@@ -11,6 +11,7 @@
           name={{@name}}
           @isDisabled={{@isDisabled}}
           @isChecked={{this.isChecked}}
+          @isReadOnly={{@isReadOnly}}
           @value={{@value}}
           @onChange={{@onChange}}
           ...attributes

--- a/packages/ember-toucan-core/src/components/form/fields/radio.ts
+++ b/packages/ember-toucan-core/src/components/form/fields/radio.ts
@@ -20,6 +20,11 @@ export interface ToucanFormRadioFieldComponentSignature {
     isDisabled?: boolean;
 
     /**
+     * Sets the readonly attribute of the radio.
+     */
+    isReadOnly?: boolean;
+
+    /**
      * Provide a string to this argument to render inside of the label tag.
      */
     label?: string;

--- a/packages/ember-toucan-core/src/components/form/fields/textarea.hbs
+++ b/packages/ember-toucan-core/src/components/form/fields/textarea.hbs
@@ -42,6 +42,7 @@
         aria-describedby="{{if @error field.errorId}} {{if @hint field.hintId}}"
         id={{field.id}}
         @isDisabled={{@isDisabled}}
+        @isReadOnly={{@isReadOnly}}
         @value={{@value}}
         @onChange={{@onChange}}
         @hasError={{this.hasError}}

--- a/packages/ember-toucan-core/src/components/form/fields/textarea.ts
+++ b/packages/ember-toucan-core/src/components/form/fields/textarea.ts
@@ -28,6 +28,7 @@ export interface ToucanFormTextareaFieldComponentSignature {
      * Sets the readonly attribute of the textarea.
      */
     isReadOnly?: boolean;
+
     /**
      * Provide a string to this argument to render inside of the label tag.
      */

--- a/packages/ember-toucan-core/src/components/form/fields/textarea.ts
+++ b/packages/ember-toucan-core/src/components/form/fields/textarea.ts
@@ -25,6 +25,10 @@ export interface ToucanFormTextareaFieldComponentSignature {
     isDisabled?: boolean;
 
     /**
+     * Sets the readonly attribute of the textarea.
+     */
+    isReadOnly?: boolean;
+    /**
      * Provide a string to this argument to render inside of the label tag.
      */
     label?: string;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,7 +27,7 @@ importers:
     dependencies:
       '@crowdstrike/ember-oss-docs':
         specifier: ^1.1.3
-        version: 1.1.3(@babel/core@7.20.12)(@crowdstrike/tailwind-toucan-base@3.4.0)(@docfy/core@0.6.0)(@docfy/ember@0.6.0)(@glimmer/component@1.1.2)(@glint/environment-ember-loose@1.0.0-beta.3)(@glint/template@1.0.0-beta.3)(@tailwindcss/typography@0.5.9)(ember-source@4.12.0)(highlight.js@11.7.0)(highlightjs-glimmer@2.0.1)
+        version: 1.1.3(@babel/core@7.20.12)(@crowdstrike/tailwind-toucan-base@3.5.0)(@docfy/core@0.6.0)(@docfy/ember@0.6.0)(@glimmer/component@1.1.2)(@glint/environment-ember-loose@1.0.0-beta.3)(@glint/template@1.0.0-beta.3)(@tailwindcss/typography@0.5.9)(ember-source@4.12.0)(highlight.js@11.7.0)(highlightjs-glimmer@2.0.1)
       '@crowdstrike/ember-toucan-core':
         specifier: workspace:*
         version: file:packages/ember-toucan-core(@crowdstrike/ember-toucan-styles@2.0.1)(@ember/test-helpers@2.9.3)(@glimmer/tracking@1.1.2)(autoprefixer@10.4.13)(ember-source@4.12.0)(fractal-page-object@0.4.0)(postcss@8.4.21)(tailwindcss@3.2.4)
@@ -75,8 +75,8 @@ importers:
         specifier: ^2.0.1
         version: 2.0.1(@glimmer/tracking@1.1.2)(autoprefixer@10.4.13)(ember-source@4.12.0)(postcss@8.4.21)(tailwindcss@3.2.4)
       '@crowdstrike/tailwind-toucan-base':
-        specifier: ^3.4.0
-        version: 3.4.0(autoprefixer@10.4.13)(postcss@8.4.21)
+        specifier: ^3.5.0
+        version: 3.5.0(autoprefixer@10.4.13)(postcss@8.4.21)
       '@docfy/core':
         specifier: ^0.6.0
         version: 0.6.0
@@ -3349,7 +3349,6 @@ packages:
       prettier: 2.8.3
       resolve-from: 5.0.0
       semver: 5.7.1
-    dev: true
 
   /@changesets/assemble-release-plan@5.2.3:
     resolution: {integrity: sha512-g7EVZCmnWz3zMBAdrcKhid4hkHT+Ft1n0mLussFMcB1dE2zCuwcvGoy9ec3yOgPGF4hoMtgHaMIk3T3TBdvU9g==}
@@ -3360,13 +3359,11 @@ packages:
       '@changesets/types': 5.2.1
       '@manypkg/get-packages': 1.1.3
       semver: 5.7.1
-    dev: true
 
   /@changesets/changelog-git@0.1.14:
     resolution: {integrity: sha512-+vRfnKtXVWsDDxGctOfzJsPhaCdXRYoe+KyWYoq5X/GqoISREiat0l3L8B0a453B2B4dfHGcZaGyowHbp9BSaA==}
     dependencies:
       '@changesets/types': 5.2.1
-    dev: true
 
   /@changesets/changelog-github@0.4.8:
     resolution: {integrity: sha512-jR1DHibkMAb5v/8ym77E4AMNWZKB5NPzw5a5Wtqm1JepAuIF+hrKp2u04NKM14oBZhHglkCfrla9uq8ORnK/dw==}
@@ -3376,7 +3373,6 @@ packages:
       dotenv: 8.6.0
     transitivePeerDependencies:
       - encoding
-    dev: true
 
   /@changesets/cli@2.26.0:
     resolution: {integrity: sha512-0cbTiDms+ICTVtEwAFLNW0jBNex9f5+fFv3I771nBvdnV/mOjd1QJ4+f8KtVSOrwD9SJkk9xbDkWFb0oXd8d1Q==}
@@ -3417,6 +3413,44 @@ packages:
       tty-table: 4.1.6
     dev: true
 
+  /@changesets/cli@2.26.1:
+    resolution: {integrity: sha512-XnTa+b51vt057fyAudvDKGB0Sh72xutQZNAdXkCqPBKO2zvs2yYZx5hFZj1u9cbtpwM6Sxtcr02/FQJfZOzemQ==}
+    hasBin: true
+    dependencies:
+      '@babel/runtime': 7.20.13
+      '@changesets/apply-release-plan': 6.1.3
+      '@changesets/assemble-release-plan': 5.2.3
+      '@changesets/changelog-git': 0.1.14
+      '@changesets/config': 2.3.0
+      '@changesets/errors': 0.1.4
+      '@changesets/get-dependents-graph': 1.3.5
+      '@changesets/get-release-plan': 3.0.16
+      '@changesets/git': 2.0.0
+      '@changesets/logger': 0.0.5
+      '@changesets/pre': 1.0.14
+      '@changesets/read': 0.5.9
+      '@changesets/types': 5.2.1
+      '@changesets/write': 0.2.3
+      '@manypkg/get-packages': 1.1.3
+      '@types/is-ci': 3.0.0
+      '@types/semver': 6.2.3
+      ansi-colors: 4.1.3
+      chalk: 2.4.2
+      enquirer: 2.3.6
+      external-editor: 3.1.0
+      fs-extra: 7.0.1
+      human-id: 1.0.2
+      is-ci: 3.0.1
+      meow: 6.1.1
+      outdent: 0.5.0
+      p-limit: 2.3.0
+      preferred-pm: 3.0.3
+      resolve-from: 5.0.0
+      semver: 5.7.1
+      spawndamnit: 2.0.0
+      term-size: 2.2.1
+      tty-table: 4.1.6
+
   /@changesets/config@2.3.0:
     resolution: {integrity: sha512-EgP/px6mhCx8QeaMAvWtRrgyxW08k/Bx2tpGT+M84jEdX37v3VKfh4Cz1BkwrYKuMV2HZKeHOh8sHvja/HcXfQ==}
     dependencies:
@@ -3427,13 +3461,11 @@ packages:
       '@manypkg/get-packages': 1.1.3
       fs-extra: 7.0.1
       micromatch: 4.0.5
-    dev: true
 
   /@changesets/errors@0.1.4:
     resolution: {integrity: sha512-HAcqPF7snsUJ/QzkWoKfRfXushHTu+K5KZLJWPb34s4eCZShIf8BFO3fwq6KU8+G7L5KdtN2BzQAXOSXEyiY9Q==}
     dependencies:
       extendable-error: 0.1.7
-    dev: true
 
   /@changesets/get-dependents-graph@1.3.5:
     resolution: {integrity: sha512-w1eEvnWlbVDIY8mWXqWuYE9oKhvIaBhzqzo4ITSJY9hgoqQ3RoBqwlcAzg11qHxv/b8ReDWnMrpjpKrW6m1ZTA==}
@@ -3443,7 +3475,6 @@ packages:
       chalk: 2.4.2
       fs-extra: 7.0.1
       semver: 5.7.1
-    dev: true
 
   /@changesets/get-github-info@0.5.2:
     resolution: {integrity: sha512-JppheLu7S114aEs157fOZDjFqUDpm7eHdq5E8SSR0gUBTEK0cNSHsrSR5a66xs0z3RWuo46QvA3vawp8BxDHvg==}
@@ -3452,7 +3483,6 @@ packages:
       node-fetch: 2.6.9
     transitivePeerDependencies:
       - encoding
-    dev: true
 
   /@changesets/get-release-plan@3.0.16:
     resolution: {integrity: sha512-OpP9QILpBp1bY2YNIKFzwigKh7Qe9KizRsZomzLe6pK8IUo8onkAAVUD8+JRKSr8R7d4+JRuQrfSSNlEwKyPYg==}
@@ -3464,11 +3494,9 @@ packages:
       '@changesets/read': 0.5.9
       '@changesets/types': 5.2.1
       '@manypkg/get-packages': 1.1.3
-    dev: true
 
   /@changesets/get-version-range-type@0.3.2:
     resolution: {integrity: sha512-SVqwYs5pULYjYT4op21F2pVbcrca4qA/bAA3FmFXKMN7Y+HcO8sbZUTx3TAy2VXulP2FACd1aC7f2nTuqSPbqg==}
-    dev: true
 
   /@changesets/git@2.0.0:
     resolution: {integrity: sha512-enUVEWbiqUTxqSnmesyJGWfzd51PY4H7mH9yUw0hPVpZBJ6tQZFMU3F3mT/t9OJ/GjyiM4770i+sehAn6ymx6A==}
@@ -3480,20 +3508,17 @@ packages:
       is-subdir: 1.2.0
       micromatch: 4.0.5
       spawndamnit: 2.0.0
-    dev: true
 
   /@changesets/logger@0.0.5:
     resolution: {integrity: sha512-gJyZHomu8nASHpaANzc6bkQMO9gU/ib20lqew1rVx753FOxffnCrJlGIeQVxNWCqM+o6OOleCo/ivL8UAO5iFw==}
     dependencies:
       chalk: 2.4.2
-    dev: true
 
   /@changesets/parse@0.3.16:
     resolution: {integrity: sha512-127JKNd167ayAuBjUggZBkmDS5fIKsthnr9jr6bdnuUljroiERW7FBTDNnNVyJ4l69PzR57pk6mXQdtJyBCJKg==}
     dependencies:
       '@changesets/types': 5.2.1
       js-yaml: 3.14.1
-    dev: true
 
   /@changesets/pre@1.0.14:
     resolution: {integrity: sha512-dTsHmxQWEQekHYHbg+M1mDVYFvegDh9j/kySNuDKdylwfMEevTeDouR7IfHNyVodxZXu17sXoJuf2D0vi55FHQ==}
@@ -3503,7 +3528,6 @@ packages:
       '@changesets/types': 5.2.1
       '@manypkg/get-packages': 1.1.3
       fs-extra: 7.0.1
-    dev: true
 
   /@changesets/read@0.5.9:
     resolution: {integrity: sha512-T8BJ6JS6j1gfO1HFq50kU3qawYxa4NTbI/ASNVVCBTsKquy2HYwM9r7ZnzkiMe8IEObAJtUVGSrePCOxAK2haQ==}
@@ -3516,15 +3540,12 @@ packages:
       chalk: 2.4.2
       fs-extra: 7.0.1
       p-filter: 2.1.0
-    dev: true
 
   /@changesets/types@4.1.0:
     resolution: {integrity: sha512-LDQvVDv5Kb50ny2s25Fhm3d9QSZimsoUGBsUioj6MC3qbMUCuC8GPIvk/M6IvXx3lYhAs0lwWUQLb+VIEUCECw==}
-    dev: true
 
   /@changesets/types@5.2.1:
     resolution: {integrity: sha512-myLfHbVOqaq9UtUKqR/nZA/OY7xFjQMdfgfqeZIBK4d0hA6pgxArvdv8M+6NUzzBsjWLOtvApv8YHr4qM+Kpfg==}
-    dev: true
 
   /@changesets/write@0.2.3:
     resolution: {integrity: sha512-Dbamr7AIMvslKnNYsLFafaVORx4H0pvCA2MHqgtNCySMe1blImEyAEOzDmcgKAkgz4+uwoLz7demIrX+JBr/Xw==}
@@ -3534,7 +3555,6 @@ packages:
       fs-extra: 7.0.1
       human-id: 1.0.2
       prettier: 2.8.3
-    dev: true
 
   /@cnakazawa/watch@1.0.4:
     resolution: {integrity: sha512-v9kIhKwjeZThiWrLmj0y17CWoyddASLj9O2yvbZkbvw/N3rWOYy9zkV66ursAoVr0mV15bL8g0c4QZUE6cdDoQ==}
@@ -3552,7 +3572,7 @@ packages:
     dev: true
     optional: true
 
-  /@crowdstrike/ember-oss-docs@1.1.3(@babel/core@7.20.12)(@crowdstrike/tailwind-toucan-base@3.4.0)(@docfy/core@0.6.0)(@docfy/ember@0.6.0)(@glimmer/component@1.1.2)(@glint/environment-ember-loose@1.0.0-beta.3)(@glint/template@1.0.0-beta.3)(@tailwindcss/typography@0.5.9)(ember-source@4.12.0)(highlight.js@11.7.0)(highlightjs-glimmer@2.0.1):
+  /@crowdstrike/ember-oss-docs@1.1.3(@babel/core@7.20.12)(@crowdstrike/tailwind-toucan-base@3.5.0)(@docfy/core@0.6.0)(@docfy/ember@0.6.0)(@glimmer/component@1.1.2)(@glint/environment-ember-loose@1.0.0-beta.3)(@glint/template@1.0.0-beta.3)(@tailwindcss/typography@0.5.9)(ember-source@4.12.0)(highlight.js@11.7.0)(highlightjs-glimmer@2.0.1):
     resolution: {integrity: sha512-2GiPPy4G4BDP+4BZpFd8dJ3CQSCrp2FobrxUE9uszSaPyF2wTim5ZH46IwKzrozF+fHB6EaDZG/hls7S8nyhQg==}
     peerDependencies:
       '@crowdstrike/tailwind-toucan-base': ^3.3.1
@@ -3566,7 +3586,7 @@ packages:
       highlightjs-glimmer: ^1.4.1 || ^2.0.0
     dependencies:
       '@babel/runtime': 7.20.13
-      '@crowdstrike/tailwind-toucan-base': 3.4.0(autoprefixer@10.4.13)(postcss@8.4.21)
+      '@crowdstrike/tailwind-toucan-base': 3.5.0(autoprefixer@10.4.13)(postcss@8.4.21)
       '@docfy/core': 0.6.0
       '@docfy/ember': 0.6.0
       '@embroider/addon-shim': 1.8.4
@@ -3593,7 +3613,7 @@ packages:
       ember-source: ^3.24.0 || >= 4.0.0
       tailwindcss: ^2.2.15 || ^3.0.0
     dependencies:
-      '@crowdstrike/tailwind-toucan-base': 3.4.0(autoprefixer@10.4.13)(postcss@8.4.21)
+      '@crowdstrike/tailwind-toucan-base': 3.5.0(autoprefixer@10.4.13)(postcss@8.4.21)
       '@embroider/addon-shim': 1.8.4
       '@glimmer/tracking': 1.1.2
       ember-browser-services: 4.0.4
@@ -3601,6 +3621,7 @@ packages:
       tailwindcss: 2.2.19(autoprefixer@10.4.13)(postcss@8.4.21)
     transitivePeerDependencies:
       - autoprefixer
+      - encoding
       - postcss
       - supports-color
       - ts-node
@@ -3613,7 +3634,7 @@ packages:
       ember-source: ^3.24.0 || >= 4.0.0
       tailwindcss: ^2.2.15 || ^3.0.0
     dependencies:
-      '@crowdstrike/tailwind-toucan-base': 3.4.0(autoprefixer@10.4.13)(postcss@8.4.21)
+      '@crowdstrike/tailwind-toucan-base': 3.5.0(autoprefixer@10.4.13)(postcss@8.4.21)
       '@embroider/addon-shim': 1.8.4
       '@glimmer/tracking': 1.1.2
       ember-browser-services: 4.0.4
@@ -3621,17 +3642,21 @@ packages:
       tailwindcss: 3.2.4(postcss@8.4.21)
     transitivePeerDependencies:
       - autoprefixer
+      - encoding
       - postcss
       - supports-color
       - ts-node
 
-  /@crowdstrike/tailwind-toucan-base@3.4.0(autoprefixer@10.4.13)(postcss@8.4.21):
-    resolution: {integrity: sha512-WXWnXn5RIFDJQ2FtjgIqshiilPqv8xslEpTvTnduqnxE+4tJPhiP1FXrGPjo8g42W3l4RXa9Ml5wKSBXvSffVQ==}
+  /@crowdstrike/tailwind-toucan-base@3.5.0(autoprefixer@10.4.13)(postcss@8.4.21):
+    resolution: {integrity: sha512-Z1ShDe66sRgggW1GDd5mg44WYI7q3H8B1yB1l1cCAprvSyI6U61WtBiPEHs2kRz4d0PH78XUnNGQlopbLjZUew==}
     engines: {node: '>=14.15.0'}
     dependencies:
+      '@changesets/changelog-github': 0.4.8
+      '@changesets/cli': 2.26.1
       tailwindcss: 2.2.19(autoprefixer@10.4.13)(postcss@8.4.21)
     transitivePeerDependencies:
       - autoprefixer
+      - encoding
       - postcss
       - ts-node
 
@@ -4418,7 +4443,6 @@ packages:
       '@types/node': 12.20.55
       find-up: 4.1.0
       fs-extra: 8.1.0
-    dev: true
 
   /@manypkg/find-root@2.1.0:
     resolution: {integrity: sha512-NEYRVlZCJYhRTqQURhv+WBpDcvmsp/M423Wcdvggv8lYJYD4GtqnTMLrQaTjA10fYt/PIc3tSdwV+wxJnWqPfQ==}
@@ -4439,7 +4463,6 @@ packages:
       fs-extra: 8.1.0
       globby: 11.1.0
       read-yaml-file: 1.1.0
-    dev: true
 
   /@manypkg/get-packages@2.1.0:
     resolution: {integrity: sha512-IgWPEGgeKeR3ISlgHAMbY+m042yjNe3NPt8UmJT0xMwofe/UifUVtOq5aUBkNSygfOrcUh/j5JExLPuOx72quA==}
@@ -5281,7 +5304,6 @@ packages:
     resolution: {integrity: sha512-Q0Op0hdWbYd1iahB+IFNQcWXFq4O0Q5MwQP7uN0souuQ4rPg1vEYcnIOfr1gY+M+6rc8FGoRaBO1mOOvL29sEQ==}
     dependencies:
       ci-info: 3.8.0
-    dev: true
 
   /@types/json-schema@7.0.11:
     resolution: {integrity: sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==}
@@ -5313,7 +5335,6 @@ packages:
 
   /@types/minimist@1.2.2:
     resolution: {integrity: sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==}
-    dev: true
 
   /@types/node@12.20.55:
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
@@ -5331,7 +5352,6 @@ packages:
 
   /@types/normalize-package-data@2.4.1:
     resolution: {integrity: sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==}
-    dev: true
 
   /@types/object-path@0.11.1:
     resolution: {integrity: sha512-219LSCO9HPcoXcRTC6DbCs0FRhZgBnEMzf16RRqkT40WbkKx3mOeQuz3e2XqbfhOz/AHfbru0kzB1n1RCAsIIg==}
@@ -5369,7 +5389,6 @@ packages:
 
   /@types/semver@6.2.3:
     resolution: {integrity: sha512-KQf+QAMWKMrtBMsB8/24w53tEsxllMj6TuA80TT/5igJalLI/zm0L3oXRbIAl4Ohfc85gyHX/jhMwsVkmhLU4A==}
-    dev: true
 
   /@types/semver@7.3.13:
     resolution: {integrity: sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==}
@@ -5814,7 +5833,6 @@ packages:
   /ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
     engines: {node: '>=6'}
-    dev: true
 
   /ansi-escapes@3.2.0:
     resolution: {integrity: sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==}
@@ -5852,7 +5870,6 @@ packages:
   /ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
-    dev: true
 
   /ansi-styles@2.2.1:
     resolution: {integrity: sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==}
@@ -5988,7 +6005,6 @@ packages:
       define-properties: 1.1.4
       es-abstract: 1.21.1
       es-shim-unscopables: 1.0.0
-    dev: true
 
   /array.prototype.flatmap@1.3.1:
     resolution: {integrity: sha512-8UGn9O1FDVvMNB0UlLv4voxRMze7+FpHyF5mSMRjWHUMlpoDViniy05870VlxhfgTnLbpuwTzvD76MTtWxB/mQ==}
@@ -6003,7 +6019,6 @@ packages:
   /arrify@1.0.1:
     resolution: {integrity: sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==}
     engines: {node: '>=0.10.0'}
-    dev: true
 
   /assert-never@1.2.1:
     resolution: {integrity: sha512-TaTivMB6pYI1kXwrFlEhLeGfOqoDNdTxjCdwRfFFkEA30Eu+k48W34nlok2EYWJfFFzqaEmichdNM7th6M5HNw==}
@@ -6812,7 +6827,6 @@ packages:
     engines: {node: '>=4'}
     dependencies:
       is-windows: 1.0.2
-    dev: true
 
   /big.js@5.2.2:
     resolution: {integrity: sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==}
@@ -6934,7 +6948,6 @@ packages:
     resolution: {integrity: sha512-ex5W9DoOQ/LUEU3PMdLs9ua/CYZl1678NUkKOdUSi8Aw5F1idieaiRURCBFJCwVcrD1J8Iy3vfWSloaMwO2qFg==}
     dependencies:
       wcwidth: 1.0.1
-    dev: true
 
   /broccoli-amd-funnel@2.0.1:
     resolution: {integrity: sha512-VRE+0PYAN4jQfkIq3GKRj4U/4UV9rVpLan5ll6fVYV4ziVg4OEfR5GUnILEg++QtR4xSaugRxCPU5XJLDy3bNQ==}
@@ -7591,12 +7604,10 @@ packages:
       camelcase: 5.3.1
       map-obj: 4.3.0
       quick-lru: 4.0.1
-    dev: true
 
   /camelcase@5.3.1:
     resolution: {integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==}
     engines: {node: '>=6'}
-    dev: true
 
   /can-symlink@1.0.0:
     resolution: {integrity: sha512-RbsNrFyhwkx+6psk/0fK/Q9orOUr9VMxohGd8vTa4djf4TGLfblBgUfqZChrZuW0Q+mz2eBPFLusw9Jfukzmhg==}
@@ -7679,7 +7690,6 @@ packages:
 
   /chardet@0.7.0:
     resolution: {integrity: sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==}
-    dev: true
 
   /charm@1.0.2:
     resolution: {integrity: sha512-wqW3VdPnlSWT4eRiYX+hcs+C6ViBPUWk1qTCd+37qw9kEm/a5n2qcyQDMBWvSYKN/ctqZzeXNQaeBjOetJJUkw==}
@@ -7708,7 +7718,6 @@ packages:
   /ci-info@3.8.0:
     resolution: {integrity: sha512-eXTggHWSooYhq49F2opQhuHWgzucfF2YgODK4e1566GQs5BIfP30B0oenwBJHfWxAs2fyPB1s7Mg949zLf61Yw==}
     engines: {node: '>=8'}
-    dev: true
 
   /class-utils@0.3.6:
     resolution: {integrity: sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==}
@@ -7799,7 +7808,6 @@ packages:
       string-width: 4.2.3
       strip-ansi: 6.0.1
       wrap-ansi: 6.2.0
-    dev: true
 
   /cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
@@ -7808,7 +7816,6 @@ packages:
       string-width: 4.2.3
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
-    dev: true
 
   /clone-response@1.0.3:
     resolution: {integrity: sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==}
@@ -7819,7 +7826,6 @@ packages:
   /clone@1.0.4:
     resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
     engines: {node: '>=0.8'}
-    dev: true
 
   /clone@2.1.2:
     resolution: {integrity: sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==}
@@ -8290,7 +8296,6 @@ packages:
       lru-cache: 4.1.5
       shebang-command: 1.2.0
       which: 1.3.1
-    dev: true
 
   /cross-spawn@6.0.5:
     resolution: {integrity: sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==}
@@ -8510,15 +8515,12 @@ packages:
 
   /csv-generate@3.4.3:
     resolution: {integrity: sha512-w/T+rqR0vwvHqWs/1ZyMDWtHHSJaN06klRqJXBEpDJaM/+dZkso0OKh1VcuuYvK3XM53KysVNq8Ko/epCK8wOw==}
-    dev: true
 
   /csv-parse@4.16.3:
     resolution: {integrity: sha512-cO1I/zmz4w2dcKHVvpCr7JVRu8/FymG5OEpmvsZYlccYolPBLoVGKUHgNoc4ZGkFeFlWGEDmMyBM+TTqRdW/wg==}
-    dev: true
 
   /csv-stringify@5.6.5:
     resolution: {integrity: sha512-PjiQ659aQ+fUTQqSrd1XEDnOr52jh30RBurfzkscaE2tPaFsDH5wOAHJiw8XAHphRknCwMUE9KRayc4K/NbO8A==}
-    dev: true
 
   /csv@5.5.3:
     resolution: {integrity: sha512-QTaY0XjjhTQOdguARF0lGKm5/mEq9PD9/VhZZegHDIBq2tQwgNpHc3dneD4mGo2iJs+fTKv5Bp0fZ+BRuY3Z0g==}
@@ -8528,7 +8530,6 @@ packages:
       csv-parse: 4.16.3
       csv-stringify: 5.6.5
       stream-transform: 2.1.3
-    dev: true
 
   /dag-map@2.0.2:
     resolution: {integrity: sha512-xnsprIzYuDeiyu5zSKwilV/ajRHxnoMlAhEREfyfTgTSViMVY2fGP1ZcHJbtwup26oCkofySU/m6oKJ3HrkW7w==}
@@ -8544,7 +8545,6 @@ packages:
 
   /dataloader@1.4.0:
     resolution: {integrity: sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==}
-    dev: true
 
   /date-fns@2.29.3:
     resolution: {integrity: sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==}
@@ -8620,12 +8620,10 @@ packages:
     dependencies:
       decamelize: 1.2.0
       map-obj: 1.0.1
-    dev: true
 
   /decamelize@1.2.0:
     resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
     engines: {node: '>=0.10.0'}
-    dev: true
 
   /decimal.js@10.4.3:
     resolution: {integrity: sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==}
@@ -8676,7 +8674,6 @@ packages:
     resolution: {integrity: sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==}
     dependencies:
       clone: 1.0.4
-    dev: true
 
   /defer-to-connect@1.1.3:
     resolution: {integrity: sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ==}
@@ -8764,7 +8761,6 @@ packages:
   /detect-indent@6.1.0:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
     engines: {node: '>=8'}
-    dev: true
 
   /detect-newline@3.1.0:
     resolution: {integrity: sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==}
@@ -8869,7 +8865,6 @@ packages:
   /dotenv@8.6.0:
     resolution: {integrity: sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==}
     engines: {node: '>=10'}
-    dev: true
 
   /duplexer3@0.1.5:
     resolution: {integrity: sha512-1A8za6ws41LQgv9HrE/66jyC5yuSjQ3L/KOpFtoBilsAK2iA2wuS5rTt1OCzIvtS2V7nVmedsUU+DGRcjBmOYA==}
@@ -10110,7 +10105,6 @@ packages:
 
   /emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
-    dev: true
 
   /emojis-list@3.0.0:
     resolution: {integrity: sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==}
@@ -10163,7 +10157,6 @@ packages:
     engines: {node: '>=8.6'}
     dependencies:
       ansi-colors: 4.1.3
-    dev: true
 
   /ensure-posix-path@1.1.1:
     resolution: {integrity: sha512-VWU0/zXzVbeJNXvME/5EmLuEj2TauvoaTz6aFYK1Z92JCBlDlZ3Gu0tuGR42kpW1754ywTs+QB0g5TP0oj9Zaw==}
@@ -10263,7 +10256,6 @@ packages:
     resolution: {integrity: sha512-Jm6GPcCdC30eMLbZ2x8z2WuRwAws3zTBBKuusffYVUrNj/GVSUAZ+xKMaUpfNDR5IbyNA5LJbaecoUVbmUcB1w==}
     dependencies:
       has: 1.0.3
-    dev: true
 
   /es-to-primitive@1.2.1:
     resolution: {integrity: sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==}
@@ -10941,7 +10933,6 @@ packages:
 
   /extendable-error@0.1.7:
     resolution: {integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==}
-    dev: true
 
   /external-editor@3.1.0:
     resolution: {integrity: sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==}
@@ -10950,7 +10941,6 @@ packages:
       chardet: 0.7.0
       iconv-lite: 0.4.24
       tmp: 0.0.33
-    dev: true
 
   /extglob@2.0.4:
     resolution: {integrity: sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==}
@@ -11188,7 +11178,6 @@ packages:
     dependencies:
       micromatch: 4.0.5
       pkg-dir: 4.2.0
-    dev: true
 
   /find-yarn-workspace-root@1.2.1:
     resolution: {integrity: sha512-dVtfb0WuQG+8Ag2uWkbG79hOUzEsRrhBzgfn86g2sJPkzmcpGdghbNTfUKGTxymFrY/tLIodDzLoW9nOJ4FY8Q==}
@@ -11491,7 +11480,6 @@ packages:
   /get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
-    dev: true
 
   /get-intrinsic@1.2.0:
     resolution: {integrity: sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==}
@@ -11747,7 +11735,6 @@ packages:
 
   /grapheme-splitter@1.0.4:
     resolution: {integrity: sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==}
-    dev: true
 
   /growly@1.3.0:
     resolution: {integrity: sha512-+xGQY0YyAWCnqy7Cd++hc2JqMYzlm0dG30Jd0beaA64sROr8C4nt8Yc9V5Ro3avlSUDTN0ulqP/VBKi1/lLygw==}
@@ -11768,7 +11755,6 @@ packages:
   /hard-rejection@2.1.0:
     resolution: {integrity: sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==}
     engines: {node: '>=6'}
-    dev: true
 
   /has-ansi@2.0.0:
     resolution: {integrity: sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==}
@@ -11948,7 +11934,6 @@ packages:
 
   /hosted-git-info@2.8.9:
     resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==}
-    dev: true
 
   /hosted-git-info@3.0.8:
     resolution: {integrity: sha512-aXpmwoOhRBrw6X3j0h5RloK4x1OzsxMPyxqIHyNfSe2pypkVTZFpEiRoSipPEPlMrh0HW/XsjkJ5WgnCirpNUw==}
@@ -12068,7 +12053,6 @@ packages:
 
   /human-id@1.0.2:
     resolution: {integrity: sha512-UNopramDEhHJD+VR+ehk8rOslwSfByxPIZyJRfV739NDhN5LF1fa1MqnzKm2lGTQRjNrjK19Q5fhkgIfjlVUKw==}
-    dev: true
 
   /human-signals@1.1.1:
     resolution: {integrity: sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==}
@@ -12121,7 +12105,6 @@ packages:
   /indent-string@4.0.0:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
-    dev: true
 
   /inflection@1.13.4:
     resolution: {integrity: sha512-6I/HUDeYFfuNCVS3td055BaXBwKYuzw7K3ExVMStBowKo9oOAMJIXIHvdyR3iboTCp1b+1i5DSkIZTcwIktuDw==}
@@ -12322,7 +12305,6 @@ packages:
     hasBin: true
     dependencies:
       ci-info: 3.8.0
-    dev: true
 
   /is-color-stop@1.1.0:
     resolution: {integrity: sha512-H1U8Vz0cfXNujrJzEcvvwMDW9Ra+biSYA3ThdQvAnMLJkEHQXn6bWzLkxHtVYJ+Sdbx0b6finn3jZiaVe7MAHA==}
@@ -12410,7 +12392,6 @@ packages:
   /is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
-    dev: true
 
   /is-git-url@1.0.0:
     resolution: {integrity: sha512-UCFta9F9rWFSavp9H3zHEHrARUfZbdJvmHKeEpds4BK3v7W2LdXoNypMtXXi5w5YBDEBCTYmbI+vsSwI8LYJaQ==}
@@ -12480,7 +12461,6 @@ packages:
   /is-plain-obj@1.1.0:
     resolution: {integrity: sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==}
     engines: {node: '>=0.10.0'}
-    dev: true
 
   /is-plain-obj@2.1.0:
     resolution: {integrity: sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==}
@@ -12543,7 +12523,6 @@ packages:
     engines: {node: '>=4'}
     dependencies:
       better-path-resolve: 1.0.0
-    dev: true
 
   /is-symbol@1.0.4:
     resolution: {integrity: sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==}
@@ -12595,7 +12574,6 @@ packages:
   /is-windows@1.0.2:
     resolution: {integrity: sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==}
     engines: {node: '>=0.10.0'}
-    dev: true
 
   /is-wsl@2.2.0:
     resolution: {integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==}
@@ -12886,12 +12864,10 @@ packages:
   /kind-of@6.0.3:
     resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
     engines: {node: '>=0.10.0'}
-    dev: true
 
   /kleur@4.1.5:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
     engines: {node: '>=6'}
-    dev: true
 
   /klona@2.0.6:
     resolution: {integrity: sha512-dhG34DXATL5hSxJbIexCft8FChFXtmskoZYnoPWjXQuebWYCNkVeV3KkGegCK9CP1oswI/vQibS2GY7Em/sJJA==}
@@ -12975,7 +12951,6 @@ packages:
       js-yaml: 3.14.1
       pify: 4.0.1
       strip-bom: 3.0.0
-    dev: true
 
   /loader-runner@4.3.0:
     resolution: {integrity: sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==}
@@ -13164,7 +13139,6 @@ packages:
 
   /lodash.startcase@4.4.0:
     resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
-    dev: true
 
   /lodash.template@4.5.0:
     resolution: {integrity: sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==}
@@ -13236,7 +13210,6 @@ packages:
     dependencies:
       pseudomap: 1.0.2
       yallist: 2.1.2
-    dev: true
 
   /lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
@@ -13299,12 +13272,10 @@ packages:
   /map-obj@1.0.1:
     resolution: {integrity: sha512-7N/q3lyZ+LVCp7PzuxrJr4KMbBE2hW7BT7YNia330OFxIf4d3r5zVpicP2650l7CPN6RM9zOJRl3NGpqSiw3Eg==}
     engines: {node: '>=0.10.0'}
-    dev: true
 
   /map-obj@4.3.0:
     resolution: {integrity: sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==}
     engines: {node: '>=8'}
-    dev: true
 
   /map-visit@1.0.0:
     resolution: {integrity: sha512-4y7uGv8bd2WdM9vpQsiQNo41Ln1NvhvDRuVt0k2JZQ+ezN2uaQes7lZeZ+QQUHOLQAtDaBJ+7wCbi+ab/KFs+w==}
@@ -13510,7 +13481,6 @@ packages:
       trim-newlines: 3.0.1
       type-fest: 0.13.1
       yargs-parser: 18.1.3
-    dev: true
 
   /merge-descriptors@1.0.1:
     resolution: {integrity: sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w==}
@@ -13653,7 +13623,6 @@ packages:
   /min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
-    dev: true
 
   /mini-css-extract-plugin@2.7.2:
     resolution: {integrity: sha512-EdlUizq13o0Pd+uCp+WO/JpkLvHRVGt97RqfeGhXqAcorYo1ypJSpkV+WDT0vY/kmh/p7wRdJNJtuyK540PXDw==}
@@ -13705,7 +13674,6 @@ packages:
       arrify: 1.0.1
       is-plain-obj: 1.1.0
       kind-of: 6.0.3
-    dev: true
 
   /minimist@0.2.2:
     resolution: {integrity: sha512-g92kDfAOAszDRtHNagjZPPI/9lfOFaRBL/Ud6Z0RKZua/x+49awTydZLh5Gkhb80Xy5hmcvZNLGzscW5n5yd0g==}
@@ -13732,7 +13700,6 @@ packages:
   /mixme@0.5.5:
     resolution: {integrity: sha512-/6IupbRx32s7jjEwHcycXikJwFD5UujbVNuJFkeKLYje+92OvtuPniF6JhnFm5JCTDUhS+kYK3W/4BWYQYXz7w==}
     engines: {node: '>= 8.0.0'}
-    dev: true
 
   /mkdirp@0.5.6:
     resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
@@ -13860,7 +13827,6 @@ packages:
         optional: true
     dependencies:
       whatwg-url: 5.0.0
-    dev: true
 
   /node-int64@0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
@@ -13903,7 +13869,6 @@ packages:
       resolve: 1.22.1
       semver: 5.7.1
       validate-npm-package-license: 3.0.4
-    dev: true
 
   /normalize-path@2.1.1:
     resolution: {integrity: sha512-3pKJwH184Xo/lnH6oyP1q2pMd7HcypqqmRs91/6/i2CGtWwIKGCkOOMTm/zXbgTEWHw1uNpNi/igc3ePOYHb6w==}
@@ -14253,7 +14218,6 @@ packages:
 
   /outdent@0.5.0:
     resolution: {integrity: sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==}
-    dev: true
 
   /p-cancelable@1.1.0:
     resolution: {integrity: sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==}
@@ -14275,7 +14239,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       p-map: 2.1.0
-    dev: true
 
   /p-finally@1.0.0:
     resolution: {integrity: sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==}
@@ -14351,7 +14314,6 @@ packages:
   /p-map@2.1.0:
     resolution: {integrity: sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==}
     engines: {node: '>=6'}
-    dev: true
 
   /p-map@3.0.0:
     resolution: {integrity: sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==}
@@ -14985,7 +14947,6 @@ packages:
       find-yarn-workspace-root2: 1.2.16
       path-exists: 4.0.0
       which-pm: 2.0.0
-    dev: true
 
   /prelude-ls@1.1.2:
     resolution: {integrity: sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==}
@@ -15150,7 +15111,6 @@ packages:
 
   /pseudomap@1.0.2:
     resolution: {integrity: sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==}
-    dev: true
 
   /psl@1.9.0:
     resolution: {integrity: sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==}
@@ -15190,7 +15150,6 @@ packages:
   /quick-lru@4.0.1:
     resolution: {integrity: sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==}
     engines: {node: '>=8'}
-    dev: true
 
   /quick-lru@5.1.1:
     resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
@@ -15275,7 +15234,6 @@ packages:
       find-up: 4.1.0
       read-pkg: 5.2.0
       type-fest: 0.8.1
-    dev: true
 
   /read-pkg@5.2.0:
     resolution: {integrity: sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==}
@@ -15285,7 +15243,6 @@ packages:
       normalize-package-data: 2.5.0
       parse-json: 5.2.0
       type-fest: 0.6.0
-    dev: true
 
   /read-yaml-file@1.1.0:
     resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
@@ -15334,7 +15291,6 @@ packages:
     dependencies:
       indent-string: 4.0.0
       strip-indent: 3.0.0
-    dev: true
 
   /redeyed@1.0.1:
     resolution: {integrity: sha512-8eEWsNCkV2rvwKLS1Cvp5agNjMhwRe2um+y32B2+3LqOzg4C9BBPs6vzAfV16Ivb8B9HPNKIqd8OrdBws8kNlQ==}
@@ -15535,7 +15491,6 @@ packages:
   /require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
-    dev: true
 
   /require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
@@ -15543,7 +15498,6 @@ packages:
 
   /require-main-filename@2.0.0:
     resolution: {integrity: sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==}
-    dev: true
 
   /require-relative@0.8.7:
     resolution: {integrity: sha512-AKGr4qvHiryxRb19m3PsLRGuKVAbJLUD7E6eOaHkfKhwc+vSgVOCY5xNvm9EkolBKTOf0GrQAZKLimOCz81Khg==}
@@ -15579,7 +15533,6 @@ packages:
   /resolve-from@5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
-    dev: true
 
   /resolve-package-path@1.2.7:
     resolution: {integrity: sha512-fVEKHGeK85bGbVFuwO9o1aU0n3vqQGrezPc51JGu9UTXpFQfWq5qCeKxyaRUSvephs+06c5j5rPq/dzHGEo8+Q==}
@@ -16034,7 +15987,6 @@ packages:
 
   /set-blocking@2.0.0:
     resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
-    dev: true
 
   /set-value@2.0.1:
     resolution: {integrity: sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==}
@@ -16059,7 +16011,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       shebang-regex: 1.0.0
-    dev: true
 
   /shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -16070,7 +16021,6 @@ packages:
   /shebang-regex@1.0.0:
     resolution: {integrity: sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==}
     engines: {node: '>=0.10.0'}
-    dev: true
 
   /shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
@@ -16130,7 +16080,6 @@ packages:
       strip-ansi: 6.0.1
       wcwidth: 1.0.1
       yargs: 15.4.1
-    dev: true
 
   /snake-case@3.0.4:
     resolution: {integrity: sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==}
@@ -16302,29 +16251,24 @@ packages:
     dependencies:
       cross-spawn: 5.1.0
       signal-exit: 3.0.7
-    dev: true
 
   /spdx-correct@3.1.1:
     resolution: {integrity: sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==}
     dependencies:
       spdx-expression-parse: 3.0.1
       spdx-license-ids: 3.0.12
-    dev: true
 
   /spdx-exceptions@2.3.0:
     resolution: {integrity: sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==}
-    dev: true
 
   /spdx-expression-parse@3.0.1:
     resolution: {integrity: sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==}
     dependencies:
       spdx-exceptions: 2.3.0
       spdx-license-ids: 3.0.12
-    dev: true
 
   /spdx-license-ids@3.0.12:
     resolution: {integrity: sha512-rr+VVSXtRhO4OHbXUiAF7xW3Bo9DuuF6C5jH+q/x15j2jniycgKbxU09Hr0WqlSLUs4i4ltHGXqTe7VHclYWyA==}
-    dev: true
 
   /split-string@3.1.0:
     resolution: {integrity: sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==}
@@ -16381,7 +16325,6 @@ packages:
     resolution: {integrity: sha512-9GHUiM5hMiCi6Y03jD2ARC1ettBXkQBoQAe7nJsPknnI0ow10aXjTnew8QtYQmLjzn974BnmWEAJgCY6ZP1DeQ==}
     dependencies:
       mixme: 0.5.5
-    dev: true
 
   /string-template@0.2.1:
     resolution: {integrity: sha512-Yptehjogou2xm4UJbxJ4CxgZx12HBfeystp0y3x7s4Dj32ltVVG1Gg8YhKjHZkHicuKpZX/ffilA8505VbUbpw==}
@@ -16402,7 +16345,6 @@ packages:
       emoji-regex: 8.0.0
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
-    dev: true
 
   /string.prototype.matchall@4.0.8:
     resolution: {integrity: sha512-6zOCOcJ+RJAQshcTvXPHoxoQGONa3e/Lqx90wUA+wEzX78sg5Bo+1tQo4N0pohS0erG9qtCqJDjNCQBjeWVxyg==}
@@ -16472,7 +16414,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       ansi-regex: 5.0.1
-    dev: true
 
   /strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
@@ -16496,7 +16437,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       min-indent: 1.0.1
-    dev: true
 
   /strip-json-comments@2.0.1:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
@@ -16734,7 +16674,6 @@ packages:
   /term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
     engines: {node: '>=8'}
-    dev: true
 
   /terser-webpack-plugin@5.3.6(webpack@5.75.0):
     resolution: {integrity: sha512-kfLFk+PoLUQIbLmB1+PZDMRSZS99Mp+/MHqDNmMA6tOItzRt+Npe3E+fsMs5mfcM0wCtrrdU387UnV+vnSffXQ==}
@@ -17021,7 +16960,6 @@ packages:
 
   /tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
-    dev: true
 
   /tr46@2.1.0:
     resolution: {integrity: sha512-15Ih7phfcdP5YxqiB+iDtLoaTz4Nd35+IiAv0kQ5FNKHzXgdWqPoTIqEDDJmXceQt4JZk6lVPT8lnDlPpGDppw==}
@@ -17071,7 +17009,6 @@ packages:
   /trim-newlines@3.0.1:
     resolution: {integrity: sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==}
     engines: {node: '>=8'}
-    dev: true
 
   /trough@1.0.5:
     resolution: {integrity: sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==}
@@ -17131,7 +17068,6 @@ packages:
       strip-ansi: 6.0.1
       wcwidth: 1.0.1
       yargs: 17.6.2
-    dev: true
 
   /turbo-darwin-64@1.8.8:
     resolution: {integrity: sha512-18cSeIm7aeEvIxGyq7PVoFyEnPpWDM/0CpZvXKHpQ6qMTkfNt517qVqUTAwsIYqNS8xazcKAqkNbvU1V49n65Q==}
@@ -17215,7 +17151,6 @@ packages:
   /type-fest@0.13.1:
     resolution: {integrity: sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==}
     engines: {node: '>=10'}
-    dev: true
 
   /type-fest@0.20.2:
     resolution: {integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==}
@@ -17230,12 +17165,10 @@ packages:
   /type-fest@0.6.0:
     resolution: {integrity: sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==}
     engines: {node: '>=8'}
-    dev: true
 
   /type-fest@0.8.1:
     resolution: {integrity: sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==}
     engines: {node: '>=8'}
-    dev: true
 
   /type-is@1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
@@ -17501,7 +17434,6 @@ packages:
     dependencies:
       spdx-correct: 3.1.1
       spdx-expression-parse: 3.0.1
-    dev: true
 
   /validate-npm-package-name@5.0.0:
     resolution: {integrity: sha512-YuKoXDAhBYxY7SfOKxHBDoSyENFeW5VvIIQp2TGQuit8gpK6MnWaQelBKxso72DoxTZfZdcP3W90LqpSkgPzLQ==}
@@ -17676,11 +17608,9 @@ packages:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
     dependencies:
       defaults: 1.0.4
-    dev: true
 
   /webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
-    dev: true
 
   /webidl-conversions@5.0.0:
     resolution: {integrity: sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==}
@@ -17764,7 +17694,6 @@ packages:
     dependencies:
       tr46: 0.0.3
       webidl-conversions: 3.0.1
-    dev: true
 
   /whatwg-url@8.7.0:
     resolution: {integrity: sha512-gAojqb/m9Q8a5IV96E3fHJM70AzCkgt4uXYX2O7EmuyOnLrViCQlsEBmF9UQIu3/aeAIp2U17rtbpZWNntQqdg==}
@@ -17794,7 +17723,6 @@ packages:
 
   /which-module@2.0.0:
     resolution: {integrity: sha512-B+enWhmw6cjfVC7kS8Pj9pCrKSc5txArRyaYGe088shv/FGWH+0Rjx/xPgtsWfsUtS27FkP697E4DDhgrgoc0Q==}
-    dev: true
 
   /which-pm@2.0.0:
     resolution: {integrity: sha512-Lhs9Pmyph0p5n5Z3mVnN0yWcbQYUAD7rbQUiMsQxOJ3T57k7RFe35SUwWMf7dsbDZks1uOmw4AecB/JMDj3v/w==}
@@ -17802,7 +17730,6 @@ packages:
     dependencies:
       load-yaml-file: 0.2.0
       path-exists: 4.0.0
-    dev: true
 
   /which-typed-array@1.1.9:
     resolution: {integrity: sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==}
@@ -17820,7 +17747,6 @@ packages:
     hasBin: true
     dependencies:
       isexe: 2.0.0
-    dev: true
 
   /which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -17871,7 +17797,6 @@ packages:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
-    dev: true
 
   /wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
@@ -17880,7 +17805,6 @@ packages:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
-    dev: true
 
   /wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
@@ -17936,16 +17860,13 @@ packages:
 
   /y18n@4.0.3:
     resolution: {integrity: sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==}
-    dev: true
 
   /y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
-    dev: true
 
   /yallist@2.1.2:
     resolution: {integrity: sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==}
-    dev: true
 
   /yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
@@ -17971,12 +17892,10 @@ packages:
     dependencies:
       camelcase: 5.3.1
       decamelize: 1.2.0
-    dev: true
 
   /yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
-    dev: true
 
   /yargs@15.4.1:
     resolution: {integrity: sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==}
@@ -17993,7 +17912,6 @@ packages:
       which-module: 2.0.0
       y18n: 4.0.3
       yargs-parser: 18.1.3
-    dev: true
 
   /yargs@17.6.2:
     resolution: {integrity: sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==}
@@ -18006,7 +17924,6 @@ packages:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
-    dev: true
 
   /yargs@17.7.1:
     resolution: {integrity: sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==}
@@ -18037,7 +17954,7 @@ packages:
     resolution: {directory: packages/ember-toucan-core, type: directory}
     id: file:packages/ember-toucan-core
     name: '@crowdstrike/ember-toucan-core'
-    version: 0.1.0-beta.0
+    version: 0.1.0
     peerDependencies:
       '@crowdstrike/ember-toucan-styles': ^2.0.1
       '@ember/test-helpers': ^2.8.1
@@ -18066,7 +17983,7 @@ packages:
     resolution: {directory: packages/ember-toucan-core, type: directory}
     id: file:packages/ember-toucan-core
     name: '@crowdstrike/ember-toucan-core'
-    version: 0.1.0-beta.0
+    version: 0.1.0
     peerDependencies:
       '@crowdstrike/ember-toucan-styles': ^2.0.1
       '@ember/test-helpers': ^2.8.1

--- a/test-app/tests/integration/components/checkbox-field-test.gts
+++ b/test-app/tests/integration/components/checkbox-field-test.gts
@@ -118,6 +118,14 @@ module('Integration | Component | Fields | CheckboxField', function (hooks) {
     assert.dom('[data-checkbox]').isDisabled();
   });
 
+  test('it sets readonly on the checkbox using `@isReadOnly`', async function (assert) {
+    await render(<template>
+      <CheckboxField @label="Label" @isReadOnly={{true}} data-checkbox />
+    </template>);
+
+    assert.dom('[data-checkbox]').hasAttribute('readonly');
+  });
+
   test('it spreads attributes to the underlying checkbox', async function (assert) {
     await render(<template>
       <CheckboxField @label="Label" name="checkbox-name" data-checkbox />

--- a/test-app/tests/integration/components/checkbox-group-field-test.gts
+++ b/test-app/tests/integration/components/checkbox-group-field-test.gts
@@ -179,6 +179,26 @@ module('Integration | Component | Fields | CheckboxGroup', function (hooks) {
     assert.dom('[data-checkbox-2]').isDisabled();
   });
 
+  test('it sets an individual checkbox to readonly with `@isReadOnly`', async function (assert) {
+    await render(<template>
+      <CheckboxGroupField
+        @label="Label"
+        @name="group"
+        data-group-field
+        as |group|
+      >
+        <group.CheckboxField
+          @label="label 1"
+          @value="option-1"
+          @isReadOnly={{true}}
+          data-checkbox-1
+        />
+      </CheckboxGroupField>
+    </template>);
+
+    assert.dom('[data-checkbox-1]').hasAttribute('readonly');
+  });
+
   test('it calls `@onChange` when a checkbox is clicked and can update `@value`', async function (assert) {
     assert.expect(10);
 

--- a/test-app/tests/integration/components/checkbox-group-field-test.gts
+++ b/test-app/tests/integration/components/checkbox-group-field-test.gts
@@ -219,7 +219,7 @@ module('Integration | Component | Fields | CheckboxGroup', function (hooks) {
     assert.dom('[data-checkbox-1]').hasAttribute('readonly');
   });
 
-  test('it sets readonly on the fieldset and all child checkboxes using `@isReadOnly` at the root', async function (assert) {
+  test('it sets readonly on all child checkboxes using `@isReadOnly` at the root', async function (assert) {
     await render(<template>
       <CheckboxGroupField
         @label="Label"
@@ -241,7 +241,6 @@ module('Integration | Component | Fields | CheckboxGroup', function (hooks) {
       </CheckboxGroupField>
     </template>);
 
-    assert.dom('[data-group-field]').hasAttribute('readonly');
     assert.dom('[data-checkbox-1]').hasAttribute('readonly');
     assert.dom('[data-checkbox-2]').hasAttribute('readonly');
   });

--- a/test-app/tests/integration/components/checkbox-group-field-test.gts
+++ b/test-app/tests/integration/components/checkbox-group-field-test.gts
@@ -152,7 +152,7 @@ module('Integration | Component | Fields | CheckboxGroup', function (hooks) {
     assert.dom('[data-checkbox-2]').isChecked();
   });
 
-  test('it disables the fieldset and all child checkboxes using `@isDisabled`', async function (assert) {
+  test('it disables the fieldset and all child checkboxes using `@isDisabled` at the root', async function (assert) {
     await render(<template>
       <CheckboxGroupField
         @label="Label"
@@ -179,6 +179,26 @@ module('Integration | Component | Fields | CheckboxGroup', function (hooks) {
     assert.dom('[data-checkbox-2]').isDisabled();
   });
 
+  test('it sets an individual checkbox to disabled with `@isDisabled`', async function (assert) {
+    await render(<template>
+      <CheckboxGroupField
+        @label="Label"
+        @name="group"
+        data-group-field
+        as |group|
+      >
+        <group.CheckboxField
+          @label="label 1"
+          @value="option-1"
+          @isDisabled={{true}}
+          data-checkbox-1
+        />
+      </CheckboxGroupField>
+    </template>);
+
+    assert.dom('[data-checkbox-1]').isDisabled();
+  });
+
   test('it sets an individual checkbox to readonly with `@isReadOnly`', async function (assert) {
     await render(<template>
       <CheckboxGroupField
@@ -197,6 +217,33 @@ module('Integration | Component | Fields | CheckboxGroup', function (hooks) {
     </template>);
 
     assert.dom('[data-checkbox-1]').hasAttribute('readonly');
+  });
+
+  test('it sets readonly on the fieldset and all child checkboxes using `@isReadOnly` at the root', async function (assert) {
+    await render(<template>
+      <CheckboxGroupField
+        @label="Label"
+        @name="group"
+        @isReadOnly={{true}}
+        data-group-field
+        as |group|
+      >
+        <group.CheckboxField
+          @label="label 1"
+          @value="option-1"
+          data-checkbox-1
+        />
+        <group.CheckboxField
+          @label="label 2"
+          @value="option-2"
+          data-checkbox-2
+        />
+      </CheckboxGroupField>
+    </template>);
+
+    assert.dom('[data-group-field]').hasAttribute('readonly');
+    assert.dom('[data-checkbox-1]').hasAttribute('readonly');
+    assert.dom('[data-checkbox-2]').hasAttribute('readonly');
   });
 
   test('it calls `@onChange` when a checkbox is clicked and can update `@value`', async function (assert) {

--- a/test-app/tests/integration/components/checkbox-test.gts
+++ b/test-app/tests/integration/components/checkbox-test.gts
@@ -25,6 +25,8 @@ module('Integration | Component | Checkbox', function (hooks) {
 
     assert.dom('[data-checkbox]').hasClass('bg-normal-idle');
     assert.dom('[data-checkbox]').doesNotHaveClass('border-disabled');
+
+    assert.dom('[data-checkbox]').hasNoAttribute('readonly');
   });
 
   test('it disables the checkbox using `@isDisabled`', async function (assert) {
@@ -40,6 +42,16 @@ module('Integration | Component | Checkbox', function (hooks) {
     assert.dom('[data-checkbox]').hasClass('bg-transparent');
     assert.dom('[data-checkbox]').doesNotHaveClass('bg-primary-idle');
     assert.dom('[data-checkbox]').doesNotHaveClass('border-none');
+  });
+
+  test('it sets readonly on the checkbox using `@isReadOnly`', async function (assert) {
+    await render(<template>
+      {{! we do not require a label, but instead suggest using Field / TextareaField }}
+      {{! template-lint-disable require-input-label }}
+      <CheckboxControl @isReadOnly={{true}} data-checkbox />
+    </template>);
+
+    assert.dom('[data-checkbox]').hasAttribute('readonly');
   });
 
   test('it makes the checkbox checked using `@isChecked`', async function (assert) {
@@ -93,6 +105,43 @@ module('Integration | Component | Checkbox', function (hooks) {
     assert.dom('[data-checkbox]').hasClass('bg-disabled');
     assert.dom('[data-checkbox]').hasClass('border-none');
     assert.dom('[data-checkbox]').hasNoClass('bg-primary-idle');
+  });
+
+  test('it applies the expected classes when `@isChecked={{true}}` and `@isReadOnly={{true}}', async function (assert) {
+    await render(<template>
+      {{! we do not require a label, but instead suggest using Field / TextareaField }}
+      {{! template-lint-disable require-input-label }}
+      <CheckboxControl @isChecked={{true}} @isReadOnly={{true}} data-checkbox />
+    </template>);
+
+    assert.dom('[data-checkbox]').hasClass('bg-titles-and-attributes');
+    assert.dom('[data-checkbox]').hasClass('border-none');
+    assert.dom('[data-checkbox]').hasNoClass('bg-primary-idle');
+    assert.dom('[data-checkbox]').hasNoClass('bg-transparent');
+    assert.dom('[data-checkbox]').hasNoClass('bg-surface-xl');
+    assert.dom('[data-checkbox]').hasNoClass('bg-normal-idle');
+    assert.dom('[data-checkbox]').hasNoClass('bg-disabled');
+    assert.dom('[data-checkbox]').hasNoClass('border-disabled');
+  });
+
+  test('it applies the expected classes when `@isChecked={{false}}` and `@isReadOnly={{true}}', async function (assert) {
+    await render(<template>
+      {{! we do not require a label, but instead suggest using Field / TextareaField }}
+      {{! template-lint-disable require-input-label }}
+      <CheckboxControl
+        @isChecked={{false}}
+        @isReadOnly={{true}}
+        data-checkbox
+      />
+    </template>);
+
+    assert.dom('[data-checkbox]').hasClass('bg-surface-xl');
+    assert.dom('[data-checkbox]').hasNoClass('bg-primary-idle');
+    assert.dom('[data-checkbox]').hasNoClass('bg-transparent');
+    assert.dom('[data-checkbox]').hasNoClass('bg-titles-and-attributes');
+    assert.dom('[data-checkbox]').hasNoClass('bg-normal-idle');
+    assert.dom('[data-checkbox]').hasNoClass('bg-disabled');
+    assert.dom('[data-checkbox]').hasNoClass('border-disabled');
   });
 
   test('it spreads attributes to the underlying checkbox', async function (assert) {

--- a/test-app/tests/integration/components/file-input-field-test.gts
+++ b/test-app/tests/integration/components/file-input-field-test.gts
@@ -188,6 +188,21 @@ module('Integration | Component | Fields | FileInput', function (hooks) {
     assert.dom('[data-file-input-field]').hasClass('text-disabled');
   });
 
+  test('it sets readonly on the input using `@isReadOnly`', async function (assert) {
+    await render(<template>
+      <FileInputField
+        @deleteLabel="Delete File"
+        @label="Label"
+        @trigger="Select Files"
+        @isReadOnly={{true}}
+        @onChange={{onChange}}
+        data-file-input-field
+      />
+    </template>);
+
+    assert.dom('[data-file-input-field]').hasAttribute('readonly');
+  });
+
   test('it spreads attributes to the underlying file-input-field', async function (assert) {
     await render(<template>
       <FileInputField

--- a/test-app/tests/integration/components/file-input-test.gts
+++ b/test-app/tests/integration/components/file-input-test.gts
@@ -12,9 +12,21 @@ module(
     setupRenderingTest(hooks);
 
     test('it renders', async function (assert) {
-      await render(<template><FileInput @trigger="Select Files" /></template>);
+      await render(<template>
+        <FileInput @trigger="Select Files" data-input />
+      </template>);
 
-      assert.dom('input').exists();
+      assert.dom('[data-input]').exists();
+
+      assert.dom('[data-input]').hasNoAttribute('readonly');
+    });
+
+    test('it sets readonly on the input using `@isReadOnly`', async function (assert) {
+      await render(<template>
+        <FileInput @trigger="Select Files" @isReadOnly={{true}} data-input />
+      </template>);
+
+      assert.dom('[data-input]').hasAttribute('readonly');
     });
   }
 );

--- a/test-app/tests/integration/components/input-field-test.gts
+++ b/test-app/tests/integration/components/input-field-test.gts
@@ -214,4 +214,20 @@ module('Integration | Component | Fields | Input', function (hooks) {
 
     assert.dom('[data-character]').hasText('11 / 255');
   });
+
+  test('it disables the input using `@isDisabled`', async function (assert) {
+    await render(<template>
+      <InputField @label="Label" @isDisabled={{true}} data-input />
+    </template>);
+
+    assert.dom('[data-input]').isDisabled();
+  });
+
+  test('it sets readonly on the input using `@isReadOnly`', async function (assert) {
+    await render(<template>
+      <InputField @label="Label" @isReadOnly={{true}} data-input />
+    </template>);
+
+    assert.dom('[data-input]').hasAttribute('readonly');
+  });
 });

--- a/test-app/tests/integration/components/input-test.gts
+++ b/test-app/tests/integration/components/input-test.gts
@@ -39,6 +39,23 @@ module('Integration | Component | Input', function (hooks) {
     assert.dom('[data-input]').doesNotHaveClass('text-titles-and-attributes');
   });
 
+  test('it sets readonly on the input using `@isReadOnly`', async function (assert) {
+    await render(<template>
+      {{! we do not require a label, but instead suggest using Field / TextareaField }}
+      {{! template-lint-disable require-input-label }}
+      <InputControl @isReadOnly={{true}} data-input />
+    </template>);
+
+    assert.dom('[data-input]').hasAttribute('readonly');
+
+    assert.dom('[data-input]').hasClass('shadow-read-only-outline');
+    assert.dom('[data-input]').hasClass('bg-surface-xl');
+    assert.dom('[data-input]').hasNoClass('bg-overlay-1');
+    assert.dom('[data-input]').hasNoClass('text-disabled');
+    assert.dom('[data-input]').hasNoClass('shadow-error-outline');
+    assert.dom('[data-input]').hasNoClass('shadow-focusable-outline');
+  });
+
   test('it spreads attributes to the underlying input', async function (assert) {
     await render(<template>
       {{! we do not require a label, but instead suggest using Field / InputField }}

--- a/test-app/tests/integration/components/radio-field-test.gts
+++ b/test-app/tests/integration/components/radio-field-test.gts
@@ -91,6 +91,20 @@ module('Integration | Component | Fields | Radio', function (hooks) {
     assert.dom('[data-radio]').isDisabled();
   });
 
+  test('it sets readonly on the radio using `@isReadOnly`', async function (assert) {
+    await render(<template>
+      <RadioField
+        @value="option"
+        @name="name"
+        @label="Label"
+        @isReadOnly={{true}}
+        data-radio
+      />
+    </template>);
+
+    assert.dom('[data-radio]').hasAttribute('readonly');
+  });
+
   test('it spreads attributes to the underlying radio', async function (assert) {
     await render(<template>
       <RadioField

--- a/test-app/tests/integration/components/radio-group-field-test.gts
+++ b/test-app/tests/integration/components/radio-group-field-test.gts
@@ -149,7 +149,7 @@ module('Integration | Component | Fields | RadioGroup', function (hooks) {
     assert.dom('[data-radio-1]').hasAttribute('readonly');
   });
 
-  test('it sets readonly on the fieldset and all child radios using `@isReadOnly` at the root', async function (assert) {
+  test('it sets readonly on all child radios using `@isReadOnly` at the root', async function (assert) {
     await render(<template>
       <RadioGroupField
         @label="Label"
@@ -163,7 +163,6 @@ module('Integration | Component | Fields | RadioGroup', function (hooks) {
       </RadioGroupField>
     </template>);
 
-    assert.dom('[data-group-field]').hasAttribute('readonly');
     assert.dom('[data-radio-1]').hasAttribute('readonly');
     assert.dom('[data-radio-2]').hasAttribute('readonly');
   });

--- a/test-app/tests/integration/components/radio-group-field-test.gts
+++ b/test-app/tests/integration/components/radio-group-field-test.gts
@@ -119,6 +119,21 @@ module('Integration | Component | Fields | RadioGroup', function (hooks) {
     assert.dom('[data-radio-2]').isDisabled();
   });
 
+  test('it sets an individual radio to readonly with `@isReadOnly`', async function (assert) {
+    await render(<template>
+      <RadioGroupField @label="Label" @name="group" data-group-field as |group|>
+        <group.RadioField
+          @label="option-1"
+          @value="option-1"
+          @isReadOnly={{true}}
+          data-radio-1
+        />
+      </RadioGroupField>
+    </template>);
+
+    assert.dom('[data-radio-1]').hasAttribute('readonly');
+  });
+
   test('it calls `@onChange` when a radio is clicked and can update `@value`', async function (assert) {
     assert.expect(8);
 

--- a/test-app/tests/integration/components/radio-group-field-test.gts
+++ b/test-app/tests/integration/components/radio-group-field-test.gts
@@ -100,7 +100,7 @@ module('Integration | Component | Fields | RadioGroup', function (hooks) {
     assert.dom('[data-radio-2]').isChecked();
   });
 
-  test('it disables the fieldset and all child radios using `@isDisabled`', async function (assert) {
+  test('it disables the fieldset and all child radios using `@isDisabled` at the root', async function (assert) {
     await render(<template>
       <RadioGroupField
         @label="Label"
@@ -119,6 +119,21 @@ module('Integration | Component | Fields | RadioGroup', function (hooks) {
     assert.dom('[data-radio-2]').isDisabled();
   });
 
+  test('it sets an individual radio to disabled with `@isDisabled`', async function (assert) {
+    await render(<template>
+      <RadioGroupField @label="Label" @name="group" data-group-field as |group|>
+        <group.RadioField
+          @label="option-1"
+          @value="option-1"
+          @isDisabled={{true}}
+          data-radio-1
+        />
+      </RadioGroupField>
+    </template>);
+
+    assert.dom('[data-radio-1]').isDisabled();
+  });
+
   test('it sets an individual radio to readonly with `@isReadOnly`', async function (assert) {
     await render(<template>
       <RadioGroupField @label="Label" @name="group" data-group-field as |group|>
@@ -132,6 +147,25 @@ module('Integration | Component | Fields | RadioGroup', function (hooks) {
     </template>);
 
     assert.dom('[data-radio-1]').hasAttribute('readonly');
+  });
+
+  test('it sets readonly on the fieldset and all child radios using `@isReadOnly` at the root', async function (assert) {
+    await render(<template>
+      <RadioGroupField
+        @label="Label"
+        @name="group"
+        @isReadOnly={{true}}
+        data-group-field
+        as |group|
+      >
+        <group.RadioField @label="option-1" @value="option-1" data-radio-1 />
+        <group.RadioField @label="option-2" @value="option-2" data-radio-2 />
+      </RadioGroupField>
+    </template>);
+
+    assert.dom('[data-group-field]').hasAttribute('readonly');
+    assert.dom('[data-radio-1]').hasAttribute('readonly');
+    assert.dom('[data-radio-2]').hasAttribute('readonly');
   });
 
   test('it calls `@onChange` when a radio is clicked and can update `@value`', async function (assert) {

--- a/test-app/tests/integration/components/radio-test.gts
+++ b/test-app/tests/integration/components/radio-test.gts
@@ -22,6 +22,8 @@ module('Integration | Component | Radio', function (hooks) {
     assert.dom('[data-radio]').hasAttribute('value', 'option');
 
     assert.dom('[data-radio]').isNotChecked();
+
+    assert.dom('[data-radio]').hasNoAttribute('readonly');
   });
 
   test('it disables the radio using `@isDisabled`', async function (assert) {
@@ -38,6 +40,16 @@ module('Integration | Component | Radio', function (hooks) {
     assert.dom('[data-radio]').doesNotHaveClass('bg-primary-idle');
     assert.dom('[data-radio]').doesNotHaveClass('bg-disabled');
     assert.dom('[data-radio]').doesNotHaveClass('border-none');
+  });
+
+  test('it sets readonly on the radio using `@isReadOnly`', async function (assert) {
+    await render(<template>
+      {{! we do not require a label, but instead suggest using Field / TextareaField }}
+      {{! template-lint-disable require-input-label }}
+      <RadioControl @value="option" @isReadOnly={{true}} data-radio />
+    </template>);
+
+    assert.dom('[data-radio]').hasAttribute('readonly');
   });
 
   test('it makes the radio checked using `@isChecked={{true}}`', async function (assert) {
@@ -116,6 +128,49 @@ module('Integration | Component | Radio', function (hooks) {
     assert.dom('[data-radio]').doesNotHaveClass('bg-transparent');
     assert.dom('[data-radio]').doesNotHaveClass('bg-normal-idle');
     assert.dom('[data-radio]').doesNotHaveClass('border-disabled');
+  });
+
+  test('it applies the expected classes when `@isChecked={{true}}` and `@isReadOnly={{true}}', async function (assert) {
+    await render(<template>
+      {{! we do not require a label, but instead suggest using Field / TextareaField }}
+      {{! template-lint-disable require-input-label }}
+      <RadioControl
+        @value="option"
+        @isChecked={{true}}
+        @isReadOnly={{true}}
+        data-radio
+      />
+    </template>);
+
+    assert.dom('[data-radio]').hasClass('bg-titles-and-attributes');
+    assert.dom('[data-radio]').hasClass('border-none');
+    assert.dom('[data-radio]').hasNoClass('bg-primary-idle');
+    assert.dom('[data-radio]').hasNoClass('bg-transparent');
+    assert.dom('[data-radio]').hasNoClass('bg-surface-xl');
+    assert.dom('[data-radio]').hasNoClass('bg-normal-idle');
+    assert.dom('[data-radio]').hasNoClass('bg-disabled');
+    assert.dom('[data-radio]').hasNoClass('border-disabled');
+  });
+
+  test('it applies the expected classes when `@isChecked={{false}}` and `@isReadOnly={{true}}', async function (assert) {
+    await render(<template>
+      {{! we do not require a label, but instead suggest using Field / TextareaField }}
+      {{! template-lint-disable require-input-label }}
+      <RadioControl
+        @value="option"
+        @isChecked={{false}}
+        @isReadOnly={{true}}
+        data-radio
+      />
+    </template>);
+
+    assert.dom('[data-radio]').hasClass('bg-surface-xl');
+    assert.dom('[data-radio]').hasNoClass('bg-primary-idle');
+    assert.dom('[data-radio]').hasNoClass('bg-transparent');
+    assert.dom('[data-radio]').hasNoClass('bg-titles-and-attributes');
+    assert.dom('[data-radio]').hasNoClass('bg-normal-idle');
+    assert.dom('[data-radio]').hasNoClass('bg-disabled');
+    assert.dom('[data-radio]').hasNoClass('border-disabled');
   });
 
   test('it spreads attributes to the underlying radio', async function (assert) {

--- a/test-app/tests/integration/components/textarea-field-test.gts
+++ b/test-app/tests/integration/components/textarea-field-test.gts
@@ -124,6 +124,14 @@ module('Integration | Component | Fields | Textarea', function (hooks) {
     assert.dom('[data-textarea]').hasClass('text-disabled');
   });
 
+  test('it sets readonly on the textarea using `@isReadOnly`', async function (assert) {
+    await render(<template>
+      <TextareaField @label="Label" @isReadOnly={{true}} data-textarea />
+    </template>);
+
+    assert.dom('[data-textarea]').hasAttribute('readonly');
+  });
+
   test('it spreads attributes to the underlying textarea', async function (assert) {
     await render(<template>
       <TextareaField

--- a/test-app/tests/integration/components/textarea-test.gts
+++ b/test-app/tests/integration/components/textarea-test.gts
@@ -41,6 +41,23 @@ module('Integration | Component | Textarea', function (hooks) {
       .doesNotHaveClass('text-titles-and-attributes');
   });
 
+  test('it sets readonly on the textarea using `@isReadOnly`', async function (assert) {
+    await render(<template>
+      {{! we do not require a label, but instead suggest using Field / TextareaField }}
+      {{! template-lint-disable require-input-label }}
+      <TextareaControl @isReadOnly={{true}} data-textarea />
+    </template>);
+
+    assert.dom('[data-textarea]').hasAttribute('readonly');
+
+    assert.dom('[data-textarea]').hasClass('shadow-read-only-outline');
+    assert.dom('[data-textarea]').hasClass('bg-surface-xl');
+    assert.dom('[data-textarea]').hasNoClass('bg-overlay-1');
+    assert.dom('[data-textarea]').hasNoClass('text-disabled');
+    assert.dom('[data-textarea]').hasNoClass('shadow-error-outline');
+    assert.dom('[data-textarea]').hasNoClass('shadow-focusable-outline');
+  });
+
   test('it spreads attributes to the underlying textarea', async function (assert) {
     await render(<template>
       {{! we do not require a label, but instead suggest using Field / TextareaField }}


### PR DESCRIPTION
## 🚀 Description

This PR adds `@isReadOnly` support to all controls and fields that support it.

---

## 🔬 How to Test

Visit the following pages and verify the read only states:

- https://202bc927.ember-toucan-core.pages.dev/docs/components/checkbox-field#checkboxfield-with-ischecked-and-isreadonly
- https://202bc927.ember-toucan-core.pages.dev/docs/components/file-input-field#fileinputfield-with-isreadonly
- https://202bc927.ember-toucan-core.pages.dev/docs/components/input-field#inputfield-with-isreadonly-and-a-value
- https://202bc927.ember-toucan-core.pages.dev/docs/components/radio-group-field#radiogroupfield-with-label-and-all-read-only-with-one-checked
- https://202bc927.ember-toucan-core.pages.dev/docs/components/textarea-field#textareafield-with-isreadonly-and-a-value

---

## 📸 Images/Videos of Functionality

I got this visually design-approved with Mary and David 🎉 

<img width="505" alt="Screenshot 2023-04-20 at 11 15 12 AM" src="https://user-images.githubusercontent.com/8069555/233410542-231b35ca-dbc6-43c8-a2e3-e4ab6e89f25c.png">

<img width="322" alt="Screenshot 2023-04-20 at 11 16 02 AM" src="https://user-images.githubusercontent.com/8069555/233410804-dcc9f591-3040-4fdb-94e2-8815da479380.png">

<img width="411" alt="Screenshot 2023-04-20 at 11 17 00 AM" src="https://user-images.githubusercontent.com/8069555/233411058-1d1cf1d2-2ac3-4d5e-8e98-286e032fb6b0.png">

<img width="224" alt="Screenshot 2023-04-20 at 11 17 17 AM" src="https://user-images.githubusercontent.com/8069555/233411237-a642ee07-887d-4147-9068-b3a7be3d9db8.png">

<img width="633" alt="Screenshot 2023-04-20 at 11 17 57 AM" src="https://user-images.githubusercontent.com/8069555/233411321-16e96822-10d7-4940-a149-422433bb4838.png">

<img width="440" alt="Screenshot 2023-04-20 at 11 18 16 AM" src="https://user-images.githubusercontent.com/8069555/233411408-de777a01-54e7-4fc2-b4df-41391e5b4983.png">
