### PR TITLE
toucan-form: Add RadioGroup support 

### DIFF
--- a/docs/toucan-form/changeset-validation/demo/base-demo.md
+++ b/docs/toucan-form/changeset-validation/demo/base-demo.md
@@ -1,6 +1,6 @@
 ```hbs template
 <ToucanForm
-  class='space-y-4'
+  class='space-y-4 max-w-xs'
   @data={{changeset this.data this.validations}}
   @dataMode='mutable'
   @onSubmit={{this.handleSubmit}}
@@ -10,6 +10,12 @@
   <form.Input @label='First name' @name='firstName' />
   <form.Input @label='Last name' @name='lastName' />
   <form.Textarea @label='Comment' @name='comment' />
+
+  <form.RadioGroup @label='Radios' @name='radio' as |group|>
+    <group.RadioField @label='option-1' @value='option-1' data-radio-1 />
+    <group.RadioField @label='option-2' @value='option-2' data-radio-2 />
+  </form.RadioGroup>
+
   <form.Checkbox @label='Agree to the Terms' @name='terms' />
 
   <Button type='submit'>Submit</Button>
@@ -31,6 +37,7 @@ export default class extends Component {
     comment: validatePresence(true),
     firstName: validatePresence(true),
     lastName: validatePresence(true),
+    radio: validatePresence(true),
     terms: validatePresence(true),
   };
 

--- a/docs/toucan-form/native-validation/demo/base-demo.md
+++ b/docs/toucan-form/native-validation/demo/base-demo.md
@@ -1,6 +1,6 @@
 ```hbs template
 <ToucanForm
-  class='space-y-4'
+  class='space-y-4 max-w-xs'
   @data={{this.data}}
   @onSubmit={{this.handleSubmit}}
   as |form|
@@ -8,6 +8,17 @@
   <form.Input @label='First name' @name='firstName' required />
   <form.Input @label='Last name' @name='lastName' required />
   <form.Textarea @label='Comment' @name='comment' required />
+
+  <form.RadioGroup @label='Radios' @name='radio' as |group|>
+    <group.RadioField
+      @label='option-1'
+      @value='option-1'
+      data-radio-1
+      required
+    />
+    <group.RadioField @label='option-2' @value='option-2' data-radio-2 />
+  </form.RadioGroup>
+
   <form.Checkbox @label='Agree to the Terms' @name='terms' required />
 
   <Button type='submit'>Submit</Button>

--- a/packages/ember-toucan-core/src/components/form/fields/checkbox-group.hbs
+++ b/packages/ember-toucan-core/src/components/form/fields/checkbox-group.hbs
@@ -2,7 +2,7 @@
   <fieldset
     aria-describedby="{{if @error field.errorId}} {{if @hint field.hintId}}"
     disabled={{@isDisabled}}
