### PR TITLE
Add FileInput support to toucan-form

### DIFF
--- a/.changeset/nine-taxis-drop.md
+++ b/.changeset/nine-taxis-drop.md
@@ -1,0 +1,6 @@
+---
+'@crowdstrike/ember-toucan-core': patch
+'@crowdstrike/ember-toucan-form': patch
+---
+
+Added `<form.FileInput>` support to `toucan-form`. Resolved a bug where the `accept` attribute was not being applied to the `toucan-core` file-input control. Resolved a bug where `ToucanFormFileInputFieldComponentSignature` was not being exported from the file-input field.

--- a/docs/toucan-form/changeset-validation/demo/base-demo.md
+++ b/docs/toucan-form/changeset-validation/demo/base-demo.md
@@ -26,6 +26,13 @@
     <group.RadioField @label='Broccoli' @value='broccoli' data-radio-2 />
   </form.RadioGroup>
 
+  <form.FileInput
+    @label='Files to attach'
+    @trigger='Select files'
+    @deleteLabel='Delete'
+    @name='files'
+  />
+
   <form.Checkbox @label='Agree to the Terms' @name='terms' />
 
   <Button type='submit'>Submit</Button>
@@ -45,6 +52,7 @@ export default class extends Component {
 
   validations = {
     comment: validatePresence(true),
+    files: validatePresence(true),
     firstName: validatePresence(true),
     fruit: validatePresence(true),
     lastName: validatePresence(true),

--- a/packages/ember-toucan-core/src/components/form/controls/file-input.hbs
+++ b/packages/ember-toucan-core/src/components/form/controls/file-input.hbs
@@ -1,4 +1,5 @@
 <input
+  accept={{this.accept}}
   class="text-titles-and-attributes focus:outline-none absolute m-1 h-6 w-0 cursor-pointer bg-transparent p-1
     {{if @isDisabled 'text-disabled' 'text-titles-and-attributes'}}"
   disabled={{@isDisabled}}

--- a/packages/ember-toucan-core/src/components/form/fields/file-input.ts
+++ b/packages/ember-toucan-core/src/components/form/fields/file-input.ts
@@ -10,7 +10,7 @@ import type { ErrorMessage } from '../../../-private/types';
 type FileTarget = EventTarget & { files?: FileList };
 export type FileEvent = (Event | MouseEvent) & { target: FileTarget | null };
 
-interface ToucanFormFileInputFieldComponentSignature {
+export interface ToucanFormFileInputFieldComponentSignature {
   Element: HTMLInputElement;
   Args: {
     /**

--- a/packages/ember-toucan-form/src/-private/file-input-field.hbs
+++ b/packages/ember-toucan-form/src/-private/file-input-field.hbs
@@ -20,17 +20,17 @@
   {{#if (this.hasOnlyLabelBlock (has-block 'label') (has-block 'hint'))}}
     <Form::Fields::FileInput
       @accept={{@accept}}
-      @hint={{@hint}}
+      @deleteLabel={{@deleteLabel}}
       @error={{this.mapErrors field.rawErrors}}
       @files={{this.assertArrayOfFiles field.value}}
-      {{! @glint-expect-error }}
-      @onChange={{field.setValue}}
+      @hint={{@hint}}
       @isDisabled={{@isDisabled}}
       @isReadOnly={{@isReadOnly}}
-      @rootTestSelector={{@rootTestSelector}}
       @multiple={{@multiple}}
+      {{! @glint-expect-error }}
+      @onChange={{field.setValue}}
+      @rootTestSelector={{@rootTestSelector}}
       @trigger={{@trigger}}
-      @deleteLabel={{@deleteLabel}}
       name={{@name}}
       ...attributes
     >
@@ -40,16 +40,16 @@
   }}
     <Form::Fields::FileInput
       @accept={{@accept}}
+      @deleteLabel={{@deleteLabel}}
       @error={{this.mapErrors field.rawErrors}}
       @files={{this.assertArrayOfFiles field.value}}
-      {{! @glint-expect-error }}
-      @onChange={{field.setValue}}
       @isDisabled={{@isDisabled}}
       @isReadOnly={{@isReadOnly}}
-      @rootTestSelector={{@rootTestSelector}}
       @multiple={{@multiple}}
+      {{! @glint-expect-error }}
+      @onChange={{field.setValue}}
+      @rootTestSelector={{@rootTestSelector}}
       @trigger={{@trigger}}
-      @deleteLabel={{@deleteLabel}}
       name={{@name}}
       ...attributes
     >
@@ -59,17 +59,17 @@
   {{else if (this.hasLabelArgAndHintBlock @label (has-block 'hint'))}}
     <Form::Fields::FileInput
       @accept={{@accept}}
-      @label={{@label}}
+      @deleteLabel={{@deleteLabel}}
       @error={{this.mapErrors field.rawErrors}}
       @files={{this.assertArrayOfFiles field.value}}
-      {{! @glint-expect-error }}
-      @onChange={{field.setValue}}
       @isDisabled={{@isDisabled}}
       @isReadOnly={{@isReadOnly}}
-      @rootTestSelector={{@rootTestSelector}}
+      @label={{@label}}
       @multiple={{@multiple}}
+      {{! @glint-expect-error }}
+      @onChange={{field.setValue}}
+      @rootTestSelector={{@rootTestSelector}}
       @trigger={{@trigger}}
-      @deleteLabel={{@deleteLabel}}
       name={{@name}}
       ...attributes
     >
@@ -79,18 +79,18 @@
     {{! Argument-only case }}
     <Form::Fields::FileInput
       @accept={{@accept}}
-      @label={{@label}}
-      @hint={{@hint}}
+      @deleteLabel={{@deleteLabel}}
       @error={{this.mapErrors field.rawErrors}}
       @files={{this.assertArrayOfFiles field.value}}
-      {{! @glint-expect-error }}
-      @onChange={{field.setValue}}
+      @hint={{@hint}}
       @isDisabled={{@isDisabled}}
       @isReadOnly={{@isReadOnly}}
-      @rootTestSelector={{@rootTestSelector}}
+      @label={{@label}}
       @multiple={{@multiple}}
+      {{! @glint-expect-error }}
+      @onChange={{field.setValue}}
+      @rootTestSelector={{@rootTestSelector}}
       @trigger={{@trigger}}
-      @deleteLabel={{@deleteLabel}}
       name={{@name}}
       ...attributes
     />

--- a/packages/ember-toucan-form/src/-private/file-input-field.hbs
+++ b/packages/ember-toucan-form/src/-private/file-input-field.hbs
@@ -1,0 +1,98 @@
+{{!
+  Regarding Conditionals
+
+  This looks really messy, but Form::Fields::FileInput exposes named blocks; HOWEVER,
+  we cannot conditionally render named blocks due to https://github.com/emberjs/rfcs/issues/735.
+
+  We *can* conditionally render components though, based on the blocks and argument combinations
+  users provide us.  This is very brittle, but until https://github.com/emberjs/rfcs/issues/735
+  is resolved and a solution is found, this appears to be the only way to truly expose
+  conditional named blocks.
+
+  ---
+
+  Regarding glint-expect-error
+
+  "@onChange" of the FileInput only expects an array of files typed value, but field.setValue is generic,
+  accepting anything that DATA[KEY] could be. Similar case with "@files", but there casting to is easy.
+}}
+<@form.Field @name={{@name}} as |field|>
+  {{#if (this.hasOnlyLabelBlock (has-block 'label') (has-block 'hint'))}}
+    <Form::Fields::FileInput
+      @accept={{@accept}}
+      @hint={{@hint}}
+      @error={{this.mapErrors field.rawErrors}}
+      @files={{this.assertArrayOfFiles field.value}}
+      {{! @glint-expect-error }}
+      @onChange={{field.setValue}}
+      @isDisabled={{@isDisabled}}
+      @isReadOnly={{@isReadOnly}}
+      @rootTestSelector={{@rootTestSelector}}
+      @multiple={{@multiple}}
+      @trigger={{@trigger}}
+      @deleteLabel={{@deleteLabel}}
+      name={{@name}}
+      ...attributes
+    >
+      <:label>{{yield to='label'}}</:label>
+    </Form::Fields::FileInput>
+  {{else if (this.hasHintAndLabelBlocks (has-block 'label') (has-block 'hint'))
+  }}
+    <Form::Fields::FileInput
+      @accept={{@accept}}
+      @error={{this.mapErrors field.rawErrors}}
+      @files={{this.assertArrayOfFiles field.value}}
+      {{! @glint-expect-error }}
+      @onChange={{field.setValue}}
+      @isDisabled={{@isDisabled}}
+      @isReadOnly={{@isReadOnly}}
+      @rootTestSelector={{@rootTestSelector}}
+      @multiple={{@multiple}}
+      @trigger={{@trigger}}
+      @deleteLabel={{@deleteLabel}}
+      name={{@name}}
+      ...attributes
+    >
+      <:label>{{yield to='label'}}</:label>
+      <:hint>{{yield to='hint'}}</:hint>
+    </Form::Fields::FileInput>
+  {{else if (this.hasLabelArgAndHintBlock @label (has-block 'hint'))}}
+    <Form::Fields::FileInput
+      @accept={{@accept}}
+      @label={{@label}}
+      @error={{this.mapErrors field.rawErrors}}
+      @files={{this.assertArrayOfFiles field.value}}
+      {{! @glint-expect-error }}
+      @onChange={{field.setValue}}
+      @isDisabled={{@isDisabled}}
+      @isReadOnly={{@isReadOnly}}
+      @rootTestSelector={{@rootTestSelector}}
+      @multiple={{@multiple}}
+      @trigger={{@trigger}}
+      @deleteLabel={{@deleteLabel}}
+      name={{@name}}
+      ...attributes
+    >
+      <:hint>{{yield to='hint'}}</:hint>
+    </Form::Fields::FileInput>
+  {{else}}
+    {{! Argument-only case }}
+    <Form::Fields::FileInput
+      @accept={{@accept}}
+      @label={{@label}}
+      @hint={{@hint}}
+      @error={{this.mapErrors field.rawErrors}}
+      @files={{this.assertArrayOfFiles field.value}}
+      {{! @glint-expect-error }}
+      @onChange={{field.setValue}}
+      @isDisabled={{@isDisabled}}
+      @isReadOnly={{@isReadOnly}}
+      @rootTestSelector={{@rootTestSelector}}
+      @multiple={{@multiple}}
+      @trigger={{@trigger}}
+      @deleteLabel={{@deleteLabel}}
+      name={{@name}}
+      ...attributes
+    />
+  {{/if}}
+</@form.Field>

--- a/packages/ember-toucan-form/src/-private/file-input-field.ts
+++ b/packages/ember-toucan-form/src/-private/file-input-field.ts
@@ -1,0 +1,64 @@
+import Component from '@glimmer/component';
+import { assert } from '@ember/debug';
+import { action } from '@ember/object';
+
+import type { HeadlessFormBlock, UserData } from './types';
+import type { ToucanFormFileInputFieldComponentSignature as BaseFileInputFieldSignature } from '@crowdstrike/ember-toucan-core/components/form/fields/file-input';
+import type { FormData, FormKey, ValidationError } from 'ember-headless-form';
+
+export interface ToucanFormFieldInputFieldComponentSignature<
+  DATA extends UserData,
+  KEY extends FormKey<FormData<DATA>> = FormKey<FormData<DATA>>
+> {
+  Element: HTMLInputElement;
+  Args: Omit<
+    BaseFileInputFieldSignature['Args'],
+    'error' | 'files' | 'onChange' | 'name'
+  > & {
+    /**
+     * The name of your field, which must match a property of the `@data` passed to the form
+     */
+    name: KEY;
+
+    /*
+     * @internal
+     */
+    form: HeadlessFormBlock<DATA>;
+  };
+  Blocks: BaseFileInputFieldSignature['Blocks'];
+}
+
+export default class ToucanFormFileInputFieldComponent<
+  DATA extends UserData,
+  KEY extends FormKey<FormData<DATA>> = FormKey<FormData<DATA>>
+> extends Component<ToucanFormFieldInputFieldComponentSignature<DATA, KEY>> {
+  hasOnlyLabelBlock = (hasLabel: boolean, hasHint: boolean) =>
+    hasLabel && !hasHint;
+  hasHintAndLabelBlocks = (hasLabel: boolean, hasHint: boolean) =>
+    hasLabel && hasHint;
+  hasLabelArgAndHintBlock = (hasLabel: string | undefined, hasHint: boolean) =>
+    hasLabel && hasHint;
+
+  mapErrors = (errors?: ValidationError[]) => {
+    if (!errors) {
+      return;
+    }
+
+    // @todo we need to figure out what to do when message is undefined
+    return errors.map((error) => error.message ?? error.type);
+  };
+
+  @action
+  assertArrayOfFiles(value: unknown): File[] | undefined {
+    assert(
+      `Only File[] values are expected for ${String(
+        this.args.name
+      )}, but you passed ${typeof value}`,
+      typeof value === 'undefined' ||
+        Array.isArray(value) ||
+        (value as File[]).forEach((file) => file instanceof File)
+    );
+
+    return value as File[] | undefined;
+  }
+}

--- a/packages/ember-toucan-form/src/-private/file-input-field.ts
+++ b/packages/ember-toucan-form/src/-private/file-input-field.ts
@@ -54,9 +54,8 @@ export default class ToucanFormFileInputFieldComponent<
       `Only File[] values are expected for ${String(
         this.args.name
       )}, but you passed ${typeof value}`,
-      typeof value === 'undefined' ||
-        Array.isArray(value) ||
-        (value as File[]).forEach((file) => file instanceof File)
+      value === undefined ||
+        (Array.isArray(value) && value.every((file) => file instanceof File))
     );
 
     return value as File[] | undefined;

--- a/packages/ember-toucan-form/src/components/toucan-form.hbs
+++ b/packages/ember-toucan-form/src/components/toucan-form.hbs
@@ -18,6 +18,9 @@
         (ensure-safe-component this.CheckboxGroupComponent) form=form
       )
       Field=form.Field
+      FileInput=(component
+        (ensure-safe-component this.FileInputFieldComponent) form=form
+      )
       Input=(component
         (ensure-safe-component this.InputFieldComponent) form=form
       )
@@ -26,9 +29,6 @@
       )
       Textarea=(component
         (ensure-safe-component this.TextareaFieldComponent) form=form
-      )
-      FileInput=(component
-        (ensure-safe-component this.FileInputFieldComponent) form=form
       )
     )
   }}

