### PR TITLE
chore: add @value support to Form::Controls::Checkbox

### DIFF
--- a/.changeset/polite-bobcats-do.md
+++ b/.changeset/polite-bobcats-do.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/ember-toucan-core': minor
+---
+
+add @value support to Form::Controls::Checkbox

--- a/packages/ember-toucan-core/src/components/form/controls/checkbox.hbs
+++ b/packages/ember-toucan-core/src/components/form/controls/checkbox.hbs
@@ -7,6 +7,7 @@
     indeterminate={{this.isIndeterminate}}
     disabled={{@isDisabled}}
     readonly={{@isReadOnly}}
+    value={{@value}}
     ...attributes
     {{on "click" this.handleInput}}
   />

--- a/packages/ember-toucan-core/src/components/form/controls/checkbox.ts
+++ b/packages/ember-toucan-core/src/components/form/controls/checkbox.ts
@@ -18,7 +18,7 @@ export interface ToucanFormCheckboxControlComponentSignature {
     isReadOnly?: boolean;
 
     /**
-     * The function called when the element is clicked.
+     * The function called when the checkbox is clicked.
      */
     onChange?: OnChangeCallback<boolean>;
 
@@ -33,6 +33,11 @@ export interface ToucanFormCheckboxControlComponentSignature {
      * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox#indeterminate_state_checkboxes
      */
     isIndeterminate?: boolean;
+
+    /**
+     * Sets the value attribute of the checkbox.
+     */
+    value?: string;
   };
 }
 

--- a/packages/ember-toucan-core/src/components/form/fields/checkbox.hbs
+++ b/packages/ember-toucan-core/src/components/form/fields/checkbox.hbs
@@ -16,12 +16,12 @@
           aria-describedby="{{if @error field.errorId}}"
           id={{field.id}}
           name={{@name}}
-          value={{@value}}
           @isDisabled={{@isDisabled}}
           @isChecked={{this.isChecked}}
           @isIndeterminate={{@isIndeterminate}}
           @isReadOnly={{@isReadOnly}}
           @onChange={{@onChange}}
+          @value={{@value}}
           ...attributes
         />
 

--- a/packages/ember-toucan-core/src/components/form/fields/checkbox.ts
+++ b/packages/ember-toucan-core/src/components/form/fields/checkbox.ts
@@ -79,7 +79,7 @@ export interface ToucanFormCheckboxFieldComponentSignature {
      *
      * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox#handling_multiple_checkboxes
      */
-    value?: string;
+    value?: ToucanFormCheckboxControlComponentSignature['Args']['value'];
   };
   Blocks: {
     label: [];

--- a/test-app/tests/integration/components/checkbox-test.gts
+++ b/test-app/tests/integration/components/checkbox-test.gts
@@ -79,7 +79,7 @@ module('Integration | Component | Checkbox', function (hooks) {
     assert.dom('[data-checkbox]').hasNoClass('bg-transparent');
   });
 
-  test('it applies the expected classes when `@isIndeterminate={{true}}` and `@isDisabled={{true}}', async function (assert) {
+  test('it applies the expected classes when `@isIndeterminate={{true}}` and `@isDisabled={{true}}`', async function (assert) {
     await render(<template>
       {{! we do not require a label, but instead suggest using Field / TextareaField }}
       {{! template-lint-disable require-input-label }}
@@ -95,7 +95,7 @@ module('Integration | Component | Checkbox', function (hooks) {
     assert.dom('[data-checkbox]').hasNoClass('bg-primary-idle');
   });
 
-  test('it applies the expected classes when `@isChecked={{true}}` and `@isDisabled={{true}}', async function (assert) {
+  test('it applies the expected classes when `@isChecked={{true}}` and `@isDisabled={{true}}`', async function (assert) {
     await render(<template>
       {{! we do not require a label, but instead suggest using Field / TextareaField }}
       {{! template-lint-disable require-input-label }}
@@ -142,6 +142,16 @@ module('Integration | Component | Checkbox', function (hooks) {
     assert.dom('[data-checkbox]').hasNoClass('bg-normal-idle');
     assert.dom('[data-checkbox]').hasNoClass('bg-disabled');
     assert.dom('[data-checkbox]').hasNoClass('border-disabled');
+  });
+
+  test('it sets the value of the checkbox using `@value`', async function (assert) {
+    await render(<template>
+      {{! we do not require a label, but instead suggest using Field / TextareaField }}
+      {{! template-lint-disable require-input-label }}
+      <CheckboxControl @value="test" data-checkbox />
+    </template>);
+
+    assert.dom('[data-checkbox]').hasProperty('value', 'test');
   });
 
   test('it spreads attributes to the underlying checkbox', async function (assert) {


### PR DESCRIPTION
## 🚀 Description

This is a small but breaking change that removes `value` as an attribute in favor of `@value` the argument.  The reason for the change is consistency. Other controls that accept a value accept it by a `@value` argument.

---

## 🔬 How to Test

1. Navigate to the Checkbox Group Field at the preview URL.
2. Use your browser's inspector to inspect the `<input />` of one of the checkboxes. Note the value of its `value` property.
4. Confirm that value is equal to the `@value` specified in the demo template below it.