-    {{! attribute aria-invalid is not supported by the element fieldset with the implicit role of group }}
+    data-root-field={{if @rootTestSelector @rootTestSelector}}
     ...attributes
   >
     {{#if

--- a/packages/ember-toucan-core/src/components/form/fields/checkbox-group.ts
+++ b/packages/ember-toucan-core/src/components/form/fields/checkbox-group.ts
@@ -43,6 +43,11 @@ export interface ToucanFormCheckboxGroupFieldComponentSignature {
     onChange?: (selectedValues: Array<string>, e: Event | InputEvent) => void;
 
     /**
+     * A test selector for targeting the root element of the field. In this case, the wrapping div element.
+     */
+    rootTestSelector?: string;
+
+    /**
      * The currently selected checkbox elements. The elements with the matching `@value` / underlying value attribute will be checked.
      */
     value?: Array<string>;

--- a/packages/ember-toucan-core/src/components/form/fields/radio-group.hbs
+++ b/packages/ember-toucan-core/src/components/form/fields/radio-group.hbs
@@ -4,6 +4,7 @@
     disabled={{@isDisabled}}
     aria-invalid={{if @error "true"}}
     aria-required="true"
+    data-root-field={{if @rootTestSelector @rootTestSelector}}
     role="radiogroup"
     ...attributes
   >

--- a/packages/ember-toucan-form/src/-private/radio-group-field.hbs
+++ b/packages/ember-toucan-form/src/-private/radio-group-field.hbs
@@ -1,0 +1,18 @@
+<@form.Field @name={{@name}} as |field|>
+  <Form::Fields::RadioGroup
+    @label={{@label}}
+    @hint={{@hint}}
+    @error={{this.mapErrors field.rawErrors}}
+    @value={{this.assertString field.value}}
+    {{! The issue here is that onChange only expects a string typed value, but field.setValue is generic, accepting anything that DATA[KEY] could be. Similar case with @value, but there casting to a string is easy. }}
+    {{! @glint-expect-error }}
+    @onChange={{field.setValue}}
+    @isDisabled={{@isDisabled}}
+    @rootTestSelector={{@rootTestSelector}}
+    @name={{@name}}
+    ...attributes
+    as |group|
+  >
+    {{yield (hash RadioField=group.RadioField)}}
+  </Form::Fields::RadioGroup>
+</@form.Field>

--- a/packages/ember-toucan-form/src/-private/radio-group-field.ts
+++ b/packages/ember-toucan-form/src/-private/radio-group-field.ts
@@ -1,0 +1,61 @@
+import Component from '@glimmer/component';
+import { assert } from '@ember/debug';
+import { action } from '@ember/object';
+
+import type { HeadlessFormBlock, UserData } from './types';
+import type { ToucanFormRadioGroupFieldComponentSignature as BaseRadioGroupFieldSignature } from '@crowdstrike/ember-toucan-core/components/form/fields/radio-group';
+import type { FormData, FormKey, ValidationError } from 'ember-headless-form';
+
+export interface ToucanFormRadioGroupFieldComponentSignature<
+  DATA extends UserData,
+  KEY extends FormKey<FormData<DATA>> = FormKey<FormData<DATA>>
+> {
+  Element: HTMLFieldSetElement;
+  Args: Omit<
+    BaseRadioGroupFieldSignature['Args'],
+    'error' | 'value' | 'onChange'
+  > & {
+    /**
+     * The name of your field, which must match a property of the `@data` passed to the form
+     */
+    name: KEY;
+
+    /*
+     * @internal
+     */
+    form: HeadlessFormBlock<DATA>;
+  };
+  Blocks: {
+    default: [
+      {
+        RadioField: BaseRadioGroupFieldSignature['Blocks']['default'][0]['RadioField'];
+      }
+    ];
+  };
+}
+
+export default class ToucanFormTextareaFieldComponent<
+  DATA extends UserData,
+  KEY extends FormKey<FormData<DATA>> = FormKey<FormData<DATA>>
+> extends Component<ToucanFormRadioGroupFieldComponentSignature<DATA, KEY>> {
+  mapErrors = (errors?: ValidationError[]) => {
+    if (!errors) {
+      return;
+    }
+
+    // @todo we need to figure out what to do when message is undefined
+    return errors.map((error) => error.message ?? error.type);
+  };
+
+  @action
+  assertString(value: unknown): string | undefined {
+    assert(
+      `Only string values are expected for ${String(
+        this.args.name
+      )}, but you passed ${typeof value}`,
+      typeof value === 'undefined' || typeof value === 'string'
+    );
+
+    return value;
+  }
+}

--- a/packages/ember-toucan-form/src/components/toucan-form.hbs
+++ b/packages/ember-toucan-form/src/components/toucan-form.hbs
@@ -14,13 +14,16 @@
       Checkbox=(component
         (ensure-safe-component this.CheckboxComponent) form=form
       )
-      Textarea=(component
-        (ensure-safe-component this.TextareaFieldComponent) form=form
-      )
+      Field=form.Field
       Input=(component
         (ensure-safe-component this.InputFieldComponent) form=form
       )
-      Field=form.Field
+      RadioGroup=(component
+        (ensure-safe-component this.RadioGroupFieldComponent) form=form
+      )
+      Textarea=(component
+        (ensure-safe-component this.TextareaFieldComponent) form=form
+      )
     )
   }}
 </HeadlessForm>

