### PR TITLE
feat: Add Input support to toucan-form

### DIFF
--- a/docs/toucan-form/changeset-validation/demo/base-demo.md
+++ b/docs/toucan-form/changeset-validation/demo/base-demo.md
@@ -7,6 +7,8 @@
   @validate={{validate-changeset}}
   as |form|
 >
+  <form.Input @label='First name' @name='firstName' />
+  <form.Input @label='Last name' @name='lastName' />
   <form.Textarea @label='Comment' @name='comment' />
 
   <Button type='submit'>Submit</Button>
@@ -26,14 +28,18 @@ export default class extends Component {
 
   validations = {
     comment: validatePresence(true),
+    firstName: validatePresence(true),
+    lastName: validatePresence(true),
   };
 
   handleSubmit(data) {
     console.log({ data });
 
-    const { comment } = data;
-
-    alert(`Form submitted with: ${comment}`);
+    alert(
+      `Form submitted with:\n${Object.entries(data.get('pendingData'))
+        .map(([key, value]) => `${key}: ${value}`)
+        .join('\n')}`
+    );
   }
 }
 ```

--- a/docs/toucan-form/native-validation/demo/base-demo.md
+++ b/docs/toucan-form/native-validation/demo/base-demo.md
@@ -5,7 +5,10 @@
   @onSubmit={{this.handleSubmit}}
   as |form|
 >
+  <form.Input @label='First name' @name='firstName' required />
+  <form.Input @label='Last name' @name='lastName' required />
   <form.Textarea @label='Comment' @name='comment' required />
+
   <Button type='submit'>Submit</Button>
 </ToucanForm>
 ```
