### PR TITLE
toucan-form: Checkbox named block support

### DIFF
--- a/packages/ember-toucan-form/src/-private/checkbox-field.hbs
+++ b/packages/ember-toucan-form/src/-private/checkbox-field.hbs
@@ -1,16 +1,83 @@
+{{!
+  Regarding Conditionals
+
+  This looks really messy, but Form::Fields::Checkbox exposes named blocks; HOWEVER,
+  we cannot conditionally render named blocks due to https://github.com/emberjs/rfcs/issues/735.
+
+  We *can* conditionally render components though, based on the blocks and argument combinations
+  users provide us.  This is very brittle, but until https://github.com/emberjs/rfcs/issues/735
+  is resolved and a solution is found, this appears to be the only way to truly expose
+  conditional named blocks.
+
+  ---
+
+  Regarding glint-expect-error
+
+  "@onChange" of the checkbox only expects a boolean typed value, but field.setValue is generic,
+  accepting anything that DATA[KEY] could be. Similar case with "@isChecked", but there casting to
+  a boolean is easy.
+}}
 <@form.Field @name={{@name}} as |field|>
-  <Form::Fields::Checkbox
-    @label={{@label}}
-    @hint={{@hint}}
-    @error={{this.mapErrors field.rawErrors}}
-    @isChecked={{this.assertBoolean field.value}}
-    {{! The issue here is that onChange only expects a string typed value, but field.setValue is generic, accepting anything that DATA[KEY] could be. }}
-    {{! @glint-expect-error }}
-    @onChange={{field.setValue}}
-    @isDisabled={{@isDisabled}}
-    @isReadOnly={{@isReadOnly}}
-    @rootTestSelector={{@rootTestSelector}}
-    name={{@name}}
-    ...attributes
-  />
+  {{#if (this.hasOnlyLabelBlock (has-block 'label') (has-block 'hint'))}}
+    <Form::Fields::Checkbox
+      @hint={{@hint}}
+      @error={{this.mapErrors field.rawErrors}}
+      @isChecked={{this.assertBoolean field.value}}
+      {{! @glint-expect-error }}
+      @onChange={{field.setValue}}
+      @isDisabled={{@isDisabled}}
+      @isReadOnly={{@isReadOnly}}
+      @rootTestSelector={{@rootTestSelector}}
+      name={{@name}}
+      ...attributes
+    >
+      <:label>{{yield to='label'}}</:label>
+    </Form::Fields::Checkbox>
+  {{else if (this.hasHintAndLabelBlocks (has-block 'label') (has-block 'hint'))
+  }}
+    <Form::Fields::Checkbox
+      @error={{this.mapErrors field.rawErrors}}
+      @isChecked={{this.assertBoolean field.value}}
+      {{! @glint-expect-error }}
+      @onChange={{field.setValue}}
+      @isDisabled={{@isDisabled}}
+      @isReadOnly={{@isReadOnly}}
+      @rootTestSelector={{@rootTestSelector}}
+      name={{@name}}
+      ...attributes
+    >
+      <:label>{{yield to='label'}}</:label>
+      <:hint>{{yield to='hint'}}</:hint>
+    </Form::Fields::Checkbox>
+  {{else if (this.hasLabelArgAndHintBlock @label (has-block 'hint'))}}
+    <Form::Fields::Checkbox
+      @label={{@label}}
+      @error={{this.mapErrors field.rawErrors}}
+      @isChecked={{this.assertBoolean field.value}}
+      {{! @glint-expect-error }}
+      @onChange={{field.setValue}}
+      @isDisabled={{@isDisabled}}
+      @isReadOnly={{@isReadOnly}}
+      @rootTestSelector={{@rootTestSelector}}
+      name={{@name}}
+      ...attributes
+    >
+      <:hint>{{yield to='hint'}}</:hint>
+    </Form::Fields::Checkbox>
+  {{else}}
+    {{! Argument-only case }}
+    <Form::Fields::Checkbox
+      @label={{@label}}
+      @hint={{@hint}}
+      @error={{this.mapErrors field.rawErrors}}
+      @isChecked={{this.assertBoolean field.value}}
+      {{! @glint-expect-error }}
+      @onChange={{field.setValue}}
+      @isDisabled={{@isDisabled}}
+      @isReadOnly={{@isReadOnly}}
+      @rootTestSelector={{@rootTestSelector}}
+      name={{@name}}
+      ...attributes
+    />
+  {{/if}}
 </@form.Field>

--- a/packages/ember-toucan-form/src/-private/checkbox-field.ts
+++ b/packages/ember-toucan-form/src/-private/checkbox-field.ts
@@ -25,15 +25,20 @@ export interface ToucanFormCheckboxFieldComponentSignature<
      */
     form: HeadlessFormBlock<DATA>;
   };
-  Blocks: {
-    default: [];
-  };
+  Blocks: BaseCheckboxFieldSignature['Blocks'];
 }
 
 export default class ToucanFormTextareaFieldComponent<
   DATA extends UserData,
   KEY extends FormKey<FormData<DATA>> = FormKey<FormData<DATA>>
 > extends Component<ToucanFormCheckboxFieldComponentSignature<DATA, KEY>> {
+  hasOnlyLabelBlock = (hasLabel: boolean, hasHint: boolean) =>
+    hasLabel && !hasHint;
+  hasHintAndLabelBlocks = (hasLabel: boolean, hasHint: boolean) =>
+    hasLabel && hasHint;
+  hasLabelArgAndHintBlock = (hasLabel: string | undefined, hasHint: boolean) =>
+    hasLabel && hasHint;
+
   mapErrors = (errors?: ValidationError[]) => {
     if (!errors) {
       return;

--- a/test-app/tests/integration/components/toucan-form/form-checkbox-test.gts
+++ b/test-app/tests/integration/components/toucan-form/form-checkbox-test.gts
@@ -31,4 +31,77 @@ module('Integration | Component | ToucanForm | Checkbox', function (hooks) {
 
     assert.dom('[data-checkbox]').hasAttribute('readonly');
   });
+
+  test('it renders `@label` and `@hint` component arguments', async function (assert) {
+    const data: TestData = {
+      checked: false,
+    };
+
+    await render(<template>
+      <ToucanForm @data={{data}} as |form|>
+        <form.Checkbox @label="Label" @hint="Hint" @name="checked" />
+      </ToucanForm>
+    </template>);
+
+    assert.dom('[data-label]').exists();
+    assert.dom('[data-hint]').exists();
+  });
+
+  test('it renders a `:label` named block with a `@hint` argument', async function (assert) {
+    const data: TestData = {
+      checked: false,
+    };
+
+    await render(<template>
+      <ToucanForm @data={{data}} as |form|>
+        <form.Checkbox @name="checked" @hint="Hint">
+          <:label><span data-label-block>Label</span></:label>
+        </form.Checkbox>
+      </ToucanForm>
+    </template>);
+
+    assert.dom('[data-label-block]').exists();
+
+    // NOTE: `data-hint` comes from `@hint`.
+    assert.dom('[data-hint]').exists();
+    assert.dom('[data-hint]').hasText('Hint');
+  });
+
+  test('it renders a `:hint` named block with a `@label` argument', async function (assert) {
+    const data: TestData = {
+      checked: false,
+    };
+
+    await render(<template>
+      <ToucanForm @data={{data}} as |form|>
+        <form.Checkbox @label="Label" @name="checked">
+          <:hint><span data-hint-block>Hint</span></:hint>
+        </form.Checkbox>
+      </ToucanForm>
+    </template>);
+
+    // NOTE: `data-label` comes from `@label`.
+    assert.dom('[data-label]').exists();
+    assert.dom('[data-label]').hasText('Label');
+
+    assert.dom('[data-hint-block]').exists();
+  });
+
+  test('it renders both a `:label` and `:hint` named block', async function (assert) {
+    const data: TestData = {
+      checked: false,
+    };
+
+    await render(<template>
+      <ToucanForm @data={{data}} as |form|>
+        <form.Checkbox @label="Label" @name="checked">
+          <:label><span data-label-block>Label</span></:label>
+          <:hint><span data-hint-block>Hint</span></:hint>
+        </form.Checkbox>
+      </ToucanForm>
+    </template>);
+
+    assert.dom('[data-label-block]').exists();
+    assert.dom('[data-hint-block]').exists();
+  });
 });


### PR DESCRIPTION
**NOTE:** This is going into the `feature-toucan-form-named-blocks` feature branch.  Once everything is feature complete, that branch will be put up for PR to merge into `main` with a changeset.  I'm making separate PRs for these so it's a bit easier to review on a component-by-component basis.

Downstream of https://github.com/CrowdStrike/ember-toucan-core/pull/150

---

## 🚀 Description

This PR adds named-block support to `form.Checkbox`.

---

## 🔬 How to Test

- Green build
  - We test the named blocks via integration tests

---

## 📸 Images/Videos of Functionality

N/A - this is exposing functionality of `toucan-form` already in `toucan-core`