### PR TITLE
chore: remove unused ember-cached-decorator-polyfill

### DIFF
--- a/docs-app/package.json
+++ b/docs-app/package.json
@@ -136,7 +136,6 @@
     "@embroider/router": "^2.0.0",
     "dompurify": "^3.0.0",
     "ember-browser-services": "^4.0.4",
-    "ember-cached-decorator-polyfill": "^1.0.1",
     "ember-modifier": "^4.1.0",
     "ember-resources": "^6.0.0",
     "highlight.js": "^11.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,9 +46,6 @@ importers:
       ember-browser-services:
         specifier: ^4.0.4
         version: 4.0.4
-      ember-cached-decorator-polyfill:
-        specifier: ^1.0.1
-        version: 1.0.1(@babel/core@7.20.12)(ember-source@5.0.0)
       ember-modifier:
         specifier: ^4.1.0
         version: 4.1.0(ember-source@5.0.0)
@@ -3345,7 +3342,7 @@ packages:
   /@changesets/apply-release-plan@6.1.3:
     resolution: {integrity: sha512-ECDNeoc3nfeAe1jqJb5aFQX7CqzQhD2klXRez2JDb/aVpGUbX673HgKrnrgJRuQR/9f2TtLoYIzrGB9qwD77mg==}
     dependencies:
-      '@babel/runtime': 7.20.13
+      '@babel/runtime': 7.21.5
       '@changesets/config': 2.3.0
       '@changesets/get-version-range-type': 0.3.2
       '@changesets/git': 2.0.0
@@ -3362,7 +3359,7 @@ packages:
   /@changesets/assemble-release-plan@5.2.3:
     resolution: {integrity: sha512-g7EVZCmnWz3zMBAdrcKhid4hkHT+Ft1n0mLussFMcB1dE2zCuwcvGoy9ec3yOgPGF4hoMtgHaMIk3T3TBdvU9g==}
     dependencies:
-      '@babel/runtime': 7.20.13
+      '@babel/runtime': 7.21.5
       '@changesets/errors': 0.1.4
       '@changesets/get-dependents-graph': 1.3.5
       '@changesets/types': 5.2.1
@@ -3426,7 +3423,7 @@ packages:
     resolution: {integrity: sha512-XnTa+b51vt057fyAudvDKGB0Sh72xutQZNAdXkCqPBKO2zvs2yYZx5hFZj1u9cbtpwM6Sxtcr02/FQJfZOzemQ==}
     hasBin: true
     dependencies:
-      '@babel/runtime': 7.20.13
+      '@babel/runtime': 7.21.5
       '@changesets/apply-release-plan': 6.1.3
       '@changesets/assemble-release-plan': 5.2.3
       '@changesets/changelog-git': 0.1.14
@@ -3496,7 +3493,7 @@ packages:
   /@changesets/get-release-plan@3.0.16:
     resolution: {integrity: sha512-OpP9QILpBp1bY2YNIKFzwigKh7Qe9KizRsZomzLe6pK8IUo8onkAAVUD8+JRKSr8R7d4+JRuQrfSSNlEwKyPYg==}
     dependencies:
-      '@babel/runtime': 7.20.13
+      '@babel/runtime': 7.21.5
       '@changesets/assemble-release-plan': 5.2.3
       '@changesets/config': 2.3.0
       '@changesets/pre': 1.0.14
@@ -3510,7 +3507,7 @@ packages:
   /@changesets/git@2.0.0:
     resolution: {integrity: sha512-enUVEWbiqUTxqSnmesyJGWfzd51PY4H7mH9yUw0hPVpZBJ6tQZFMU3F3mT/t9OJ/GjyiM4770i+sehAn6ymx6A==}
     dependencies:
-      '@babel/runtime': 7.20.13
+      '@babel/runtime': 7.21.5
       '@changesets/errors': 0.1.4
       '@changesets/types': 5.2.1
       '@manypkg/get-packages': 1.1.3
@@ -3532,7 +3529,7 @@ packages:
   /@changesets/pre@1.0.14:
     resolution: {integrity: sha512-dTsHmxQWEQekHYHbg+M1mDVYFvegDh9j/kySNuDKdylwfMEevTeDouR7IfHNyVodxZXu17sXoJuf2D0vi55FHQ==}
     dependencies:
