### PR TITLE
toucan-form: Input named block support

### DIFF
--- a/packages/ember-toucan-form/src/-private/input-field.hbs
+++ b/packages/ember-toucan-form/src/-private/input-field.hbs
@@ -1,16 +1,83 @@
+{{!
+  Regarding Conditionals
+
+  This looks really messy, but Form::Fields::Input exposes named blocks; HOWEVER,
+  we cannot conditionally render named blocks due to https://github.com/emberjs/rfcs/issues/735.
+
+  We *can* conditionally render components though, based on the blocks and argument combinations
+  users provide us.  This is very brittle, but until https://github.com/emberjs/rfcs/issues/735
+  is resolved and a solution is found, this appears to be the only way to truly expose
+  conditional named blocks.
+
+  ---
+
+  Regarding glint-expect-error
+
+  "@onChange" of the input only expects a string typed value, but field.setValue is generic,
+  accepting anything that DATA[KEY] could be. Similar case with "@value", but there casting to
+  a string is easy.
+}}
 <@form.Field @name={{@name}} as |field|>
-  <Form::Fields::Input
-    @label={{@label}}
-    @hint={{@hint}}
-    @error={{this.mapErrors field.rawErrors}}
-    @value={{this.assertString field.value}}
-    {{! The issue here is that onChange of input only expects a string typed value, but field.setValue is generic, accepting anything that DATA[KEY] could be. Similar case with @value, but there casting to a string is easy. }}
-    {{! @glint-expect-error }}
-    @onChange={{field.setValue}}
-    @isDisabled={{@isDisabled}}
-    @isReadOnly={{@isReadOnly}}
-    @rootTestSelector={{@rootTestSelector}}
-    name={{@name}}
-    ...attributes
-  />
+  {{#if (this.hasOnlyLabelBlock (has-block 'label') (has-block 'hint'))}}
+    <Form::Fields::Input
+      @hint={{@hint}}
+      @error={{this.mapErrors field.rawErrors}}
+      @value={{this.assertString field.value}}
+      {{! @glint-expect-error }}
+      @onChange={{field.setValue}}
+      @isDisabled={{@isDisabled}}
+      @isReadOnly={{@isReadOnly}}
+      @rootTestSelector={{@rootTestSelector}}
+      name={{@name}}
+      ...attributes
+    >
+      <:label>{{yield to='label'}}</:label>
+    </Form::Fields::Input>
+  {{else if (this.hasHintAndLabelBlocks (has-block 'label') (has-block 'hint'))
+  }}
+    <Form::Fields::Input
+      @error={{this.mapErrors field.rawErrors}}
+      @value={{this.assertString field.value}}
+      {{! @glint-expect-error }}
+      @onChange={{field.setValue}}
+      @isDisabled={{@isDisabled}}
+      @isReadOnly={{@isReadOnly}}
+      @rootTestSelector={{@rootTestSelector}}
+      name={{@name}}
+      ...attributes
+    >
+      <:label>{{yield to='label'}}</:label>
+      <:hint>{{yield to='hint'}}</:hint>
+    </Form::Fields::Input>
+  {{else if (this.hasLabelArgAndHintBlock @label (has-block 'hint'))}}
+    <Form::Fields::Input
+      @label={{@label}}
+      @error={{this.mapErrors field.rawErrors}}
+      @value={{this.assertString field.value}}
+      {{! @glint-expect-error }}
+      @onChange={{field.setValue}}
+      @isDisabled={{@isDisabled}}
+      @isReadOnly={{@isReadOnly}}
+      @rootTestSelector={{@rootTestSelector}}
+      name={{@name}}
+      ...attributes
+    >
+      <:hint>{{yield to='hint'}}</:hint>
+    </Form::Fields::Input>
+  {{else}}
+    {{! Argument-only case }}
+    <Form::Fields::Input
+      @label={{@label}}
+      @hint={{@hint}}
+      @error={{this.mapErrors field.rawErrors}}
+      @value={{this.assertString field.value}}
+      {{! @glint-expect-error }}
+      @onChange={{field.setValue}}
+      @isDisabled={{@isDisabled}}
+      @isReadOnly={{@isReadOnly}}
+      @rootTestSelector={{@rootTestSelector}}
+      name={{@name}}
+      ...attributes
+    />
+  {{/if}}
 </@form.Field>

--- a/packages/ember-toucan-form/src/-private/input-field.ts
+++ b/packages/ember-toucan-form/src/-private/input-field.ts
@@ -25,15 +25,20 @@ export interface ToucanFormInputFieldComponentSignature<
      */
     form: HeadlessFormBlock<DATA>;
   };
-  Blocks: {
-    default: [];
-  };
+  Blocks: BaseInputFieldSignature['Blocks'];
 }
 
 export default class ToucanFormInputFieldComponent<
   DATA extends UserData,
   KEY extends FormKey<FormData<DATA>> = FormKey<FormData<DATA>>
 > extends Component<ToucanFormInputFieldComponentSignature<DATA, KEY>> {
+  hasOnlyLabelBlock = (hasLabel: boolean, hasHint: boolean) =>
+    hasLabel && !hasHint;
+  hasHintAndLabelBlocks = (hasLabel: boolean, hasHint: boolean) =>
+    hasLabel && hasHint;
+  hasLabelArgAndHintBlock = (hasLabel: string | undefined, hasHint: boolean) =>
+    hasLabel && hasHint;
+
   mapErrors = (errors?: ValidationError[]) => {
     if (!errors) {
       return;

--- a/test-app/tests/integration/components/toucan-form/form-input-test.gts
+++ b/test-app/tests/integration/components/toucan-form/form-input-test.gts
@@ -31,4 +31,77 @@ module('Integration | Component | ToucanForm | Input', function (hooks) {
 
     assert.dom('[data-input]').hasAttribute('readonly');
   });
+
+  test('it renders `@label` and `@hint` component arguments', async function (assert) {
+    const data: TestData = {
+      text: 'text',
+    };
+
+    await render(<template>
+      <ToucanForm @data={{data}} as |form|>
+        <form.Input @label="Label" @hint="Hint" @name="text" />
+      </ToucanForm>
+    </template>);
+
+    assert.dom('[data-label]').exists();
+    assert.dom('[data-hint]').exists();
+  });
+
+  test('it renders a `:label` named block with a `@hint` argument', async function (assert) {
+    const data: TestData = {
+      text: 'text',
+    };
+
+    await render(<template>
+      <ToucanForm @data={{data}} as |form|>
+        <form.Input @name="text" @hint="Hint">
+          <:label><span data-label-block>Label</span></:label>
+        </form.Input>
+      </ToucanForm>
+    </template>);
+
+    assert.dom('[data-label-block]').exists();
+
+    // NOTE: `data-hint` comes from `@hint`.
+    assert.dom('[data-hint]').exists();
+    assert.dom('[data-hint]').hasText('Hint');
+  });
+
+  test('it renders a `:hint` named block with a `@label` argument', async function (assert) {
+    const data: TestData = {
+      text: 'text',
+    };
+
+    await render(<template>
+      <ToucanForm @data={{data}} as |form|>
+        <form.Input @label="Label" @name="text">
+          <:hint><span data-hint-block>Hint</span></:hint>
+        </form.Input>
+      </ToucanForm>
+    </template>);
+
+    // NOTE: `data-label` comes from `@label`.
+    assert.dom('[data-label]').exists();
+    assert.dom('[data-label]').hasText('Label');
+
+    assert.dom('[data-hint-block]').exists();
+  });
+
+  test('it renders both a `:label` and `:hint` named block', async function (assert) {
+    const data: TestData = {
+      text: 'text',
+    };
+
+    await render(<template>
+      <ToucanForm @data={{data}} as |form|>
+        <form.Input @label="Label" @name="text">
+          <:label><span data-label-block>Label</span></:label>
+          <:hint><span data-hint-block>Hint</span></:hint>
+        </form.Input>
+      </ToucanForm>
+    </template>);
+
+    assert.dom('[data-label-block]').exists();
+    assert.dom('[data-hint-block]').exists();
+  });
 });


### PR DESCRIPTION
**NOTE:** This is going into the `feature-toucan-form-named-blocks` feature branch.  Once everything is feature complete, that branch will be put up for PR to merge into `main` with a changeset.  I'm making separate PRs for these so it's a bit easier to review on a component-by-component basis.

## 🚀 Description

This PR adds named-block support to `form.Input`.

---

## 🔬 How to Test

- Green build
  - We test the named blocks via integration tests

---

## 📸 Images/Videos of Functionality

N/A - this is exposing functionality of `toucan-form` already in `toucan-core`