### PR TITLE
toucan-form: Add readonly support

### DIFF
--- a/.changeset/long-months-leave.md
+++ b/.changeset/long-months-leave.md
@@ -1,0 +1,63 @@
+---
+'@crowdstrike/ember-toucan-form': patch
+---
+
+Added `@isReadOnly` component argument support.
+
+```hbs
+<ToucanForm @data={{data}} as |form|>
+  <form.Textarea
+    @label='Comment'
+    @name='comment'
+    @isReadOnly={{true}}
+    data-textarea
+  />
+  <form.Input
+    @label='Input'
+    @name='firstName'
+    @isReadOnly={{true}}
+    data-input
+  />
+  <form.Checkbox
+    @label='Terms'
+    @name='termsAndConditions'
+    @isReadOnly={{true}}
+    data-checkbox
+  />
+
+  <form.RadioGroup
+    @label='Radios'
+    @name='radio'
+    @isReadOnly={{true}}
+    as |group|
+  >
+    <group.RadioField @label='option-1' @value='option-1' data-radio-1 />
+    <group.RadioField @label='option-2' @value='option-2' data-radio-2 />
+  </form.RadioGroup>
+
+  <form.CheckboxGroup
+    @label='Checkboxes'
+    @name='checkboxes'
+    @isReadOnly={{true}}
+    as |group|
+  >
+    <group.CheckboxField
+      @label='Option 1'
+      @value='option-1'
+      data-checkbox-group-1
+    />
+    <group.CheckboxField
+      @label='Option 2'
+      @value='option-2'
+      data-checkbox-group-2
+    />
+    <group.CheckboxField
+      @label='Option 3'
+      @value='option-3'
+      data-checkbox-group-3
+    />
+  </form.CheckboxGroup>
+</ToucanForm>
+```
+
+For CheckboxGroup and RadioGroup, the argument can be set on the root component, or on individual CheckboxFields / RadioFields directly.

--- a/packages/ember-toucan-form/src/-private/checkbox-field.hbs
+++ b/packages/ember-toucan-form/src/-private/checkbox-field.hbs
@@ -8,6 +8,7 @@
     {{! @glint-expect-error }}
     @onChange={{field.setValue}}
     @isDisabled={{@isDisabled}}
+    @isReadOnly={{@isReadOnly}}
     @rootTestSelector={{@rootTestSelector}}
     name={{@name}}
     ...attributes

--- a/packages/ember-toucan-form/src/-private/checkbox-group-field.hbs
+++ b/packages/ember-toucan-form/src/-private/checkbox-group-field.hbs
@@ -8,6 +8,7 @@
     {{! @glint-expect-error }}
     @onChange={{field.setValue}}
     @isDisabled={{@isDisabled}}
+    @isReadOnly={{@isReadOnly}}
     @rootTestSelector={{@rootTestSelector}}
     @name={{@name}}
     ...attributes

--- a/packages/ember-toucan-form/src/-private/input-field.hbs
+++ b/packages/ember-toucan-form/src/-private/input-field.hbs
@@ -8,6 +8,7 @@
     {{! @glint-expect-error }}
     @onChange={{field.setValue}}
     @isDisabled={{@isDisabled}}
+    @isReadOnly={{@isReadOnly}}
     @rootTestSelector={{@rootTestSelector}}
     name={{@name}}
     ...attributes

--- a/packages/ember-toucan-form/src/-private/radio-group-field.hbs
+++ b/packages/ember-toucan-form/src/-private/radio-group-field.hbs
@@ -8,6 +8,7 @@
     {{! @glint-expect-error }}
     @onChange={{field.setValue}}
     @isDisabled={{@isDisabled}}
+    @isReadOnly={{@isReadOnly}}
     @rootTestSelector={{@rootTestSelector}}
     @name={{@name}}
     ...attributes

--- a/packages/ember-toucan-form/src/-private/textarea-field.hbs
+++ b/packages/ember-toucan-form/src/-private/textarea-field.hbs
@@ -8,6 +8,7 @@
     {{! @glint-expect-error }}
     @onChange={{field.setValue}}
     @isDisabled={{@isDisabled}}
+    @isReadOnly={{@isReadOnly}}
     @rootTestSelector={{@rootTestSelector}}
     name={{@name}}
     ...attributes

