### PR TITLE
toucan-form: Add CheckboxGroup support 

### DIFF
--- a/docs/toucan-form/changeset-validation/demo/base-demo.md
+++ b/docs/toucan-form/changeset-validation/demo/base-demo.md
@@ -12,9 +12,27 @@
   <form.Textarea @label='Comment' @name='comment' />
 
   <form.RadioGroup @label='Radios' @name='radio' as |group|>
-    <group.RadioField @label='option-1' @value='option-1' data-radio-1 />
-    <group.RadioField @label='option-2' @value='option-2' data-radio-2 />
+    <group.RadioField @label='Option 1' @value='option-1' data-radio-1 />
+    <group.RadioField @label='Option 2' @value='option-2' data-radio-2 />
   </form.RadioGroup>
+
+  <form.CheckboxGroup @label='Checkboxes' @name='checkboxes' as |group|>
+    <group.CheckboxField
+      @label='Option 1'
+      @value='option-1'
+      data-checkbox-group-1
+    />
+    <group.CheckboxField
+      @label='Option 2'
+      @value='option-2'
+      data-checkbox-group-2
+    />
+    <group.CheckboxField
+      @label='Option 3'
+      @value='option-3'
+      data-checkbox-group-3
+    />
+  </form.CheckboxGroup>
 
   <form.Checkbox @label='Agree to the Terms' @name='terms' />
 