--- a/packages/ember-toucan-form/src/components/toucan-form.hbs
+++ b/packages/ember-toucan-form/src/components/toucan-form.hbs
@@ -27,6 +27,9 @@
       Textarea=(component
         (ensure-safe-component this.TextareaFieldComponent) form=form
       )
+      FileInput=(component
+        (ensure-safe-component this.FileInputFieldComponent) form=form
+      )
     )
   }}
 </HeadlessForm>

--- a/packages/ember-toucan-form/src/components/toucan-form.ts
+++ b/packages/ember-toucan-form/src/components/toucan-form.ts
@@ -31,13 +31,13 @@ export interface ToucanFormComponentSignature<
           'form'
         >;
         Field: HeadlessFormBlock<DATA>['Field'];
+        FileInput: WithBoundArgs<typeof FileInputFieldComponent<DATA>, 'form'>;
         Input: WithBoundArgs<typeof InputFieldComponent<DATA>, 'form'>;
         RadioGroup: WithBoundArgs<
           typeof RadioGroupFieldComponent<DATA>,
           'form'
         >;
         Textarea: WithBoundArgs<typeof TextareaFieldComponent<DATA>, 'form'>;
-        FileInput: WithBoundArgs<typeof FileInputFieldComponent<DATA>, 'form'>;
       }
     ];
   };
