### PR TITLE
docs: Update contributing docs and add bash script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,25 @@ When developing a new component, add it to the `packages/ember-toucan-core` dire
 
 ## Viewing changes in the docs/test-app
 
+### Option 1: run the bash script
+
 For the time being you can use `pnpm link` to create a symlink between the addon and the apps. This will allow you to make a change in the addon and immediately see the change in the app rather than having to stop the app, rebuild, resync dependencies, etc.
+
+There are two ways to do this:
+
+### Option 1: run the bash script
+
+In the root of the repo, run:
+
+```bash
+./local-setup.bash
+```
+
+This will run a bash script, where you can choose to install and symlink.
+
+You will also have the option of deleting the turbo repo, and/or deleting the node_modules, dist, and tsc cache. But running these takes longer.
+
+### Option 2: symlink manually
 
 ```bash
 # Create a symlink in the ember-toucan-core addon
@@ -58,13 +76,13 @@ pnpm link .
 # Create a symlink in the forms addon (required even if you aren't using it)
 cd ../ember-toucan-form
 pnpm link @crowdstrike/ember-toucan-core # need to link this because ember-toucan-forms depends on it
-pnpm build 
+pnpm build
 pnpm link .
 
 # Link ember-toucan-core docs-app
 cd ../../docs-app
 pnpm link @crowdstrike/ember-toucan-core # note @crowdstrike here
-pnpm link @crowdstrike/ember-toucan-form # note @crowdstrike here 
+pnpm link @crowdstrike/ember-toucan-form # note @crowdstrike here
 pnpm i
 
 The test-app also needs to link `ember-toucan-form`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ ember-toucan-core uses [pnpm](https://pnpm.io) as a package manager. If you're u
 
 ```bash
 cd ember-toucan-core
-pnpm install
+pnpm install # can also: pnpm i
 ```
 
 ## Adding components
@@ -45,34 +45,34 @@ When developing a new component, add it to the `packages/ember-toucan-core` dire
 1. Components are added under `packages/ember-toucan-core/src/components`
 2. When adding a new component, it needs to be added to the template registry so that Glint picks it up. To do that, add a line in `packages/ember-toucan-core/src/template-registry.ts`.
 
-## Running the docs/test-app
-
-Prior to running the `docs-app` or `test-app`, you'll need to install dependencies:
-
-```bash
-cd docs-app
-pnpm i
-pnpm start
-```
-
-```bash
-cd test-app
-pnpm i
-pnpm start
-```
-
 ## Viewing changes in the docs/test-app
 
-[We're working on making this better](https://github.com/CrowdStrike/ember-toucan-core/issues/40), but for the time being you can use `pnpm link` to create a symlink between the addon and the apps. This will allow you to make a change in the addon and immediately see the change in the app rather than having to stop the app, rebuild, resync dependencies, etc.
+For the time being you can use `pnpm link` to create a symlink between the addon and the apps. This will allow you to make a change in the addon and immediately see the change in the app rather than having to stop the app, rebuild, resync dependencies, etc.
 
 ```bash
-# Create a symlink in the addon
+# Create a symlink in the ember-toucan-core addon
 cd packages/ember-toucan-core
+pnpm build
 pnpm link .
 
-# Link the docs-app
-cd ../docs-app
-pnpm link @crowdstrike/ember-toucan-core
+# Create a symlink in the forms addon (required even if you aren't using it)
+cd ../ember-toucan-form
+pnpm link @crowdstrike/ember-toucan-core # need to link this because ember-toucan-forms depends on it
+pnpm build 
+pnpm link .
+
+# Link ember-toucan-core docs-app
+cd ../../docs-app
+pnpm link @crowdstrike/ember-toucan-core # note @crowdstrike here
+pnpm link @crowdstrike/ember-toucan-form # note @crowdstrike here 
+pnpm i
+
+The test-app also needs to link `ember-toucan-form`.
+
+# Link ember-toucan-core to the test-app
+cd ../test-app
+pnpm link @crowdstrike/ember-toucan-core # note @crowdstrike here
+pnpm link @crowdstrike/ember-toucan-form # note @crowdstrike here
 pnpm i
 ```
 
@@ -84,8 +84,17 @@ cd packages/ember-toucan-core
 pnpm start
 # ember-toucan-core is now in watch mode and will rebuild automatically
 
-# In a second terminal
-cd docs-app
+
+# In a second terminal, cd to the root of the repo
+cd root-of-repo-where-that-is-for-you
+pnpm start:docs # using turbo here
+
+# In a third terminal, switch to the test-app
+cd root-of-repo-where-that-is-for-you/test-app
+pnpm start # and then navigate to /tests
+
+# IF you are making changes in ember-toucan-form, start a fourth terminal
+cd packages/ember-toucan-form
 pnpm start
 ```
 

