### PR TITLE
Replace icons with Toucan Icons

### DIFF
--- a/.changeset/fuzzy-lies-jump.md
+++ b/.changeset/fuzzy-lies-jump.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/ember-toucan-core': patch
+---
+
+Replaced placeholder icons with Toucan icons.

--- a/packages/ember-toucan-core/src/-private/components/error.hbs
+++ b/packages/ember-toucan-core/src/-private/components/error.hbs
@@ -3,21 +3,22 @@
     {{if this.hasMoreThanOneError 'items-start' 'items-center'}}"
   ...attributes
 >
-  {{! TODO: https://github.com/CrowdStrike/ember-toucan-core/issues/49 - Placeholder icon }}
   <svg
-    class="mr-1 h-3 w-3"
-    xmlns="http://www.w3.org/2000/svg"
-    width="24"
-    height="24"
-    stroke="currentColor"
-    viewBox="0 0 24 24"
+    aria-hidden="true"
+    class="mr-1"
+    width="12"
+    height="12"
+    viewBox="0 0 12 12"
+    fill="currentColor"
   >
     <path
-      d="M10.206 4.625l-3.5 6.4-3.5 6.4a2.04 2.04 0 00.038 1.987 2 2 0 001.762 1.013h14a2.007 2.007 0 001.725-.975 2.075 2.075 0 00.075-2.025l-3.5-6.4-3.5-6.4a2.068 2.068 0 00-3.6 0zM12.006 8.825v5.2M12.006 16.99v-.065h0"
-      fill="none"
-      stroke-linecap="round"
-      stroke-linejoin="round"
-      stroke-width="2"
+      d="M6.02979 9.06006C6.58207 9.06006 7.02979 8.61234 7.02979 8.06006C7.02979 7.50777 6.58207 7.06006 6.02979 7.06006C5.4775 7.06006 5.02979 7.50777 5.02979 8.06006C5.02979 8.61234 5.4775 9.06006 6.02979 9.06006Z"
+    />
+    <path d="M5.52979 3.12H6.52979V6.12H5.52979V3.12Z" />
+    <path
+      fill-rule="evenodd"
+      clip-rule="evenodd"
+      d="M11.76 9.54L6.82003 0.48C6.47003 -0.16 5.42003 -0.16 5.07003 0.48L0.120026 9.54C-0.0499739 9.85 -0.0399739 10.22 0.140026 10.53C0.320026 10.84 0.640026 11.02 1.00003 11.02H10.89C11.25 11.02 11.57 10.84 11.75 10.53C11.93 10.22 11.94 9.85 11.77 9.54H11.76ZM1.00003 10.02L5.94003 0.96L10.88 10.02H1.00003Z"
     />
   </svg>
 

--- a/packages/ember-toucan-core/src/components/form/controls/checkbox.hbs
+++ b/packages/ember-toucan-core/src/components/form/controls/checkbox.hbs
@@ -13,37 +13,27 @@
   {{#if this.isCheckedOrIndeterminate}}
     <div class="pointer-events-none absolute">
       {{#if this.isIndeterminate}}
-        {{! TODO: https://github.com/CrowdStrike/ember-toucan-core/issues/49 - Placeholder icon }}
         <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="24"
-          height="24"
-          stroke="currentColor"
-          viewBox="0 0 24 24"
-          class="text-ground-floor h-3 w-3"
-        ><path
-            d="M20 12H4"
-            fill="none"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-          ></path></svg>
+          aria-hidden="true"
+          class="text-ground-floor"
+          width="12"
+          height="12"
+          viewBox="0 0 12 12"
+          fill="currentColor"
+        ><path d="M10 5v2H2V5h8Z" /></svg>
       {{else}}
-        {{! TODO: https://github.com/CrowdStrike/ember-toucan-core/issues/49 - Placeholder icon }}
         <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="24"
-          height="24"
-          stroke="currentColor"
-          viewBox="0 0 24 24"
+          aria-hidden="true"
           class="text-ground-floor h-3 w-3"
+          width="12"
+          height="12"
+          viewBox="0 0 12 12"
+          fill="currentColor"
         ><path
-            d="M3 14.7l2.7 2.45 2.7 2.45 6.3-7.6L21 4.4"
-            fill="none"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-          ></path></svg>
+            fill-rule="evenodd"
+            clip-rule="evenodd"
+            d="M10.207 4.207 5 9.414 2.293 6.707l1.414-1.414L5 6.586l3.793-3.793 1.414 1.414Z"
+          /></svg>
       {{/if}}
     </div>
   {{/if}}

--- a/packages/ember-toucan-core/src/components/form/fields/file-input.hbs
+++ b/packages/ember-toucan-core/src/components/form/fields/file-input.hbs
@@ -54,21 +54,20 @@
         />
         <Button @variant="secondary" @onClick={{(fn this.handleChange field)}}>
           <span data-trigger>{{@trigger}}</span>
-          {{! TODO: https://github.com/CrowdStrike/ember-toucan-core/issues/49 replace with official icon later }}
           <svg
-            class="ml-2 h-4 w-4"
-            xmlns="http://www.w3.org/2000/svg"
-            width="24"
-            height="24"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-          ><path
-              d="M16.2 7.6l-2.1-2.3L12 3v13.1M12 3L9.9 5.3 7.8 7.6M21 15.1V19a2 2 0 01-2 2H5a2.006 2.006 0 01-2-2v-3.9"
-              fill="none"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-            ></path></svg>
+            aria-hidden="true"
+            class="ml-2"
+            width="16"
+            height="16"
+            viewBox="0 0 16 16"
+            fill="currentColor"
+          ><g><path
+                fill-rule="evenodd"
+                clip-rule="evenodd"
+                d="M2 10v2.5A1.5 1.5 0 0 0 3.5 14h9a1.5 1.5 0 0 0 1.5-1.5V10h1v2.5a2.5 2.5 0 0 1-2.5 2.5h-9A2.5 2.5 0 0 1 1 12.5V10h1Z"
+              /><path
+                d="M8 10.707a.5.5 0 0 1-.5-.5V2.414L4.854 5.061a.5.5 0 1 1-.708-.707L8 .5l3.854 3.854a.5.5 0 0 1-.708.707L8.5 2.414v7.793a.5.5 0 0 1-.5.5Z"
+              /></g></svg>
         </Button>
       </field.Control>
     </field.Label>

--- a/packages/ember-toucan-core/src/components/form/file-input/delete-button.hbs
+++ b/packages/ember-toucan-core/src/components/form/file-input/delete-button.hbs
@@ -9,17 +9,15 @@
   ...attributes
 >
   <svg
+    aria-hidden="true"
     class="text-text-and-icons h-4 w-4"
-    xmlns="http://www.w3.org/2000/svg"
-    width="24"
-    height="24"
-    stroke="currentColor"
-    viewBox="0 0 24 24"
-  ><path
-      d="M3.4 6.2h17.2m-15.3 0V19a2.063 2.063 0 00.538 1.413A1.836 1.836 0 007.2 21h9.6a1.861 1.861 0 001.325-.587A2.039 2.039 0 0018.7 19V6.2M10 15.6v-4m4 0v4M9.4 6.2V3.9a.98.98 0 01.212-.637A.746.746 0 0110.2 3h3.6a.743.743 0 01.587.263.975.975 0 01.213.637v2.3"
-      fill="none"
-      stroke-linecap="round"
-      stroke-linejoin="round"
-      stroke-width="2"
-    ></path></svg>
+    width="16"
+    height="16"
+    viewBox="0 0 16 16"
+    fill="currentColor"
+  ><g fill-rule="evenodd" clip-rule="evenodd"><path
+        d="M2 3a.5.5 0 0 1 .5-.5h11a.5.5 0 0 1 0 1V13a1.5 1.5 0 0 1-1.5 1.5H4A1.5 1.5 0 0 1 2.5 13V3.5A.5.5 0 0 1 2 3Zm1.5.5V13a.5.5 0 0 0 .5.5h8a.5.5 0 0 0 .5-.5V3.5h-9Z"
+      /><path
+        d="M6 11.5v-6h1v6H6Zm3 0v-6h1v6H9ZM8 1a1.5 1.5 0 0 0-1.5 1.5h-1a2.5 2.5 0 0 1 5 0h-1A1.5 1.5 0 0 0 8 1Z"
+      /></g></svg>
 </Button>


### PR DESCRIPTION
## 🚀 Description

This PR replaces the placeholder icons with Toucan icons.

Closes #49 

---

## 🔬 How to Test

- Visit https://8d11545e.ember-toucan-core.pages.dev/docs/components/checkbox-field
  - Check the checkbox and view the new checkmark
  - Go to https://8d11545e.ember-toucan-core.pages.dev/docs/components/checkbox-field#checkboxfield-with-isindeterminate and view the indeterminate icon
- Visit https://8d11545e.ember-toucan-core.pages.dev/docs/components/file-input-field
  - View the new upload icon
  - View the new trash icon
- Visit https://8d11545e.ember-toucan-core.pages.dev/docs/components/textarea-field#textareafield-with-label-and-error
  - View the new error icon

---

## 📸 Images/Videos of Functionality





| BEFORE  | AFTER |
| ------------- | ------------- |
| <img width="336" alt="Screenshot 2023-04-20 at 11 57 36 AM" src="https://user-images.githubusercontent.com/8069555/233421721-531a8b0b-5514-47d5-b445-05e82a2c47e4.png">  | <img width="347" alt="Screenshot 2023-04-20 at 11 57 57 AM" src="https://user-images.githubusercontent.com/8069555/233421804-e5ae3bdf-a920-4a2a-ab79-38c73550bfbb.png">  |
| <img width="95" alt="Screenshot 2023-04-20 at 11 58 36 AM" src="https://user-images.githubusercontent.com/8069555/233422004-f9a21847-c35d-42d8-b0d4-07155c2f23c4.png">  | <img width="94" alt="Screenshot 2023-04-20 at 11 59 00 AM" src="https://user-images.githubusercontent.com/8069555/233422098-a23c8f4f-c37a-45fa-b8ae-c297134e40a4.png">  |
| <img width="287" alt="Screenshot 2023-04-20 at 11 59 24 AM" src="https://user-images.githubusercontent.com/8069555/233422205-4fae5596-a767-475b-a627-5fba6b7f1a1d.png"> | <img width="295" alt="Screenshot 2023-04-20 at 11 59 58 AM" src="https://user-images.githubusercontent.com/8069555/233422363-189e43ae-646d-4690-a953-3d3b684b0a48.png"> |