@@ -49,10 +49,10 @@ export default class ToucanFormComponent<
 > extends Component<ToucanFormComponentSignature<DATA, SUBMISSION_VALUE>> {
   CheckboxComponent = CheckboxFieldComponent<DATA>;
   CheckboxGroupComponent = CheckboxGroupFieldComponent<DATA>;
+  FileInputFieldComponent = FileInputFieldComponent<DATA>;
   InputFieldComponent = InputFieldComponent<DATA>;
   RadioGroupFieldComponent = RadioGroupFieldComponent<DATA>;
   TextareaFieldComponent = TextareaFieldComponent<DATA>;
-  FileInputFieldComponent = FileInputFieldComponent<DATA>;
 
   get validateOn() {
     let { validateOn } = this.args;

--- a/packages/ember-toucan-form/src/components/toucan-form.ts
+++ b/packages/ember-toucan-form/src/components/toucan-form.ts
@@ -2,6 +2,7 @@ import Component from '@glimmer/component';
 
 import CheckboxFieldComponent from '../-private/checkbox-field';
 import CheckboxGroupFieldComponent from '../-private/checkbox-group-field';
+import FileInputFieldComponent from '../-private/file-input-field';
 import InputFieldComponent from '../-private/input-field';
 import RadioGroupFieldComponent from '../-private/radio-group-field';
 import TextareaFieldComponent from '../-private/textarea-field';
@@ -36,6 +37,7 @@ export interface ToucanFormComponentSignature<
           'form'
         >;
         Textarea: WithBoundArgs<typeof TextareaFieldComponent<DATA>, 'form'>;
+        FileInput: WithBoundArgs<typeof FileInputFieldComponent<DATA>, 'form'>;
       }
     ];
   };