-      '@babel/runtime': 7.20.13
+      '@babel/runtime': 7.21.5
       '@changesets/errors': 0.1.4
       '@changesets/types': 5.2.1
       '@manypkg/get-packages': 1.1.3
@@ -3541,7 +3538,7 @@ packages:
   /@changesets/read@0.5.9:
     resolution: {integrity: sha512-T8BJ6JS6j1gfO1HFq50kU3qawYxa4NTbI/ASNVVCBTsKquy2HYwM9r7ZnzkiMe8IEObAJtUVGSrePCOxAK2haQ==}
     dependencies:
-      '@babel/runtime': 7.20.13
+      '@babel/runtime': 7.21.5
       '@changesets/git': 2.0.0
       '@changesets/logger': 0.0.5
       '@changesets/parse': 0.3.16
@@ -3559,7 +3556,7 @@ packages:
   /@changesets/write@0.2.3:
     resolution: {integrity: sha512-Dbamr7AIMvslKnNYsLFafaVORx4H0pvCA2MHqgtNCySMe1blImEyAEOzDmcgKAkgz4+uwoLz7demIrX+JBr/Xw==}
     dependencies:
-      '@babel/runtime': 7.20.13
+      '@babel/runtime': 7.21.5
       '@changesets/types': 5.2.1
       fs-extra: 7.0.1
       human-id: 1.0.2
@@ -3765,7 +3762,7 @@ packages:
       ember-cli-babel: 7.26.11
       ember-cli-htmlbars: 6.2.0
       ember-destroyable-polyfill: 2.0.3(@babel/core@7.20.12)
-      ember-source: 5.0.0(@babel/core@7.20.12)(@glimmer/component@1.1.2)(webpack@5.75.0)
+      ember-source: 5.0.0(@babel/core@7.20.12)(@glimmer/component@1.1.2)
     transitivePeerDependencies:
       - '@babel/core'
       - '@glint/template'
@@ -4022,7 +4019,7 @@ packages:
       '@glint/template': 1.0.2
       broccoli-funnel: 3.0.8
       ember-cli-babel: 7.26.11