@@ -35,6 +53,7 @@ export default class extends Component {
 
   validations = {
     comment: validatePresence(true),
+    checkboxes: validatePresence(true),
     firstName: validatePresence(true),
     lastName: validatePresence(true),
     radio: validatePresence(true),

--- a/docs/toucan-form/native-validation/demo/base-demo.md
+++ b/docs/toucan-form/native-validation/demo/base-demo.md
@@ -19,6 +19,27 @@
     <group.RadioField @label='option-2' @value='option-2' data-radio-2 />
   </form.RadioGroup>
 
+  <form.CheckboxGroup @label='Checkboxes' @name='checkboxes' as |group|>
+    <group.CheckboxField
+      @label='Option 1'
+      @value='option-1'
+      required
+      data-checkbox-group-1
+    />
+    <group.CheckboxField
+      @label='Option 2'
+      @value='option-2'
+      required
+      data-checkbox-group-2
+    />
+    <group.CheckboxField
+      @label='Option 3'
+      @value='option-3'
+      required
+      data-checkbox-group-3
+    />
+  </form.CheckboxGroup>
+
   <form.Checkbox @label='Agree to the Terms' @name='terms' required />
 
   <Button type='submit'>Submit</Button>

--- a/packages/ember-toucan-core/src/components/form/fields/checkbox-group.ts
+++ b/packages/ember-toucan-core/src/components/form/fields/checkbox-group.ts
@@ -5,15 +5,16 @@ import assertBlockOrArgumentExists from '../../../-private/assert-block-or-argum
 import CheckboxFieldComponent from './checkbox';
 
 import type { AssertBlockOrArg } from '../../../-private/assert-block-or-argument-exists';
+import type { ErrorMessage } from '../../../-private/types';
 import type { WithBoundArgs } from '@glint/template';
 
 export interface ToucanFormCheckboxGroupFieldComponentSignature {
   Element: HTMLFieldSetElement;
   Args: {
     /**
-     * Provide a string to this argument to render an error message and apply error styling to the Field.
+     * Provide a string or array of strings to this argument to render an error message and apply error styling to the Field.
      */
-    error?: string;
+    error?: ErrorMessage;
 
     /**
      * Provide a string to this argument to render a hint message to help describe the control.

--- a/packages/ember-toucan-form/src/-private/checkbox-group-field.hbs
+++ b/packages/ember-toucan-form/src/-private/checkbox-group-field.hbs
@@ -1,0 +1,18 @@
+<@form.Field @name={{@name}} as |field|>
+  <Form::Fields::CheckboxGroup
+    @label={{@label}}
+    @hint={{@hint}}
+    @error={{this.mapErrors field.rawErrors}}
+    @value={{this.assertArrayOfStrings field.value}}
+    {{! The issue here is that onChange only expects a string typed value, but field.setValue is generic, accepting anything that DATA[KEY] could be. Similar case with @value, but there casting is easy. }}
+    {{! @glint-expect-error }}
+    @onChange={{field.setValue}}
+    @isDisabled={{@isDisabled}}
+    @rootTestSelector={{@rootTestSelector}}
+    @name={{@name}}
+    ...attributes
+    as |group|
+  >
+    {{yield (hash CheckboxField=group.CheckboxField)}}
+  </Form::Fields::CheckboxGroup>
+</@form.Field>

--- a/packages/ember-toucan-form/src/-private/checkbox-group-field.ts
+++ b/packages/ember-toucan-form/src/-private/checkbox-group-field.ts
@@ -1,0 +1,61 @@
+import Component from '@glimmer/component';
+import { assert } from '@ember/debug';
+import { action } from '@ember/object';
+
+import type { HeadlessFormBlock, UserData } from './types';
+import type { ToucanFormCheckboxGroupFieldComponentSignature as BaseCheckboxGroupFieldSignature } from '@crowdstrike/ember-toucan-core/components/form/fields/checkbox-group';
+import type { FormData, FormKey, ValidationError } from 'ember-headless-form';
+
+export interface ToucanFormCheckboxGroupFieldComponentSignature<
+  DATA extends UserData,
+  KEY extends FormKey<FormData<DATA>> = FormKey<FormData<DATA>>
+> {
+  Element: HTMLFieldSetElement;
+  Args: Omit<
+    BaseCheckboxGroupFieldSignature['Args'],
+    'error' | 'value' | 'onChange'
+  > & {
+    /**
+     * The name of your field, which must match a property of the `@data` passed to the form
+     */
+    name: KEY;
+
+    /*
+     * @internal
+     */
+    form: HeadlessFormBlock<DATA>;
+  };
+  Blocks: {
+    default: [
+      {
+        CheckboxField: BaseCheckboxGroupFieldSignature['Blocks']['default'][0]['CheckboxField'];
+      }
+    ];
+  };
+}
+
+export default class ToucanFormTextareaFieldComponent<
+  DATA extends UserData,
+  KEY extends FormKey<FormData<DATA>> = FormKey<FormData<DATA>>
+> extends Component<ToucanFormCheckboxGroupFieldComponentSignature<DATA, KEY>> {
+  mapErrors = (errors?: ValidationError[]) => {
+    if (!errors) {
+      return;
+    }
+
+    // @todo we need to figure out what to do when message is undefined
+    return errors.map((error) => error.message ?? error.type);
+  };
+
+  @action
+  assertArrayOfStrings(value: unknown): Array<string> | undefined {
+    assert(
+      `Only array of string values are expected for ${String(
+        this.args.name
+      )}, but you passed ${typeof value}`,
+      typeof value === 'undefined' || Array.isArray(value)
+    );
+
+    return value;
+  }
+}

--- a/packages/ember-toucan-form/src/components/toucan-form.hbs
+++ b/packages/ember-toucan-form/src/components/toucan-form.hbs
@@ -14,6 +14,9 @@
       Checkbox=(component
         (ensure-safe-component this.CheckboxComponent) form=form
       )
+      CheckboxGroup=(component
+        (ensure-safe-component this.CheckboxGroupComponent) form=form
+      )
       Field=form.Field
       Input=(component
         (ensure-safe-component this.InputFieldComponent) form=form

--- a/packages/ember-toucan-form/src/components/toucan-form.ts
+++ b/packages/ember-toucan-form/src/components/toucan-form.ts
@@ -1,6 +1,7 @@
 import Component from '@glimmer/component';
 
 import CheckboxFieldComponent from '../-private/checkbox-field';
+import CheckboxGroupFieldComponent from '../-private/checkbox-group-field';
 import InputFieldComponent from '../-private/input-field';
 import RadioGroupFieldComponent from '../-private/radio-group-field';
 import TextareaFieldComponent from '../-private/textarea-field';
@@ -24,6 +25,10 @@ export interface ToucanFormComponentSignature<
     default: [
       {
         Checkbox: WithBoundArgs<typeof CheckboxFieldComponent<DATA>, 'form'>;
+        CheckboxGroup: WithBoundArgs<
+          typeof CheckboxGroupFieldComponent<DATA>,
+          'form'
+        >;
         Field: HeadlessFormBlock<DATA>['Field'];
         Input: WithBoundArgs<typeof InputFieldComponent<DATA>, 'form'>;
         RadioGroup: WithBoundArgs<
@@ -41,6 +46,7 @@ export default class ToucanFormComponent<
   SUBMISSION_VALUE
 > extends Component<ToucanFormComponentSignature<DATA, SUBMISSION_VALUE>> {
   CheckboxComponent = CheckboxFieldComponent<DATA>;
+  CheckboxGroupComponent = CheckboxGroupFieldComponent<DATA>;
   InputFieldComponent = InputFieldComponent<DATA>;
   RadioGroupFieldComponent = RadioGroupFieldComponent<DATA>;
   TextareaFieldComponent = TextareaFieldComponent<DATA>;


### PR DESCRIPTION
Downstream of https://github.com/CrowdStrike/ember-toucan-core/pull/136

## 🚀 Description

Adds CheckboxGroup support to Toucan Form.  Usage is:

```hbs template
<ToucanForm
  class='space-y-4 max-w-xs'
  @data={{changeset this.data this.validations}}
  @dataMode='mutable'
  @onSubmit={{this.handleSubmit}}
  @validate={{validate-changeset}}
  as |form|
>
  <form.CheckboxGroup @label='Checkboxes' @name='checkboxes' as |group|>
    <group.CheckboxField
      @label='Option 1'
      @value='option-1'
      data-checkbox-group-1
    />
    <group.CheckboxField
      @label='Option 2'
      @value='option-2'
      data-checkbox-group-2
    />
    <group.CheckboxField
      @label='Option 3'
      @value='option-3'
      data-checkbox-group-3
    />
  </form.CheckboxGroup>

  <Button type='submit'>Submit</Button>
</ToucanForm>
```

```js component
import Component from '@glimmer/component';
import { action } from '@ember/object';
import {
  validatePresence,
  validateFormat,
} from 'ember-changeset-validations/validators';

export default class extends Component {
  data = {};

  validations = {
    checkboxes: validatePresence(true),
  };

  handleSubmit(data) {
    console.log({ data });

    alert(
      `Form submitted with:\n${Object.entries(data.get('pendingData'))
        .map(([key, value]) => `${key}: ${value}`)
        .join('\n')}`
    );
  }
}
```


---

## 🔬 How to Test

- Visit TBD
- Click submit
- Verify the checkbox group element has an error message
- Check one or many checkboxes
- Verify the checkbox group error goes away
- Fill out the form and submit it, verify the submitted data has whatever options you selected for `checkboxes`

---

## 📸 Images/Videos of Functionality