--- a/packages/ember-toucan-form/src/components/toucan-form.ts
+++ b/packages/ember-toucan-form/src/components/toucan-form.ts
@@ -2,6 +2,7 @@ import Component from '@glimmer/component';
 
 import CheckboxFieldComponent from '../-private/checkbox-field';
 import InputFieldComponent from '../-private/input-field';
+import RadioGroupFieldComponent from '../-private/radio-group-field';
 import TextareaFieldComponent from '../-private/textarea-field';
 
 import type { HeadlessFormBlock, UserData } from '../-private/types';
@@ -23,9 +24,13 @@ export interface ToucanFormComponentSignature<
     default: [
       {
         Checkbox: WithBoundArgs<typeof CheckboxFieldComponent<DATA>, 'form'>;
-        Textarea: WithBoundArgs<typeof TextareaFieldComponent<DATA>, 'form'>;
-        Input: WithBoundArgs<typeof InputFieldComponent<DATA>, 'form'>;
         Field: HeadlessFormBlock<DATA>['Field'];
+        Input: WithBoundArgs<typeof InputFieldComponent<DATA>, 'form'>;
+        RadioGroup: WithBoundArgs<
+          typeof RadioGroupFieldComponent<DATA>,
+          'form'
+        >;
+        Textarea: WithBoundArgs<typeof TextareaFieldComponent<DATA>, 'form'>;
       }
     ];
   };