@@ -50,6 +52,7 @@ export default class ToucanFormComponent<
   InputFieldComponent = InputFieldComponent<DATA>;
   RadioGroupFieldComponent = RadioGroupFieldComponent<DATA>;
   TextareaFieldComponent = TextareaFieldComponent<DATA>;
+  FileInputFieldComponent = FileInputFieldComponent<DATA>;
 
   get validateOn() {
     let { validateOn } = this.args;

--- a/test-app/tests/integration/components/file-input-test.gts
+++ b/test-app/tests/integration/components/file-input-test.gts
@@ -18,6 +18,11 @@ module(
       assert.dom('[data-input]').exists();
 
       assert.dom('[data-input]').hasNoAttribute('readonly');
+      assert.dom('[data-input]').hasNoAttribute('multiple');
+
+      // Verify defaults
+      assert.dom('[data-input]').hasAttribute('type', 'file');
+      assert.dom('[data-input]').hasAttribute('accept', '*');
     });
 
     test('it sets readonly on the input using `@isReadOnly`', async function (assert) {
@@ -26,6 +31,30 @@ module(
       </template>);
 
       assert.dom('[data-input]').hasAttribute('readonly');
+    });
+
+    test('it sets disabled on the input using `@isDisabled`', async function (assert) {
+      await render(<template>
+        <FileInput @trigger="Select Files" @isDisabled={{true}} data-input />
+      </template>);
+
+      assert.dom('[data-input]').isDisabled();
+    });
+
+    test('it sets accept on the input using `@accept`', async function (assert) {
+      await render(<template>
+        <FileInput @trigger="Select Files" @accept="image/png" data-input />
+      </template>);
+
+      assert.dom('[data-input]').hasAttribute('accept', 'image/png');
+    });
+
+    test('it sets the multiple attribute on the input using `@multiple`', async function (assert) {
+      await render(<template>
+        <FileInput @trigger="Select Files" @multiple={{true}} data-input />
+      </template>);
+
+      assert.dom('[data-input]').hasAttribute('multiple');
     });
   }
 );