--- a/test-app/tests/integration/components/toucan-form/form-checkbox-group-test.gts
+++ b/test-app/tests/integration/components/toucan-form/form-checkbox-group-test.gts
@@ -1,0 +1,88 @@
+/* eslint-disable no-undef -- Until https://github.com/ember-cli/eslint-plugin-ember/issues/1747 is resolved... */
+/* eslint-disable simple-import-sort/imports,padding-line-between-statements,decorator-position/decorator-position -- Can't fix these manually, without --fix working in .gts */
+import { render } from '@ember/test-helpers';
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'test-app/tests/helpers';
+
+import ToucanForm from '@crowdstrike/ember-toucan-form/components/toucan-form';
+
+interface TestData {
+  checkboxes?: Array<string>;
+}
+
+module(
+  'Integration | Component | ToucanForm | CheckboxGroup',
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    test('it sets the readonly attribute with `@isReadOnly` at the root', async function (assert) {
+      const data: TestData = {
+        checkboxes: [],
+      };
+
+      await render(<template>
+        <ToucanForm @data={{data}} as |form|>
+          <form.CheckboxGroup
+            @label="Checkboxes"
+            @name="checkboxes"
+            @isReadOnly={{true}}
+            as |group|
+          >
+            <group.CheckboxField
+              @label="Option 1"
+              @value="option-1"
+              data-checkbox-group-1
+            />
+            <group.CheckboxField
+              @label="Option 2"
+              @value="option-2"
+              data-checkbox-group-2
+            />
+            <group.CheckboxField
+              @label="Option 3"
+              @value="option-3"
+              data-checkbox-group-3
+            />
+          </form.CheckboxGroup>
+        </ToucanForm>
+      </template>);
+
+      assert.dom('[data-checkbox-group-1]').hasAttribute('readonly');
+      assert.dom('[data-checkbox-group-2]').hasAttribute('readonly');
+      assert.dom('[data-checkbox-group-3]').hasAttribute('readonly');
+    });
+
+    test('it sets the readonly attribute with `@isReadOnly` on individual checkboxes', async function (assert) {
+      const data: TestData = {
+        checkboxes: [],
+      };
+
+      await render(<template>
+        <ToucanForm @data={{data}} as |form|>
+          <form.CheckboxGroup @label="Checkboxes" @name="checkboxes" as |group|>
+            <group.CheckboxField
+              @label="Option 1"
+              @value="option-1"
+              data-checkbox-group-1
+            />
+            <group.CheckboxField
+              @label="Option 2"
+              @value="option-2"
+              @isReadOnly={{true}}
+              data-checkbox-group-2
+            />
+            <group.CheckboxField
+              @label="Option 3"
+              @value="option-3"
+              data-checkbox-group-3
+            />
+          </form.CheckboxGroup>
+        </ToucanForm>
+      </template>);
+
+      assert.dom('[data-checkbox-group-1]').hasNoAttribute('readonly');
+      assert.dom('[data-checkbox-group-2]').hasAttribute('readonly');
+      assert.dom('[data-checkbox-group-3]').hasNoAttribute('readonly');
+    });
+  }
+);

--- a/test-app/tests/integration/components/toucan-form/form-checkbox-test.gts
+++ b/test-app/tests/integration/components/toucan-form/form-checkbox-test.gts
@@ -1,0 +1,34 @@
+/* eslint-disable no-undef -- Until https://github.com/ember-cli/eslint-plugin-ember/issues/1747 is resolved... */
+/* eslint-disable simple-import-sort/imports,padding-line-between-statements,decorator-position/decorator-position -- Can't fix these manually, without --fix working in .gts */
+import { render } from '@ember/test-helpers';
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'test-app/tests/helpers';
+
+import ToucanForm from '@crowdstrike/ember-toucan-form/components/toucan-form';
+
+interface TestData {
+  checked?: boolean;
+}
+
+module('Integration | Component | ToucanForm | Checkbox', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it sets the readonly attribute with `@isReadOnly`', async function (assert) {
+    const data: TestData = {
+      checked: false,
+    };
+
+    await render(<template>
+      <ToucanForm @data={{data}} as |form|>
+        <form.Checkbox
+          @label="Checked"
+          @name="checked"
+          @isReadOnly={{true}}
+          data-checkbox
+        />
+      </ToucanForm>
+    </template>);
+
+    assert.dom('[data-checkbox]').hasAttribute('readonly');
+  });
+});

--- a/test-app/tests/integration/components/toucan-form/form-input-test.gts
+++ b/test-app/tests/integration/components/toucan-form/form-input-test.gts
@@ -1,0 +1,34 @@
+/* eslint-disable no-undef -- Until https://github.com/ember-cli/eslint-plugin-ember/issues/1747 is resolved... */
+/* eslint-disable simple-import-sort/imports,padding-line-between-statements,decorator-position/decorator-position -- Can't fix these manually, without --fix working in .gts */
+import { render } from '@ember/test-helpers';
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'test-app/tests/helpers';
+
+import ToucanForm from '@crowdstrike/ember-toucan-form/components/toucan-form';
+
+interface TestData {
+  text?: string;
+}
+
+module('Integration | Component | ToucanForm | Input', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it sets the readonly attribute with `@isReadOnly`', async function (assert) {
+    const data: TestData = {
+      text: 'text',
+    };
+
+    await render(<template>
+      <ToucanForm @data={{data}} as |form|>
+        <form.Input
+          @label="Text"
+          @name="text"
+          @isReadOnly={{true}}
+          data-input
+        />
+      </ToucanForm>
+    </template>);
+
+    assert.dom('[data-input]').hasAttribute('readonly');
+  });
+});