@@ -36,8 +41,9 @@ export default class ToucanFormComponent<
   SUBMISSION_VALUE
 > extends Component<ToucanFormComponentSignature<DATA, SUBMISSION_VALUE>> {
   CheckboxComponent = CheckboxFieldComponent<DATA>;
-  TextareaFieldComponent = TextareaFieldComponent<DATA>;
   InputFieldComponent = InputFieldComponent<DATA>;
+  RadioGroupFieldComponent = RadioGroupFieldComponent<DATA>;
+  TextareaFieldComponent = TextareaFieldComponent<DATA>;
 
   get validateOn() {
     let { validateOn } = this.args;

--- a/test-app/tests/integration/components/toucan-form/toucan-form-test.gts
+++ b/test-app/tests/integration/components/toucan-form/toucan-form-test.gts
@@ -11,6 +11,7 @@ import type { ErrorRecord } from 'ember-headless-form';
 interface TestData {
   comment?: string;
   firstName?: string;
+  radio?: string;
   termsAndConditions?: boolean;
 }
 
@@ -53,6 +54,7 @@ module('Integration | Component | ToucanForm', function (hooks) {
     const data: TestData = {
       comment: 'textarea',
       firstName: 'input',
+      radio: 'option-2',
       termsAndConditions: true,
     };
 
@@ -65,6 +67,10 @@ module('Integration | Component | ToucanForm', function (hooks) {
           @name="termsAndConditions"
           data-checkbox
         />
+        <form.RadioGroup @label="Radios" @name="radio" as |group|>
+          <group.RadioField @label="option-1" @value="option-1" data-radio-1 />
+          <group.RadioField @label="option-2" @value="option-2" data-radio-2 />
+        </form.RadioGroup>
       </ToucanForm>
     </template>);
 
@@ -76,6 +82,12 @@ module('Integration | Component | ToucanForm', function (hooks) {
 
     assert.dom('[data-checkbox]').hasAttribute('name', 'termsAndConditions');
     assert.dom('[data-checkbox]').isChecked();
+
+    assert.dom('[data-radio-1]').hasAttribute('name', 'radio');
+    assert.dom('[data-radio-2]').hasAttribute('name', 'radio');
+
+    assert.dom('[data-radio-1]').isNotChecked();
+    assert.dom('[data-radio-2]').isChecked();
   });
 
   test('it triggers validation and shows error messages in the Toucan Core components', async function (assert) {
@@ -84,6 +96,7 @@ module('Integration | Component | ToucanForm', function (hooks) {
     const formValidateCallback = ({
       comment,
       firstName,
+      radio,
       termsAndConditions,
     }: TestData) => {
       let errors: ErrorRecord<TestData> = {};
@@ -104,6 +117,16 @@ module('Integration | Component | ToucanForm', function (hooks) {
             type: 'required',
             value: firstName,
             message: 'First name is required',
+          },
+        ];
+      }
+
+      if (!radio) {
+        errors.radio = [
+          {
+            type: 'required',
+            value: radio,
+            message: 'One radio must be selected',
           },
         ];
       }
@@ -144,6 +167,16 @@ module('Integration | Component | ToucanForm', function (hooks) {
           data-checkbox
         />
 
+        <form.RadioGroup
+          @label="Radios"
+          @name="radio"
+          @rootTestSelector="data-radio-wrapper"
+          as |group|
+        >
+          <group.RadioField @label="option-1" @value="option-1" data-radio-1 />
+          <group.RadioField @label="option-2" @value="option-2" data-radio-2 />
+        </form.RadioGroup>
+
         <button type="submit" data-test-submit>Submit</button>
       </ToucanForm>
     </template>);
@@ -170,12 +203,16 @@ module('Integration | Component | ToucanForm', function (hooks) {
     assert
       .dom('[data-root-field="data-checkbox-wrapper"] [data-error]')
       .hasText('Terms must be checked');
+    assert
+      .dom('[data-root-field="data-radio-wrapper"] [data-error]')
+      .hasText('One radio must be selected');
 
     // Satisfy the validation and submit the form
     await fillIn('[data-textarea]', 'A comment.');
     await fillIn('[data-input]', 'CrowdStrike');
     await click('[data-test-submit]');
     await click('[data-checkbox]');
+    await click('[data-radio-2]');
 
     assert
       .dom('[data-error]')


### PR DESCRIPTION
Downstream of https://github.com/CrowdStrike/ember-toucan-core/pull/135

## 🚀 Description

Adds RadioGroup support to Toucan Form.  Usage is:
```hbs template
<ToucanForm
  class='space-y-4 max-w-xs'
  @data={{changeset this.data this.validations}}
  @dataMode='mutable'
  @onSubmit={{this.handleSubmit}}
  @validate={{validate-changeset}}
  as |form|
>
  <form.RadioGroup @label='Radios' @name='radio' as |group|>
    <group.RadioField @label='option-1' @value='option-1' data-radio-1 />
    <group.RadioField @label='option-2' @value='option-2' data-radio-2 />
  </form.RadioGroup>

  <Button type='submit'>Submit</Button>
</ToucanForm>
```

```js component
import Component from '@glimmer/component';
import { action } from '@ember/object';
import {
  validatePresence,
  validateFormat,
} from 'ember-changeset-validations/validators';

export default class extends Component {
  data = {};

  validations = {
    radio: validatePresence(true),
  };

  handleSubmit(data) {
    console.log({ data });

    alert(
      `Form submitted with:\n${Object.entries(data.get('pendingData'))
        .map(([key, value]) => `${key}: ${value}`)
        .join('\n')}`
    );
  }
}
```


---

## 🔬 How to Test

- Visit https://18f40f40.ember-toucan-core.pages.dev/docs/toucan-form/changeset-validation
- Click submit
- Verify the radio group element has an error message
- Check a radio
- Verify the radio group error goes away
- Fill out the form and submit it, verify the submitted data has whatever option you selected for set for `radios`

---

## 📸 Images/Videos of Functionality



https://user-images.githubusercontent.com/8069555/232595220-bc8811f5-be5a-4608-bafe-8c25bc6e3d05.mov

