### PR TITLE
toucan-form: Add Checkbox support

### DIFF
--- a/docs/toucan-form/changeset-validation/demo/base-demo.md
+++ b/docs/toucan-form/changeset-validation/demo/base-demo.md
@@ -10,6 +10,7 @@
   <form.Input @label='First name' @name='firstName' />
   <form.Input @label='Last name' @name='lastName' />
   <form.Textarea @label='Comment' @name='comment' />
+  <form.Checkbox @label='Agree to the Terms' @name='terms' />
 
   <Button type='submit'>Submit</Button>
 </ToucanForm>
@@ -30,6 +31,7 @@ export default class extends Component {
     comment: validatePresence(true),
     firstName: validatePresence(true),
     lastName: validatePresence(true),
+    terms: validatePresence(true),
   };
 
   handleSubmit(data) {

--- a/docs/toucan-form/native-validation/demo/base-demo.md
+++ b/docs/toucan-form/native-validation/demo/base-demo.md
@@ -8,6 +8,7 @@
   <form.Input @label='First name' @name='firstName' required />
   <form.Input @label='Last name' @name='lastName' required />
   <form.Textarea @label='Comment' @name='comment' required />
+  <form.Checkbox @label='Agree to the Terms' @name='terms' required />
 
   <Button type='submit'>Submit</Button>
 </ToucanForm>

--- a/packages/ember-toucan-form/src/-private/checkbox-field.hbs
+++ b/packages/ember-toucan-form/src/-private/checkbox-field.hbs
@@ -1,0 +1,15 @@
+<@form.Field @name={{@name}} as |field|>
+  <Form::Fields::Checkbox
+    @label={{@label}}
+    @hint={{@hint}}
+    @error={{this.mapErrors field.rawErrors}}
+    @isChecked={{this.assertBoolean field.value}}
+    {{! The issue here is that onChange only expects a string typed value, but field.setValue is generic, accepting anything that DATA[KEY] could be. }}
+    {{! @glint-expect-error }}
+    @onChange={{field.setValue}}
+    @isDisabled={{@isDisabled}}
+    @rootTestSelector={{@rootTestSelector}}
+    name={{@name}}
+    ...attributes
+  />
+</@form.Field>

--- a/packages/ember-toucan-form/src/-private/checkbox-field.ts
+++ b/packages/ember-toucan-form/src/-private/checkbox-field.ts
@@ -1,0 +1,57 @@
+import Component from '@glimmer/component';
+import { assert } from '@ember/debug';
+import { action } from '@ember/object';
+
+import type { HeadlessFormBlock, UserData } from './types';
+import type { ToucanFormCheckboxFieldComponentSignature as BaseCheckboxFieldSignature } from '@crowdstrike/ember-toucan-core/components/form/fields/checkbox';
+import type { FormData, FormKey, ValidationError } from 'ember-headless-form';
+
+export interface ToucanFormCheckboxFieldComponentSignature<
+  DATA extends UserData,
+  KEY extends FormKey<FormData<DATA>> = FormKey<FormData<DATA>>
+> {
+  Element: HTMLInputElement;
+  Args: Omit<
+    BaseCheckboxFieldSignature['Args'],
+    'error' | 'isChecked' | 'onChange' | 'name'
+  > & {
+    /**
+     * The name of your field, which must match a property of the `@data` passed to the form
+     */
+    name: KEY;
+
+    /*
+     * @internal
+     */
+    form: HeadlessFormBlock<DATA>;
+  };
+  Blocks: {
+    default: [];
+  };
+}
+
+export default class ToucanFormTextareaFieldComponent<
+  DATA extends UserData,
+  KEY extends FormKey<FormData<DATA>> = FormKey<FormData<DATA>>
+> extends Component<ToucanFormCheckboxFieldComponentSignature<DATA, KEY>> {
+  mapErrors = (errors?: ValidationError[]) => {
+    if (!errors) {
+      return;
+    }
+
+    // @todo we need to figure out what to do when message is undefined
+    return errors.map((error) => error.message ?? error.type);
+  };
+
+  @action
+  assertBoolean(value: unknown): boolean | undefined {
+    assert(
+      `Only boolean values are expected for ${String(
+        this.args.name
+      )}, but you passed ${typeof value}`,
+      typeof value === 'undefined' || typeof value === 'boolean'
+    );
+
+    return value;
+  }
+}

--- a/packages/ember-toucan-form/src/components/toucan-form.hbs
+++ b/packages/ember-toucan-form/src/components/toucan-form.hbs
@@ -11,6 +11,9 @@
 >
   {{yield
     (hash
+      Checkbox=(component
+        (ensure-safe-component this.CheckboxComponent) form=form
+      )
       Textarea=(component
         (ensure-safe-component this.TextareaFieldComponent) form=form
       )

--- a/packages/ember-toucan-form/src/components/toucan-form.ts
+++ b/packages/ember-toucan-form/src/components/toucan-form.ts
@@ -1,5 +1,6 @@
 import Component from '@glimmer/component';
 
+import CheckboxFieldComponent from '../-private/checkbox-field';
 import InputFieldComponent from '../-private/input-field';
 import TextareaFieldComponent from '../-private/textarea-field';
 
@@ -21,6 +22,7 @@ export interface ToucanFormComponentSignature<
   Blocks: {
     default: [
       {
+        Checkbox: WithBoundArgs<typeof CheckboxFieldComponent<DATA>, 'form'>;
         Textarea: WithBoundArgs<typeof TextareaFieldComponent<DATA>, 'form'>;
         Input: WithBoundArgs<typeof InputFieldComponent<DATA>, 'form'>;
         Field: HeadlessFormBlock<DATA>['Field'];
@@ -33,6 +35,7 @@ export default class ToucanFormComponent<
   DATA extends UserData,
   SUBMISSION_VALUE
 > extends Component<ToucanFormComponentSignature<DATA, SUBMISSION_VALUE>> {
+  CheckboxComponent = CheckboxFieldComponent<DATA>;
   TextareaFieldComponent = TextareaFieldComponent<DATA>;
   InputFieldComponent = InputFieldComponent<DATA>;
 


### PR DESCRIPTION
Downstream of https://github.com/CrowdStrike/ember-toucan-core/pull/134

## 🚀 Description

Adds checkbox support to Toucan Form.

---

## 🔬 How to Test

- Visit https://0c35392f.ember-toucan-core.pages.dev/docs/toucan-form/native-validation
- Click submit
- Verify the checkbox element has an error message
- Check the checkbox
- Verify the checkbox error goes away
- Fill out the form and submit it, verify the submitted data has `true` set for `terms`

---

## 📸 Images/Videos of Functionality


https://user-images.githubusercontent.com/8069555/232543282-9fe325e3-def2-4fe5-bcdf-30c8cfa733e0.mov