--- a/test-app/tests/integration/components/toucan-form/form-file-input-test.gts
+++ b/test-app/tests/integration/components/toucan-form/form-file-input-test.gts
@@ -1,0 +1,141 @@
+/* eslint-disable no-undef -- Until https://github.com/ember-cli/eslint-plugin-ember/issues/1747 is resolved... */
+/* eslint-disable simple-import-sort/imports,padding-line-between-statements,decorator-position/decorator-position -- Can't fix these manually, without --fix working in .gts */
+import { render } from '@ember/test-helpers';
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'test-app/tests/helpers';
+
+import ToucanForm from '@crowdstrike/ember-toucan-form/components/toucan-form';
+
+const testFile = new File(['Some sample content'], 'file.txt', {
+  type: 'text/plain',
+});
+
+interface TestData {
+  files?: File[];
+}
+
+module('Integration | Component | ToucanForm | FileInput', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it sets the readonly attribute with `@isReadOnly`', async function (assert) {
+    const data: TestData = {
+      files: [testFile],
+    };
+
+    await render(<template>
+      <ToucanForm @data={{data}} as |form|>
+        <form.FileInput
+          @label="Files"
+          @name="files"
+          @isReadOnly={{true}}
+          @deleteLabel="Delete"
+          @trigger="Select files"
+          data-file-input
+        />
+      </ToucanForm>
+    </template>);
+
+    assert.dom('[data-file-input]').hasAttribute('readonly');
+  });
+
+  test('it renders `@label` and `@hint` component arguments', async function (assert) {
+    const data: TestData = {
+      files: [testFile],
+    };
+
+    await render(<template>
+      <ToucanForm @data={{data}} as |form|>
+        <form.FileInput
+          @label="Files"
+          @hint="Hint"
+          @name="files"
+          @isReadOnly={{true}}
+          @deleteLabel="Delete"
+          @trigger="Select files"
+          data-file-input
+        />
+      </ToucanForm>
+    </template>);
+
+    assert.dom('[data-label]').exists();
+    assert.dom('[data-hint]').exists();
+  });
+
+  test('it renders a `:label` named block with a `@hint` argument', async function (assert) {
+    const data: TestData = {
+      files: [testFile],
+    };
+
+    await render(<template>
+      <ToucanForm @data={{data}} as |form|>
+        <form.FileInput
+          @hint="Hint"
+          @name="files"
+          @isReadOnly={{true}}
+          @deleteLabel="Delete"
+          @trigger="Select files"
+          data-file-input
+        >
+          <:label><span data-label-block>Label</span></:label>
+        </form.FileInput>
+      </ToucanForm>
+    </template>);
+
+    assert.dom('[data-label-block]').exists();
+
+    // NOTE: `data-hint` comes from `@hint`.
+    assert.dom('[data-hint]').exists();
+    assert.dom('[data-hint]').hasText('Hint');
+  });
+
+  test('it renders a `:hint` named block with a `@label` argument', async function (assert) {
+    const data: TestData = {
+      files: [testFile],
+    };
+
+    await render(<template>
+      <ToucanForm @data={{data}} as |form|>
+        <form.FileInput
+          @label="Label"
+          @name="files"
+          @isReadOnly={{true}}
+          @deleteLabel="Delete"
+          @trigger="Select files"
+          data-file-input
+        >
+          <:hint><span data-hint-block>Hint</span></:hint>
+        </form.FileInput>
+      </ToucanForm>
+    </template>);
+
+    // NOTE: `data-label` comes from `@label`.
+    assert.dom('[data-label]').exists();
+    assert.dom('[data-label]').hasText('Label');
+
+    assert.dom('[data-hint-block]').exists();
+  });
+
+  test('it renders both a `:label` and `:hint` named block', async function (assert) {
+    const data: TestData = {
+      files: [testFile],
+    };
+
+    await render(<template>
+      <ToucanForm @data={{data}} as |form|>
+        <form.FileInput
+          @name="files"
+          @isReadOnly={{true}}
+          @deleteLabel="Delete"
+          @trigger="Select files"
+          data-file-input
+        >
+          <:label><span data-label-block>Label</span></:label>
+          <:hint><span data-hint-block>Hint</span></:hint>
+        </form.FileInput>
+      </ToucanForm>
+    </template>);
+
+    assert.dom('[data-label-block]').exists();
+    assert.dom('[data-hint-block]').exists();
+  });
+});