--- a/test-app/tests/integration/components/toucan-form/form-radio-group-test.gts
+++ b/test-app/tests/integration/components/toucan-form/form-radio-group-test.gts
@@ -1,0 +1,61 @@
+/* eslint-disable no-undef -- Until https://github.com/ember-cli/eslint-plugin-ember/issues/1747 is resolved... */
+/* eslint-disable simple-import-sort/imports,padding-line-between-statements,decorator-position/decorator-position -- Can't fix these manually, without --fix working in .gts */
+import { render } from '@ember/test-helpers';
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'test-app/tests/helpers';
+
+import ToucanForm from '@crowdstrike/ember-toucan-form/components/toucan-form';
+
+interface TestData {
+  radio?: string;
+}
+
+module('Integration | Component | ToucanForm | RadioGroup', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it sets the readonly attribute with `@isReadOnly` at the root', async function (assert) {
+    const data: TestData = {
+      radio: 'option-2',
+    };
+
+    await render(<template>
+      <ToucanForm @data={{data}} as |form|>
+        <form.RadioGroup
+          @label="Radios"
+          @name="radio"
+          @isReadOnly={{true}}
+          as |group|
+        >
+          <group.RadioField @label="option-1" @value="option-1" data-radio-1 />
+          <group.RadioField @label="option-2" @value="option-2" data-radio-2 />
+        </form.RadioGroup>
+      </ToucanForm>
+    </template>);
+
+    assert.dom('[data-radio-1]').hasAttribute('readonly');
+    assert.dom('[data-radio-2]').hasAttribute('readonly');
+  });
+
+  test('it sets the readonly attribute with `@isReadOnly` on individual radios', async function (assert) {
+    const data: TestData = {
+      radio: 'option-2',
+    };
+
+    await render(<template>
+      <ToucanForm @data={{data}} as |form|>
+        <form.RadioGroup @label="Radios" @name="radio" as |group|>
+          <group.RadioField @label="option-1" @value="option-1" data-radio-1 />
+          <group.RadioField
+            @label="option-2"
+            @value="option-2"
+            @isReadOnly={{true}}
+            data-radio-2
+          />
+        </form.RadioGroup>
+      </ToucanForm>
+    </template>);
+
+    assert.dom('[data-radio-1]').hasNoAttribute('readonly');
+    assert.dom('[data-radio-2]').hasAttribute('readonly');
+  });
+});

--- a/test-app/tests/integration/components/toucan-form/form-textarea-test.gts
+++ b/test-app/tests/integration/components/toucan-form/form-textarea-test.gts
@@ -1,0 +1,34 @@
+/* eslint-disable no-undef -- Until https://github.com/ember-cli/eslint-plugin-ember/issues/1747 is resolved... */
+/* eslint-disable simple-import-sort/imports,padding-line-between-statements,decorator-position/decorator-position -- Can't fix these manually, without --fix working in .gts */
+import { render } from '@ember/test-helpers';
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'test-app/tests/helpers';
+
+import ToucanForm from '@crowdstrike/ember-toucan-form/components/toucan-form';
+
+interface TestData {
+  text?: string;
+}
+
+module('Integration | Component | ToucanForm | Textarea', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it sets the readonly attribute with `@isReadOnly`', async function (assert) {
+    const data: TestData = {
+      text: 'multi-line text',
+    };
+
+    await render(<template>
+      <ToucanForm @data={{data}} as |form|>
+        <form.Textarea
+          @label="Text"
+          @name="text"
+          @isReadOnly={{true}}
+          data-textarea
+        />
+      </ToucanForm>
+    </template>);
+
+    assert.dom('[data-textarea]').hasAttribute('readonly');
+  });
+});


### PR DESCRIPTION
## 🚀 Description

This PR adds read only support to all form elements.  https://github.com/CrowdStrike/ember-toucan-core/pull/132 added `@isReadOnly` to core, so this exposes `@isReadOnly` when using these components in toucan-form.

---

## 🔬 How to Test

- Integration tests cover the new functionality, so no new features or anything. Only Component API changes!

---

## 📸 Images/Videos of Functionality

N/A