--- a/local-setup.bash
+++ b/local-setup.bash
@@ -1,0 +1,53 @@
+echo "running a git check"
+if [[ $(git diff --stat) != '' ]]; then
+  echo 'You have changes not checked into git, please stash or commit them and try again'
+  exit 1
+else
+  echo 'Git status is good, moving on to local setup...'
+fi
+
+
+echo "deleting turbo cache"
+find . -name ".turbo" -type d -prune -exec rm -rf "{}" \;
+rm -rf node_modules/.cache;
+
+echo "nukin' node_modules, declaration, dist directories, and tsc build cache"
+rm -rf node_modules/.cache;
+find . -name "node_modules" -type d -prune -exec rm -rf "{}" \;
+find . -name "declarations" -type d -prune -exec rm -rf "{}" \;
+find . -name "dist" -type d -prune -exec rm -rf "{}" \;
+find . -name "tsconfig.tsbuildinfo" -type f -exec rm -rf "{}" \;
+
+pnpm i
+
+echo "--installed node modules--"
+
+echo "building ember-toucan-core"
+cd packages/ember-toucan-core
+pnpm build
+pnpm link .
+
+echo "building ember-toucan-form"
+cd ../ember-toucan-form
+pnpm link @crowdstrike/ember-toucan-core
+pnpm build
+pnpm link .
+
+echo "linking the docs app"
+cd ../../docs-app
+pnpm link @crowdstrike/ember-toucan-core
+pnpm link @crowdstrike/ember-toucan-form
+
+echo "linking the test app"
+cd ../test-app
+pnpm link @crowdstrike/ember-toucan-core
+pnpm link @crowdstrike/ember-toucan-form
+
+pnpm i # this should link all of them
+
+echo "Done"
+echo "Please open a terminal in the packages/ember-toucan-core and pnpm start"
+echo "Please open a new terminal in the root of the app and run pnpm start:docs"
+echo "Please open another terminal in the test-app folder and run pnpm start"
+echo "Please open a terminal in the packages/ember-toucan-forms and pnpm start"
+echo "REMEMBER to not check in these changes to the package.json and pnpm-lock yaml files"

--- a/local-setup.bash
+++ b/local-setup.bash
@@ -1,51 +1,114 @@
-echo "running a git check"
+#!/bin/bash
+
+# COLORS
+CYAN='\033[0;36m'
+YELLOW='\033[0;33m'
+ENDCOLOR="\033[0m"
+
+print_info() {
+  echo -e "${CYAN} $1 ${ENDCOLOR}"
+}
+
+print_warning() {
+  echo -e "${YELLOW}$1 ${ENDCOLOR}"
+}
+
+# VARIABLES
+install_and_symlink=false
+del_turbo_cache=false
+del_node_modules_dist_and_tsc_cache=false
+
+PS3='Please choose an option: '
+options=(
+  "Only install and symlink"
+  "Please delete node_modules, dist, and typescript cache, and then install and symlink"
+  "Please delete turbo cache, node modules, typescript cache, and install and symlink"
+  "Quit"
+)
+
+select opt in "${options[@]}"
+do
+  case $opt in
+    "Only install and symlink")
+      print_info "choosing simple install"
+      install_and_symlink=true
+      break
+    ;;
+    "Please delete node_modules, dist, and typescript cache, and then install and symlink")
+      del_node_modules_dist_and_tsc_cache=true
+      install_and_symlink=true
+      break
+    ;;
+    "Please delete turbo cache, node modules, typescript cache, and install and symlink")
+      del_turbo_cache=true
+      del_node_modules_dist_and_tsc_cache=true
+      install_and_symlink=true
+      break;
+    ;;
+    "Quit")
+        print_info "Quitting"
+        exit 0
+        break
+      ;;
+  esac
+done
+
+print_info "running a git check"
 if [[ $(git diff --stat) != '' ]]; then
-  echo 'You have changes not checked into git, please stash or commit them and try again'
+  print_warning "You have changes not checked into git, please stash or commit them and try again"
   exit 1
 else