--- a/test-app/tests/integration/components/toucan-form/form-file-input-test.gts
+++ b/test-app/tests/integration/components/toucan-form/form-file-input-test.gts
@@ -10,6 +10,10 @@ const testFile = new File(['Some sample content'], 'file.txt', {
   type: 'text/plain',
 });
 
+const data: TestData = {
+  files: [testFile],
+};
+
 interface TestData {
   files?: File[];
 }
@@ -17,11 +21,43 @@ interface TestData {
 module('Integration | Component | ToucanForm | FileInput', function (hooks) {
   setupRenderingTest(hooks);
 
-  test('it sets the readonly attribute with `@isReadOnly`', async function (assert) {
-    const data: TestData = {
-      files: [testFile],
-    };
+  test('it sets the accept attribute with `@accept`', async function (assert) {
+    await render(<template>
+      <ToucanForm @data={{data}} as |form|>
+        <form.FileInput
+          @accept="image/png, image/jpeg"
+          @label="Files"
+          @name="files"
+          @deleteLabel="Delete"
+          @trigger="Select files"
+          data-file-input
+        />
+      </ToucanForm>
+    </template>);
 
+    assert
+      .dom('[data-file-input]')
+      .hasAttribute('accept', 'image/png, image/jpeg');
+  });
+
+  test('it sets the accept multiple with `@multiple`', async function (assert) {
+    await render(<template>
+      <ToucanForm @data={{data}} as |form|>
+        <form.FileInput
+          @multiple={{true}}
+          @label="Files"
+          @name="files"
+          @deleteLabel="Delete"
+          @trigger="Select files"
+          data-file-input
+        />
+      </ToucanForm>
+    </template>);
+
+    assert.dom('[data-file-input]').hasAttribute('multiple');
+  });
+
+  test('it sets the readonly attribute with `@isReadOnly`', async function (assert) {
     await render(<template>
       <ToucanForm @data={{data}} as |form|>
         <form.FileInput
@@ -39,10 +75,6 @@ module('Integration | Component | ToucanForm | FileInput', function (hooks) {
   });
 
   test('it renders `@label` and `@hint` component arguments', async function (assert) {
-    const data: TestData = {
-      files: [testFile],
-    };
-
     await render(<template>
       <ToucanForm @data={{data}} as |form|>
         <form.FileInput
@@ -62,10 +94,6 @@ module('Integration | Component | ToucanForm | FileInput', function (hooks) {
   });
 
   test('it renders a `:label` named block with a `@hint` argument', async function (assert) {
-    const data: TestData = {
-      files: [testFile],
-    };
-
     await render(<template>
       <ToucanForm @data={{data}} as |form|>
         <form.FileInput
@@ -89,10 +117,6 @@ module('Integration | Component | ToucanForm | FileInput', function (hooks) {
   });
 
   test('it renders a `:hint` named block with a `@label` argument', async function (assert) {
-    const data: TestData = {
-      files: [testFile],
-    };
-
     await render(<template>
       <ToucanForm @data={{data}} as |form|>
         <form.FileInput
@@ -116,10 +140,6 @@ module('Integration | Component | ToucanForm | FileInput', function (hooks) {
   });
 
   test('it renders both a `:label` and `:hint` named block', async function (assert) {
-    const data: TestData = {
-      files: [testFile],
-    };
-
     await render(<template>
       <ToucanForm @data={{data}} as |form|>
         <form.FileInput

--- a/test-app/tests/integration/components/toucan-form/toucan-form-test.gts
+++ b/test-app/tests/integration/components/toucan-form/toucan-form-test.gts
@@ -137,7 +137,7 @@ module('Integration | Component | ToucanForm', function (hooks) {
   });
 
   test('it triggers validation and shows error messages in the Toucan Core components', async function (assert) {
-    assert.expect(19);
+    assert.expect(18);
 
     const handleSubmit = ({ files, ...data }: TestData) => {
       // Checking deep equality on files can get really tricky due
@@ -152,7 +152,6 @@ module('Integration | Component | ToucanForm', function (hooks) {
       );
       assert.strictEqual(files?.[0]?.name, 'file.txt');
       assert.strictEqual(files?.[0]?.type, 'text/plain');
-      assert.strictEqual(files?.[0]?.size, 19);
 
       // Now we assert the string/boolean based values
       assert.deepEqual(


### PR DESCRIPTION
## 🚀 Description

This PR adds `form.FileInput` support to `toucan-form`.


```hbs
<ToucanForm
  @data={{changeset this.data this.validations}}
  @onSubmit={{this.handleSubmit}}
  @validate={{(validate-changeset)}}
  as |form|
>
  <form.FileInput
    @label='Files to attach'
    @trigger='Select files'
    @deleteLabel='Delete'
    @name='files'
  />

  <Button type='submit'>Submit</Button>
</ToucanForm>
```

---

## 🔬 How to Test

- Green build
- Go to https://e6846db9.ember-toucan-core.pages.dev/docs/toucan-form/changeset-validation
  - Click submit button
  - Verify error is displayed under FileInput component
  - Click Select files button
  - Add a file
  - Verify error goes away
  - Complete the rest of the form
  - Submit it
  - Verify in the alert `files` has content

---

## 📸 Images/Videos of Functionality


https://github.com/CrowdStrike/ember-toucan-core/assets/8069555/200e10f4-fbec-4c9c-95d5-7e09b6584994

