### PR TITLE
toucan-form: CheckboxGroup named block support

### DIFF
--- a/packages/ember-toucan-form/src/-private/checkbox-group-field.hbs
+++ b/packages/ember-toucan-form/src/-private/checkbox-group-field.hbs
@@ -1,19 +1,95 @@
+{{!
+  Regarding Conditionals
+
+  This looks really messy, but Form::Fields::CheckboxGroup exposes named blocks; HOWEVER,
+  we cannot conditionally render named blocks due to https://github.com/emberjs/rfcs/issues/735.
+
+  We *can* conditionally render components though, based on the blocks and argument combinations
+  users provide us.  This is very brittle, but until https://github.com/emberjs/rfcs/issues/735
+  is resolved and a solution is found, this appears to be the only way to truly expose
+  conditional named blocks.
+
+  ---
+
+  Regarding glint-expect-error
+
+  "@onChange" of the checkbox-group only expects an array of strings typed value, but field.setValue is generic,
+  accepting anything that DATA[KEY] could be. Similar case with "@isChecked", but there casting to
+  an array of strings is easy.
+}}
 <@form.Field @name={{@name}} as |field|>
-  <Form::Fields::CheckboxGroup
-    @label={{@label}}
-    @hint={{@hint}}
-    @error={{this.mapErrors field.rawErrors}}
-    @value={{this.assertArrayOfStrings field.value}}
-    {{! The issue here is that onChange only expects a string typed value, but field.setValue is generic, accepting anything that DATA[KEY] could be. Similar case with @value, but there casting is easy. }}
-    {{! @glint-expect-error }}
-    @onChange={{field.setValue}}
-    @isDisabled={{@isDisabled}}
-    @isReadOnly={{@isReadOnly}}
-    @rootTestSelector={{@rootTestSelector}}
-    @name={{@name}}
-    ...attributes
-    as |group|
-  >
-    {{yield (hash CheckboxField=group.CheckboxField)}}
-  </Form::Fields::CheckboxGroup>
+  {{#if (this.hasOnlyLabelBlock (has-block 'label') (has-block 'hint'))}}
+    <Form::Fields::CheckboxGroup
+      @hint={{@hint}}
+      @error={{this.mapErrors field.rawErrors}}
+      @value={{this.assertArrayOfStrings field.value}}
+      {{! @glint-expect-error }}
+      @onChange={{field.setValue}}
+      @isDisabled={{@isDisabled}}
+      @isReadOnly={{@isReadOnly}}
+      @rootTestSelector={{@rootTestSelector}}
+      @name={{@name}}
+      ...attributes
+    >
+      <:label>{{yield to='label'}}</:label>
+      <:default as |group|>
+        {{yield (hash CheckboxField=group.CheckboxField) to='default'}}
+      </:default>
+    </Form::Fields::CheckboxGroup>
+  {{else if (this.hasHintAndLabelBlocks (has-block 'label') (has-block 'hint'))
+  }}
+    <Form::Fields::CheckboxGroup
+      @error={{this.mapErrors field.rawErrors}}
+      @value={{this.assertArrayOfStrings field.value}}
+      {{! @glint-expect-error }}
+      @onChange={{field.setValue}}
+      @isDisabled={{@isDisabled}}
+      @isReadOnly={{@isReadOnly}}
+      @rootTestSelector={{@rootTestSelector}}
+      @name={{@name}}
+      ...attributes
+    >
+      <:label>{{yield to='label'}}</:label>
+      <:hint>{{yield to='hint'}}</:hint>
+      <:default as |group|>
+        {{yield (hash CheckboxField=group.CheckboxField)}}
+      </:default>
+    </Form::Fields::CheckboxGroup>
+  {{else if (this.hasLabelArgAndHintBlock @label (has-block 'hint'))}}
+    <Form::Fields::CheckboxGroup
+      @label={{@label}}
+      @error={{this.mapErrors field.rawErrors}}
+      @value={{this.assertArrayOfStrings field.value}}
+      {{! @glint-expect-error }}
+      @onChange={{field.setValue}}
+      @isDisabled={{@isDisabled}}
+      @isReadOnly={{@isReadOnly}}
+      @rootTestSelector={{@rootTestSelector}}
+      @name={{@name}}
+      ...attributes
+    >
+      <:hint>{{yield to='hint'}}</:hint>
+      <:default as |group|>
+        {{yield (hash CheckboxField=group.CheckboxField)}}
+      </:default>
+    </Form::Fields::CheckboxGroup>
+  {{else}}
+    {{! Argument-only case }}
+    <Form::Fields::CheckboxGroup
+      @label={{@label}}
+      @hint={{@hint}}
+      @error={{this.mapErrors field.rawErrors}}
+      @value={{this.assertArrayOfStrings field.value}}
+      {{! @glint-expect-error }}
+      @onChange={{field.setValue}}
+      @isDisabled={{@isDisabled}}
+      @isReadOnly={{@isReadOnly}}
+      @rootTestSelector={{@rootTestSelector}}
+      @name={{@name}}
+      ...attributes
+      as |group|
+    >
+      {{yield (hash CheckboxField=group.CheckboxField)}}
+    </Form::Fields::CheckboxGroup>
+  {{/if}}
 </@form.Field>

--- a/packages/ember-toucan-form/src/-private/checkbox-group-field.ts
+++ b/packages/ember-toucan-form/src/-private/checkbox-group-field.ts
@@ -25,19 +25,20 @@ export interface ToucanFormCheckboxGroupFieldComponentSignature<
      */
     form: HeadlessFormBlock<DATA>;
   };
-  Blocks: {
-    default: [
-      {
-        CheckboxField: BaseCheckboxGroupFieldSignature['Blocks']['default'][0]['CheckboxField'];
-      }
-    ];
-  };
+  Blocks: BaseCheckboxGroupFieldSignature['Blocks'];
 }
 
 export default class ToucanFormTextareaFieldComponent<
   DATA extends UserData,
   KEY extends FormKey<FormData<DATA>> = FormKey<FormData<DATA>>
 > extends Component<ToucanFormCheckboxGroupFieldComponentSignature<DATA, KEY>> {
+  hasOnlyLabelBlock = (hasLabel: boolean, hasHint: boolean) =>
+    hasLabel && !hasHint;
+  hasHintAndLabelBlocks = (hasLabel: boolean, hasHint: boolean) =>
+    hasLabel && hasHint;
+  hasLabelArgAndHintBlock = (hasLabel: string | undefined, hasHint: boolean) =>
+    hasLabel && hasHint;
+
   mapErrors = (errors?: ValidationError[]) => {
     if (!errors) {
       return;

--- a/test-app/tests/integration/components/toucan-form/form-checkbox-group-test.gts
+++ b/test-app/tests/integration/components/toucan-form/form-checkbox-group-test.gts
@@ -84,5 +84,154 @@ module(
       assert.dom('[data-checkbox-group-2]').hasAttribute('readonly');
       assert.dom('[data-checkbox-group-3]').hasNoAttribute('readonly');
     });
+
+    test('it renders `@label` and `@hint` component arguments', async function (assert) {
+      const data: TestData = {
+        checkboxes: [],
+      };
+
+      await render(<template>
+        <ToucanForm @data={{data}} as |form|>
+          <form.CheckboxGroup
+            @label="Label"
+            @hint="Hint"
+            @name="checkboxes"
+            as |group|
+          >
+            <group.CheckboxField
+              @label="Option 1"
+              @value="option-1"
+              data-checkbox-group-1
+            />
+            <group.CheckboxField
+              @label="Option 2"
+              @value="option-2"
+              @isReadOnly={{true}}
+              data-checkbox-group-2
+            />
+            <group.CheckboxField
+              @label="Option 3"
+              @value="option-3"
+              data-checkbox-group-3
+            />
+          </form.CheckboxGroup>
+        </ToucanForm>
+      </template>);
+
+      assert.dom('[data-label]').exists();
+      assert.dom('[data-hint]').exists();
+    });
+
+    test('it renders a `:label` named block with a `@hint` argument', async function (assert) {
+      const data: TestData = {
+        checkboxes: [],
+      };
+
+      await render(<template>
+        <ToucanForm @data={{data}} as |form|>
+          <form.CheckboxGroup @hint="Hint" @name="checkboxes">
+            <:label><span data-label-block>Label</span></:label>
+            <:default as |group|>
+              <group.CheckboxField
+                @label="Option 1"
+                @value="option-1"
+                data-checkbox-group-1
+              />
+              <group.CheckboxField
+                @label="Option 2"
+                @value="option-2"
+                @isReadOnly={{true}}
+                data-checkbox-group-2
+              />
+              <group.CheckboxField
+                @label="Option 3"
+                @value="option-3"
+                data-checkbox-group-3
+              />
+            </:default>
+          </form.CheckboxGroup>
+        </ToucanForm>
+      </template>);
+
+      assert.dom('[data-label-block]').exists();
+
+      // NOTE: `data-hint` comes from `@hint`.
+      assert.dom('[data-hint]').exists();
+      assert.dom('[data-hint]').hasText('Hint');
+    });
+
+    test('it renders a `:hint` named block with a `@label` argument', async function (assert) {
+      const data: TestData = {
+        checkboxes: [],
+      };
+
+      await render(<template>
+        <ToucanForm @data={{data}} as |form|>
+          <form.CheckboxGroup @label="Label" @name="checkboxes">
+            <:hint><span data-hint-block>Hint</span></:hint>
+            <:default as |group|>
+              <group.CheckboxField
+                @label="Option 1"
+                @value="option-1"
+                data-checkbox-group-1
+              />
+              <group.CheckboxField
+                @label="Option 2"
+                @value="option-2"
+                @isReadOnly={{true}}
+                data-checkbox-group-2
+              />
+              <group.CheckboxField
+                @label="Option 3"
+                @value="option-3"
+                data-checkbox-group-3
+              />
+            </:default>
+          </form.CheckboxGroup>
+        </ToucanForm>
+      </template>);
+
+      // NOTE: `data-label` comes from `@label`.
+      assert.dom('[data-label]').exists();
+      assert.dom('[data-label]').hasText('Label');
+
+      assert.dom('[data-hint-block]').exists();
+    });
+
+    test('it renders both a `:label` and `:hint` named block', async function (assert) {
+      const data: TestData = {
+        checkboxes: [],
+      };
+
+      await render(<template>
+        <ToucanForm @data={{data}} as |form|>
+          <form.CheckboxGroup @name="checkboxes">
+            <:label><span data-label-block>Label</span></:label>
+            <:hint><span data-hint-block>Hint</span></:hint>
+            <:default as |group|>
+              <group.CheckboxField
+                @label="Option 1"
+                @value="option-1"
+                data-checkbox-group-1
+              />
+              <group.CheckboxField
+                @label="Option 2"
+                @value="option-2"
+                @isReadOnly={{true}}
+                data-checkbox-group-2
+              />
+              <group.CheckboxField
+                @label="Option 3"
+                @value="option-3"
+                data-checkbox-group-3
+              />
+            </:default>
+          </form.CheckboxGroup>
+        </ToucanForm>
+      </template>);
+
+      assert.dom('[data-label-block]').exists();
+      assert.dom('[data-hint-block]').exists();
+    });
   }
 );


### PR DESCRIPTION
**NOTE:** This is going into the `feature-toucan-form-named-blocks` feature branch.  Once everything is feature complete, that branch will be put up for PR to merge into `main` with a changeset.  I'm making separate PRs for these so it's a bit easier to review on a component-by-component basis.

Downstream of https://github.com/CrowdStrike/ember-toucan-core/pull/150

---

## 🚀 Description

This PR adds named-block support to `form.CheckboxGroup`.

---

## 🔬 How to Test

- Green build
  - We test the named blocks via integration tests

---

## 📸 Images/Videos of Functionality

N/A - this is exposing functionality of `toucan-form` already in `toucan-core`