-  echo 'Git status is good, moving on to local setup...'
+  print_info "Git status is good, moving on to local setup..."
 fi
 
+if [[ "$del_turbo_cache" = true ]]
+then
+  print_info "deleting turbo cache..."
+  find . -name ".turbo" -type d -prune -exec rm -rf "{}" \;
+  rm -rf node_modules/.cache
+fi
 
-echo "deleting turbo cache"
-find . -name ".turbo" -type d -prune -exec rm -rf "{}" \;
-rm -rf node_modules/.cache;
+if [[ "$del_node_modules_dist_and_tsc_cache" = true ]]
+then
+  print_info "nukin' node_modules, declaration, dist directories, and tsc build cache"
+  rm -rf node_modules/.cache;
+  find . -name "node_modules" -type d -prune -exec rm -rf "{}" \;
+  find . -name "declarations" -type d -prune -exec rm -rf "{}" \;
+  find . -name "dist" -type d -prune -exec rm -rf "{}" \;
+  find . -name "tsconfig.tsbuildinfo" -type f -exec rm -rf "{}" \;
+fi
 
-echo "nukin' node_modules, declaration, dist directories, and tsc build cache"
-rm -rf node_modules/.cache;
-find . -name "node_modules" -type d -prune -exec rm -rf "{}" \;
-find . -name "declarations" -type d -prune -exec rm -rf "{}" \;
-find . -name "dist" -type d -prune -exec rm -rf "{}" \;
-find . -name "tsconfig.tsbuildinfo" -type f -exec rm -rf "{}" \;
+if [[ "$install_and_symlink" = true ]]
+then
+  pnpm i
 
-pnpm i
+  print_info "--installed node modules--"
 
-echo "--installed node modules--"
+  print_info "building ember-toucan-core"
+  cd packages/ember-toucan-core
+  pnpm build
+  pnpm link .
 
-echo "building ember-toucan-core"
-cd packages/ember-toucan-core
-pnpm build
-pnpm link .
+  print_info "building ember-toucan-form"
+  cd ../ember-toucan-form
+  pnpm link @crowdstrike/ember-toucan-core
+  pnpm build
+  pnpm link .
 
-echo "building ember-toucan-form"
-cd ../ember-toucan-form
-pnpm link @crowdstrike/ember-toucan-core
-pnpm build
-pnpm link .
+  print_info "linking the docs app"
+  cd ../../docs-app
+  pnpm link @crowdstrike/ember-toucan-core
+  pnpm link @crowdstrike/ember-toucan-form
 
-echo "linking the docs app"
-cd ../../docs-app
-pnpm link @crowdstrike/ember-toucan-core
-pnpm link @crowdstrike/ember-toucan-form
+  print_info "linking the test app"
+  cd ../test-app
+  pnpm link @crowdstrike/ember-toucan-core
+  pnpm link @crowdstrike/ember-toucan-form
 
-echo "linking the test app"
-cd ../test-app
-pnpm link @crowdstrike/ember-toucan-core
-pnpm link @crowdstrike/ember-toucan-form
+  pnpm i # this should link all of them
+fi
 
-pnpm i # this should link all of them
-
-echo "Done"
+print_info "Done"
 echo "Please open a terminal in the packages/ember-toucan-core and pnpm start"
 echo "Please open a new terminal in the root of the app and run pnpm start:docs"
 echo "Please open another terminal in the test-app folder and run pnpm start"


### PR DESCRIPTION
## 🚀 Description

Updating the docs with new instructions related to using `turbo`:

- [x] removed: `pnpm i` in the `docs-app` and `test-app`. I have never had to do this - `pnpm i` in the root installs everything for me??
- [x] added: using `turbo` for the `docs-app`
- [x] added: `pnpm link @crowdstrike/ember-toucan-form` - Without this I notice the `test-app` won't build.
- [x] added: `pnpm build` in `packages/ember-toucan-form`. Without this the app errors. ⚠️  I notice that there's an error building the `form` package, I think because you link to link the `core` package inside the `form` package but I didn't try this.
- [x] 😓 HONESTLY, at this point I was getting pretty frustrated myself, so I wrote a bash script:

```
# to run it in the root of the repo
./local-setup.bash
```


## 🔬 How to Test

Please follow the instructions (locally) in the contributing doc and confirm that it works for you 👍 .

---

## 📸 Images/Videos of Functionality

N / A
