### PR TITLE
chore: Add engines and volta fields to package.json

### DIFF
--- a/.github/actions/pnpm/action.yml
+++ b/.github/actions/pnpm/action.yml
@@ -5,7 +5,7 @@ runs:
   steps:
     - uses: pnpm/action-setup@v2.2.4
       with:
-        version: 7
+        version: 7.32.5
     - uses: actions/setup-node@v3
       with:
         cache: 'pnpm'

--- a/package.json
+++ b/package.json
@@ -7,6 +7,17 @@
     "url": "git@github.com:CrowdStrike/ember-toucan-core.git",
     "directory": "ember-toucan-core"
   },
+  "engines" : {
+    "node": ">=16",
+    "pnpm": ">=7.24.2 <7.33.0"
+  },
+  "engines:comment": {
+    "pnpm": "Our lock file version is 6. PNPM 7.24.2 is the first PNPM version to support version 6 lock files. PNPM 7.33.0 adds support for version 6.1 lock files, so using it results in a `pnpm-lock.yaml` diff."
+  },
+  "volta": {
+    "node": "18.16.0",
+    "pnpm": "7.32.5"
+  },
   "license": "MIT",
   "author": "CrowdStrike UX Team",
   "scripts": {


### PR DESCRIPTION
## 🚀 Description

The `engines` field of `package.json` is supported by PNPM and is thus version-manager independent. PNPM will fail if its version is out of range. See my [code comment](https://github.com/CrowdStrike/ember-toucan-core/pull/175/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R15) for why we should support a specific range.

Volta, meanwhile, is our preferred version manager. It will look to the `volta` field of `package.json` to determine which Node.js and PNPM versions to use. 

> Note that Volta's PNPM support is [experimental](https://docs.volta.sh/advanced/pnpm) and requires the environmental variable `VOLTA_FEATURE_PNPM` to be set to `1`.

We should probably upgrade to a version 6.1 lock file and PNPM 8 as well, though I considered it out of scope. Happy to follow up with another PR if you'd like.