@@ -15,15 +18,17 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 
 export default class extends Component {
-  data = { comment: null };
+  data = {};
 
   @action
   handleSubmit(data) {
     console.log({ data });
 
-    const { comment } = data;
-
-    alert(`Form submitted with: ${comment}`);
+    alert(
+      `Form submitted with:\n${Object.entries(data)
+        .map(([key, value]) => `${key}: ${value}`)
+        .join('\n')}`
+    );
   }
 }
 ```

--- a/packages/ember-toucan-core/src/components/form/fields/input.ts
+++ b/packages/ember-toucan-core/src/components/form/fields/input.ts
@@ -5,7 +5,7 @@ import assertBlockOrArgumentExists from '../../../-private/assert-block-or-argum
 import type { AssertBlockOrArg } from '../../../-private/assert-block-or-argument-exists';
 import type { ErrorMessage, OnChangeCallback } from '../../../-private/types';
 
-interface ToucanFormInputFieldComponentSignature {
+export interface ToucanFormInputFieldComponentSignature {
   Element: HTMLInputElement;
   Args: {
     /**

--- a/packages/ember-toucan-form/src/-private/input-field.hbs
+++ b/packages/ember-toucan-form/src/-private/input-field.hbs
@@ -1,10 +1,10 @@
 <@form.Field @name={{@name}} as |field|>
-  <Form::Fields::Textarea
+  <Form::Fields::Input
     @label={{@label}}
     @hint={{@hint}}
     @error={{this.mapErrors field.rawErrors}}
     @value={{this.assertString field.value}}
-    {{! The issue here is that onChange of textarea only expects a string typed value, but field.setValue is generic, accepting anything that DATA[KEY] could be. Similar case with @value, but there casting to a string is easy. }}
+    {{! The issue here is that onChange of input only expects a string typed value, but field.setValue is generic, accepting anything that DATA[KEY] could be. Similar case with @value, but there casting to a string is easy. }}
     {{! @glint-expect-error }}
     @onChange={{field.setValue}}
     @isDisabled={{@isDisabled}}

--- a/packages/ember-toucan-form/src/-private/input-field.ts
+++ b/packages/ember-toucan-form/src/-private/input-field.ts
@@ -1,0 +1,59 @@
+import Component from '@glimmer/component';
+import { assert } from '@ember/debug';
+import { action } from '@ember/object';
+
+import type { HeadlessFormBlock, UserData } from './types';
+import type { ToucanFormInputFieldComponentSignature as BaseInputFieldSignature } from '@crowdstrike/ember-toucan-core/components/form/fields/input';
+import type { FormData, FormKey, ValidationError } from 'ember-headless-form';
+
+type ComponentArguments<
+  DATA extends UserData,
+  KEY extends FormKey<FormData<DATA>> = FormKey<FormData<DATA>>
+> = Omit<BaseInputFieldSignature['Args'], 'error' | 'value' | 'onChange'> & {
+  /**
+   * The name of your field, which must match a property of the `@data` passed to the form
+   */
+  name: KEY;
+
+  /*
+   * @internal
+   */
+  form: HeadlessFormBlock<DATA>;
+};
+
+export interface ToucanFormInputFieldComponentSignature<
+  DATA extends UserData,
+  KEY extends FormKey<FormData<DATA>> = FormKey<FormData<DATA>>
+> {
+  Element: HTMLInputElement;
+  Args: ComponentArguments<DATA, KEY>;
+  Blocks: {
+    default: [];
+  };
+}
+
+export default class ToucanFormInputFieldComponent<
+  DATA extends UserData,
+  KEY extends FormKey<FormData<DATA>> = FormKey<FormData<DATA>>
+> extends Component<ToucanFormInputFieldComponentSignature<DATA, KEY>> {
+  mapErrors = (errors?: ValidationError[]) => {
+    if (!errors) {
+      return;
+    }
+
+    // @todo we need to figure out what to do when message is undefined
+    return errors.map((error) => error.message ?? error.type);
+  };
+
+  @action
+  assertString(value: unknown): string | undefined {
+    assert(
+      `Only string values are expected for ${String(
+        this.args.name
+      )}, but you passed ${typeof value}`,
+      typeof value === 'undefined' || typeof value === 'string'
+    );
+
+    return value;
+  }
+}

--- a/packages/ember-toucan-form/src/-private/input-field.ts
+++ b/packages/ember-toucan-form/src/-private/input-field.ts
@@ -6,27 +6,25 @@ import type { HeadlessFormBlock, UserData } from './types';
 import type { ToucanFormInputFieldComponentSignature as BaseInputFieldSignature } from '@crowdstrike/ember-toucan-core/components/form/fields/input';
 import type { FormData, FormKey, ValidationError } from 'ember-headless-form';
 
-type ComponentArguments<
-  DATA extends UserData,
-  KEY extends FormKey<FormData<DATA>> = FormKey<FormData<DATA>>
-> = Omit<BaseInputFieldSignature['Args'], 'error' | 'value' | 'onChange'> & {
-  /**
-   * The name of your field, which must match a property of the `@data` passed to the form
-   */
-  name: KEY;
-
-  /*
-   * @internal
-   */
-  form: HeadlessFormBlock<DATA>;
-};
-
 export interface ToucanFormInputFieldComponentSignature<
   DATA extends UserData,
   KEY extends FormKey<FormData<DATA>> = FormKey<FormData<DATA>>
 > {
   Element: HTMLInputElement;
-  Args: ComponentArguments<DATA, KEY>;
+  Args: Omit<
+    BaseInputFieldSignature['Args'],
+    'error' | 'value' | 'onChange'
+  > & {
+    /**
+     * The name of your field, which must match a property of the `@data` passed to the form
+     */
+    name: KEY;
+
+    /*
+     * @internal
+     */
+    form: HeadlessFormBlock<DATA>;
+  };
   Blocks: {
     default: [];
   };

--- a/packages/ember-toucan-form/src/-private/textarea-field.ts
+++ b/packages/ember-toucan-form/src/-private/textarea-field.ts
@@ -6,27 +6,25 @@ import type { HeadlessFormBlock, UserData } from './types';
 import type { ToucanFormTextareaFieldComponentSignature as BaseTextareaFieldSignature } from '@crowdstrike/ember-toucan-core/components/form/fields/textarea';
 import type { FormData, FormKey, ValidationError } from 'ember-headless-form';
 
-type ComponentArguments<
-  DATA extends UserData,
-  KEY extends FormKey<FormData<DATA>> = FormKey<FormData<DATA>>
-> = Omit<BaseTextareaFieldSignature['Args'], 'error' | 'value' | 'onChange'> & {
-  /**
-   * The name of your field, which must match a property of the `@data` passed to the form
-   */
-  name: KEY;
-
-  /*
-   * @internal
-   */
-  form: HeadlessFormBlock<DATA>;
-};
-
 export interface ToucanFormTextareaFieldComponentSignature<
   DATA extends UserData,
   KEY extends FormKey<FormData<DATA>> = FormKey<FormData<DATA>>
 > {
   Element: HTMLTextAreaElement;
-  Args: ComponentArguments<DATA, KEY>;
+  Args: Omit<
+    BaseTextareaFieldSignature['Args'],
+    'error' | 'value' | 'onChange'
+  > & {
+    /**
+     * The name of your field, which must match a property of the `@data` passed to the form
+     */
+    name: KEY;
+
+    /*
+     * @internal
+     */
+    form: HeadlessFormBlock<DATA>;
+  };
   Blocks: {
     default: [];
   };

--- a/packages/ember-toucan-form/src/components/toucan-form.hbs
+++ b/packages/ember-toucan-form/src/components/toucan-form.hbs
@@ -14,6 +14,9 @@
       Textarea=(component
         (ensure-safe-component this.TextareaFieldComponent) form=form
       )
+      Input=(component
+        (ensure-safe-component this.InputFieldComponent) form=form
+      )
       Field=form.Field
     )
   }}

--- a/packages/ember-toucan-form/src/components/toucan-form.ts
+++ b/packages/ember-toucan-form/src/components/toucan-form.ts
@@ -1,5 +1,6 @@
 import Component from '@glimmer/component';
 
+import InputFieldComponent from '../-private/input-field';
 import TextareaFieldComponent from '../-private/textarea-field';
 
 import type { HeadlessFormBlock, UserData } from '../-private/types';
@@ -21,6 +22,7 @@ export interface ToucanFormComponentSignature<
     default: [
       {
         Textarea: WithBoundArgs<typeof TextareaFieldComponent<DATA>, 'form'>;
+        Input: WithBoundArgs<typeof InputFieldComponent<DATA>, 'form'>;
         Field: HeadlessFormBlock<DATA>['Field'];
       }
     ];
@@ -32,6 +34,7 @@ export default class ToucanFormComponent<
   SUBMISSION_VALUE
 > extends Component<ToucanFormComponentSignature<DATA, SUBMISSION_VALUE>> {
   TextareaFieldComponent = TextareaFieldComponent<DATA>;
+  InputFieldComponent = InputFieldComponent<DATA>;
 
   get validateOn() {
     let { validateOn } = this.args;

--- a/test-app/tests/integration/components/toucan-form/toucan-form-test.gts
+++ b/test-app/tests/integration/components/toucan-form/toucan-form-test.gts
@@ -2,9 +2,11 @@
 /* eslint-disable simple-import-sort/imports,padding-line-between-statements,decorator-position/decorator-position -- Can't fix these manually, without --fix working in .gts */
 import { click, fillIn, render } from '@ember/test-helpers';
 import { module, test } from 'qunit';
+import { setupRenderingTest } from 'test-app/tests/helpers';
 
 import ToucanForm from '@crowdstrike/ember-toucan-form/components/toucan-form';
-import { setupRenderingTest } from 'test-app/tests/helpers';
+
+import type { ErrorRecord } from 'ember-headless-form';
 
 module('Integration | Component | ToucanForm', function (hooks) {
   setupRenderingTest(hooks);
@@ -62,7 +64,12 @@ module('Integration | Component | ToucanForm', function (hooks) {
   });
 
   test('it triggers validation and shows error messages in the Toucan Core components', async function (assert) {
-    const data: { comment?: string; firstName?: string } = {};
+    interface TestData {
+      comment?: string;
+      firstName?: string;
+    }
+
+    const data: TestData = {};
 
     const formValidateCallback = ({
       comment,
@@ -71,10 +78,10 @@ module('Integration | Component | ToucanForm', function (hooks) {
       comment?: string;
       firstName?: string;
     }) => {
-      let errors: Record<string, unknown> = {};
+      let errors: ErrorRecord<TestData> = {};
 
       if (!comment) {
-        errors['comment'] = [
+        errors.comment = [
           {
             type: 'required',
             value: comment,
@@ -84,7 +91,7 @@ module('Integration | Component | ToucanForm', function (hooks) {
       }
 
       if (!firstName) {
-        errors['firstName'] = [
+        errors.firstName = [
           {
             type: 'required',
             value: firstName,


### PR DESCRIPTION
## 🚀 Description

This PR builds on top of https://github.com/CrowdStrike/ember-toucan-core/pull/129/files, by adding `Input` support to `ToucanForm`.

Follow up work after this PR merges:

- Cut a release so we can get some feedback
- Add Checkbox support
- Add CheckboxGroup support
- Add RadioGroup support
- Add FileInput support
- Add named-block support to all of above
- Convert to using the `<template>` tag

Usage is:

```hbs template
<ToucanForm
  class='space-y-4'
  @data={{this.data}}
  @onSubmit={{this.handleSubmit}}
  as |form|
>
  <form.Input @label='First name' @name='firstName' required />
  <form.Input @label='Last name' @name='lastName' required />
  <form.Textarea @label='Comment' @name='comment' required />

  <Button type='submit'>Submit</Button>
</ToucanForm>
```

```js component
import Component from '@glimmer/component';
import { action } from '@ember/object';

export default class extends Component {
  data = {};

  @action
  handleSubmit(data) {
    console.log({ data });

    alert(
      `Form submitted with:\n${Object.entries(data)
        .map(([key, value]) => `${key}: ${value}`)
        .join('\n')}`
    );
  }
}
```


---

## 🔬 How to Test

- Green build
- Visit https://be7e8d7f.ember-toucan-core.pages.dev/docs/toucan-form/changeset-validation
  - Press the Submit button
  - Verify errors show on all inputs and textareas
  - Type into each field to satisfy the requirements
  - Click Submit
  - Verify an alert is displayed with the data entered
- Do the same thing as above on https://be7e8d7f.ember-toucan-core.pages.dev/docs/toucan-form/native-validation

---

## 📸 Images/Videos of Functionality

https://user-images.githubusercontent.com/8069555/232078376-c77f175a-56e3-43db-b04f-0db77fc0f3a0.mov