-      ember-source: 5.0.0(@babel/core@7.20.12)(@glimmer/component@1.1.2)(webpack@5.75.0)
+      ember-source: 5.0.0(@babel/core@7.20.12)(@glimmer/component@1.1.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -4481,7 +4478,7 @@ packages:
   /@manypkg/get-packages@1.1.3:
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
     dependencies:
-      '@babel/runtime': 7.20.13
+      '@babel/runtime': 7.21.5
       '@changesets/types': 4.1.0
       '@manypkg/find-root': 1.1.0
       fs-extra: 8.1.0
@@ -6276,7 +6273,6 @@ packages:
       loader-utils: 2.0.4
       make-dir: 3.1.0
       schema-utils: 2.7.1
-    dev: true
 
   /babel-loader@8.3.0(@babel/core@7.20.12)(webpack@5.75.0):
     resolution: {integrity: sha512-H8SvsMF+m9t15HNLMipppzkC+Y2Yq+v3SonZyU70RBL/h1gxPkH08Ot8pEE9Z4Kd+czyWJClmFS8qzIP9OZ04Q==}
@@ -8404,7 +8400,6 @@ packages:
       postcss-value-parser: 4.2.0
       schema-utils: 3.1.1
       semver: 7.5.1
-    dev: true
 
   /css-loader@5.2.7(webpack@5.75.0):
     resolution: {integrity: sha512-Q7mOvpBNBG7YrVGMxRxcBJZFL75o+cH2abNASdibkj/fffYD8qWbInZrD0S9ccI6vZclF3DsHE7njGlLtaHbhg==}
@@ -8993,7 +8988,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
       - webpack
-    dev: true
 
   /ember-auto-import@2.6.0(webpack@5.75.0):
     resolution: {integrity: sha512-xUyypxlaqWvrx2KSseLus0H8K7Dt+sXNCvcxtquT2EmIM6r67NuQUT9woiEMa9UBvqcaX2k9hNLeubDl78saig==}
@@ -9040,37 +9034,6 @@ packages:
       ember-window-mock: 0.8.1
     transitivePeerDependencies:
       - supports-color
-
-  /ember-cache-primitive-polyfill@1.0.1(@babel/core@7.20.12):
-    resolution: {integrity: sha512-hSPcvIKarA8wad2/b6jDd/eU+OtKmi6uP+iYQbzi5TQpjsqV6b4QdRqrLk7ClSRRKBAtdTuutx+m+X+WlEd2lw==}
-    engines: {node: 10.* || >= 12}
-    dependencies:
-      ember-cli-babel: 7.26.11
-      ember-cli-version-checker: 5.1.2
-      ember-compatibility-helpers: 1.2.6(@babel/core@7.20.12)
-      silent-error: 1.1.1
-    transitivePeerDependencies:
-      - '@babel/core'
-      - supports-color
-    dev: false
-
-  /ember-cached-decorator-polyfill@1.0.1(@babel/core@7.20.12)(ember-source@5.0.0):
-    resolution: {integrity: sha512-VDgrpIJ6rDDHIfkYrsFR1BM3fpcC0+zFWIOsX0qY44zPrIXjhQWVXs2iVXLIPHprSgf+tFQ3ESxwDscpeRe/0A==}
-    engines: {node: 14.* || >= 16}
-    peerDependencies:
-      ember-source: ^3.13.0 || ^4.0.0
-    dependencies:
-      '@embroider/macros': 1.10.0
-      '@glimmer/tracking': 1.1.2
-      babel-import-util: 1.3.0
-      ember-cache-primitive-polyfill: 1.0.1(@babel/core@7.20.12)
-      ember-cli-babel: 7.26.11
-      ember-cli-babel-plugin-helpers: 1.1.1
-      ember-source: 5.0.0(@babel/core@7.20.12)(@glimmer/component@1.1.2)(webpack@5.75.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - supports-color
-    dev: false
 
   /ember-changeset-validations@4.1.1(webpack@5.75.0):
     resolution: {integrity: sha512-lRT+LOwY+kTMRC/op85L6+FFHDuOkoQvqgexexTiLFECiTNw4vQbOrcAqhfe6n/QJBr5uypZ+bg4W1Ng34dkMg==}
@@ -9726,7 +9689,7 @@ packages:
       '@glimmer/tracking': 1.1.2
       ember-async-data: 0.7.0
       ember-modifier: 4.1.0(ember-source@5.0.0)
-      ember-source: 5.0.0(@babel/core@7.20.12)(@glimmer/component@1.1.2)(webpack@5.75.0)
+      ember-source: 5.0.0(@babel/core@7.21.4)(@glimmer/component@1.1.2)
       tracked-built-ins: 3.1.1
     transitivePeerDependencies:
       - '@glint/template'
@@ -9931,7 +9894,6 @@ packages:
       - '@babel/core'
       - supports-color
       - webpack
-    dev: true
 
   /ember-source@5.0.0(@babel/core@7.20.12)(@glimmer/component@1.1.2)(webpack@5.75.0):
     resolution: {integrity: sha512-zy0iU3Mf9HZXVQacqWLAfHCbQge8Ysi2EpU6XTgrdf2PX5ILdWTbSPklxuTlkGV7NrG5PkIfGW8hfimwY6I/tw==}
@@ -10400,7 +10362,7 @@ packages:
       debug: 4.3.4
       enhanced-resolve: 5.12.0
       eslint: 8.33.0
-      eslint-plugin-import: 2.27.5(eslint-import-resolver-typescript@3.5.3)(eslint@8.33.0)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.50.0)(eslint-import-resolver-typescript@3.5.3)(eslint@8.33.0)
       get-tsconfig: 4.3.0
       globby: 13.1.4
       is-core-module: 2.12.1
@@ -10536,7 +10498,7 @@ packages:
     dev: true
 
   /eslint-plugin-es@4.1.0(eslint@8.33.0):
-    resolution: {integrity: sha512-GILhQTnjYE2WorX5Jyi5i4dz5ALWxBIdQECVQavL6s7cI76IZTDWleTHkxz/QT3kvcs2QlGHvKLYsSlPOlPXnQ==}
+    resolution: {integrity: sha512-GILhQTnjYE2WorX5Jyi5i4dz5ALWxBIdQECVQavL6s7cI76IZTDWleTHkxz/QT3kvcs2QlGHvKLYsSlPOlPXnQ==, tarball: eslint-plugin-es/-/eslint-plugin-es-4.1.0.tgz}
     engines: {node: '>=8.10.0'}
     peerDependencies:
       eslint: '>=4.19.1'
@@ -13746,7 +13708,6 @@ packages:
         optional: true
     dependencies:
       schema-utils: 4.0.0
-    dev: true
 
   /mini-css-extract-plugin@2.7.2(webpack@5.75.0):
     resolution: {integrity: sha512-EdlUizq13o0Pd+uCp+WO/JpkLvHRVGt97RqfeGhXqAcorYo1ypJSpkV+WDT0vY/kmh/p7wRdJNJtuyK540PXDw==}
@@ -16599,7 +16560,6 @@ packages:
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.1.1
-    dev: true
 
   /style-loader@2.0.0(webpack@5.75.0):
     resolution: {integrity: sha512-Z0gYUJmzZ6ZdRUqpg1r8GsaFKypE+3xAzuFeMuoHgjc9KZv3wMyCRjQIWEbhoFSq7+7yoHXySDJyyWQaPajeiQ==}
@@ -18119,7 +18079,7 @@ packages:
       postcss: ^8.2.14
       tailwindcss: ^2.2.15 || ^3.0.0
     dependencies:
-      '@babel/runtime': 7.20.13
+      '@babel/runtime': 7.21.5
       '@crowdstrike/ember-toucan-styles': 2.0.1(@glimmer/tracking@1.1.2)(autoprefixer@10.4.13)(ember-source@5.0.0)(postcss@8.4.21)(tailwindcss@2.2.19)
       '@ember/test-helpers': 2.9.3(@babel/core@7.21.4)(@glint/template@1.0.2)(ember-source@5.0.0)
       '@embroider/addon-shim': 1.8.4
@@ -18148,7 +18108,7 @@ packages:
       postcss: ^8.2.14
       tailwindcss: ^2.2.15 || ^3.0.0
     dependencies:
-      '@babel/runtime': 7.20.13
+      '@babel/runtime': 7.21.5
       '@crowdstrike/ember-toucan-styles': 2.0.1(@glimmer/tracking@1.1.2)(autoprefixer@10.4.13)(ember-source@5.0.0)(postcss@8.4.21)(tailwindcss@3.2.4)
       '@ember/test-helpers': 2.9.3(@babel/core@7.20.12)(@glint/template@1.0.2)(ember-source@5.0.0)
       '@embroider/addon-shim': 1.8.4
@@ -18177,7 +18137,7 @@ packages:
       postcss: ^8.2.14
       tailwindcss: ^2.2.15 || ^3.0.0
     dependencies:
-      '@babel/runtime': 7.20.13
+      '@babel/runtime': 7.21.5
       '@crowdstrike/ember-toucan-core': file:packages/ember-toucan-core(@crowdstrike/ember-toucan-styles@2.0.1)(@ember/test-helpers@2.9.3)(@glimmer/tracking@1.1.2)(autoprefixer@10.4.13)(ember-source@5.0.0)(fractal-page-object@0.4.0)(postcss@8.4.21)(tailwindcss@2.2.19)
       '@crowdstrike/ember-toucan-styles': 2.0.1(@glimmer/tracking@1.1.2)(autoprefixer@10.4.13)(ember-source@5.0.0)(postcss@8.4.21)(tailwindcss@2.2.19)
       '@ember/test-helpers': 2.9.3(@babel/core@7.20.12)(@glint/template@1.0.2)(ember-source@5.0.0)
@@ -18207,7 +18167,7 @@ packages:
       postcss: ^8.2.14
       tailwindcss: ^2.2.15 || ^3.0.0
     dependencies:
-      '@babel/runtime': 7.20.13
+      '@babel/runtime': 7.21.5
       '@crowdstrike/ember-toucan-core': file:packages/ember-toucan-core(@crowdstrike/ember-toucan-styles@2.0.1)(@ember/test-helpers@2.9.3)(@glimmer/tracking@1.1.2)(autoprefixer@10.4.13)(ember-source@5.0.0)(fractal-page-object@0.4.0)(postcss@8.4.21)(tailwindcss@3.2.4)
       '@crowdstrike/ember-toucan-styles': 2.0.1(@glimmer/tracking@1.1.2)(autoprefixer@10.4.13)(ember-source@5.0.0)(postcss@8.4.21)(tailwindcss@3.2.4)
       '@ember/test-helpers': 2.9.3(@babel/core@7.20.12)(@glint/template@1.0.2)(ember-source@5.0.0)


### PR DESCRIPTION
We don't need this, as we are already on an Ember version that supports `@cached` natively (>= 4.1).

This will also fix running into https://github.com/CrowdStrike/ember-headless-form/issues/146 for the docs-app.
