### PR TITLE
#43: Upgrade to latest eslint-plugin-ember, remove eslint-disable, and make --fix work again 

### DIFF
--- a/docs-app/package.json
+++ b/docs-app/package.json
@@ -102,7 +102,7 @@
     "ember-template-lint": "^5.8.0",
     "eslint": "^8.32.0",
     "eslint-config-prettier": "^8.5.0",
-    "eslint-plugin-ember": "^11.4.3",
+    "eslint-plugin-ember": "^11.8.0",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-qunit": "^7.3.1",

--- a/docs-app/tests/acceptance/button-test.gts
+++ b/docs-app/tests/acceptance/button-test.gts
@@ -1,16 +1,13 @@
 /* eslint-disable no-undef -- Until https://github.com/ember-cli/eslint-plugin-ember/issues/1747 is resolved... */
-/* eslint-disable simple-import-sort/imports,padding-line-between-statements,decorator-position/decorator-position -- Can't fix these manually, without --fix working in .gts */
+import { currentURL, visit } from '@ember/test-helpers';
 import { module, test } from 'qunit';
-import { visit, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 
 module('Acceptance | Button', function (hooks) {
   setupApplicationTest(hooks);
 
   test('visiting the button page', async function (assert) {
-
-    await visit('/docs/components/button')
+    await visit('/docs/components/button');
     assert.strictEqual(currentURL(), '/docs/components/button');
   });
-
 });

--- a/packages/ember-toucan-core/package.json
+++ b/packages/ember-toucan-core/package.json
@@ -88,7 +88,7 @@
     "ember-template-lint": "^5.8.0",
     "eslint": "^8.32.0",
     "eslint-config-prettier": "^8.3.0",
-    "eslint-plugin-ember": "^11.4.3",
+    "eslint-plugin-ember": "^11.8.0",
     "eslint-plugin-n": "^16.0.0",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^4.0.0",

--- a/packages/ember-toucan-form/package.json
+++ b/packages/ember-toucan-form/package.json
@@ -93,7 +93,7 @@
     "ember-template-lint": "^5.8.0",
     "eslint": "^8.32.0",
     "eslint-config-prettier": "^8.3.0",
-    "eslint-plugin-ember": "^11.4.3",
+    "eslint-plugin-ember": "^11.8.0",
     "eslint-plugin-n": "^16.0.0",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^4.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -121,7 +121,7 @@ importers:
         version: 4.0.2
       '@nullvoxpopuli/eslint-configs':
         specifier: ^3.0.4
-        version: 3.1.1(@babel/core@7.20.12)(@babel/eslint-parser@7.19.1)(eslint-config-prettier@8.6.0)(eslint-plugin-ember@11.4.6)(eslint-plugin-qunit@7.3.4)(eslint@8.33.0)(prettier@2.8.3)
+        version: 3.1.1(@babel/core@7.20.12)(@babel/eslint-parser@7.19.1)(eslint-config-prettier@8.6.0)(eslint-plugin-ember@11.8.0)(eslint-plugin-qunit@7.3.4)(eslint@8.33.0)(prettier@2.8.3)
       '@tailwindcss/typography':
         specifier: ^0.5.7
         version: 0.5.9(tailwindcss@3.2.4)
@@ -291,8 +291,8 @@ importers:
         specifier: ^8.5.0
         version: 8.6.0(eslint@8.33.0)
       eslint-plugin-ember:
-        specifier: ^11.4.3
-        version: 11.4.6(eslint@8.33.0)
+        specifier: ^11.8.0
+        version: 11.8.0(eslint@8.33.0)
       eslint-plugin-node:
         specifier: ^11.1.0
         version: 11.1.0(eslint@8.33.0)
@@ -424,7 +424,7 @@ importers:
         version: 1.0.2
       '@nullvoxpopuli/eslint-configs':
         specifier: ^3.0.4
-        version: 3.1.1(@babel/core@7.20.12)(@babel/eslint-parser@7.19.1)(@typescript-eslint/eslint-plugin@5.50.0)(@typescript-eslint/parser@5.50.0)(eslint-config-prettier@8.6.0)(eslint-plugin-ember@11.4.6)(eslint@8.33.0)(prettier@2.8.3)
+        version: 3.1.1(@babel/core@7.20.12)(@babel/eslint-parser@7.19.1)(@typescript-eslint/eslint-plugin@5.50.0)(@typescript-eslint/parser@5.50.0)(eslint-config-prettier@8.6.0)(eslint-plugin-ember@11.8.0)(eslint@8.33.0)(prettier@2.8.3)
       '@tsconfig/ember':
         specifier: ^2.0.0
         version: 2.0.0
@@ -507,8 +507,8 @@ importers:
         specifier: ^8.3.0
         version: 8.6.0(eslint@8.33.0)
       eslint-plugin-ember:
-        specifier: ^11.4.3
-        version: 11.4.6(eslint@8.33.0)
+        specifier: ^11.8.0
+        version: 11.8.0(eslint@8.33.0)
       eslint-plugin-n:
         specifier: ^16.0.0
         version: 16.0.0(eslint@8.33.0)
@@ -608,7 +608,7 @@ importers:
         version: 1.0.2
       '@nullvoxpopuli/eslint-configs':
         specifier: ^3.0.4
-        version: 3.1.1(@babel/core@7.21.4)(@babel/eslint-parser@7.19.1)(@typescript-eslint/eslint-plugin@5.50.0)(@typescript-eslint/parser@5.50.0)(eslint-config-prettier@8.6.0)(eslint-plugin-ember@11.4.6)(eslint@8.33.0)(prettier@2.8.3)
+        version: 3.1.1(@babel/core@7.21.4)(@babel/eslint-parser@7.19.1)(@typescript-eslint/eslint-plugin@5.50.0)(@typescript-eslint/parser@5.50.0)(eslint-config-prettier@8.6.0)(eslint-plugin-ember@11.8.0)(eslint@8.33.0)(prettier@2.8.3)
       '@tsconfig/ember':
         specifier: ^2.0.0
         version: 2.0.0
@@ -697,8 +697,8 @@ importers:
         specifier: ^8.3.0
         version: 8.6.0(eslint@8.33.0)
       eslint-plugin-ember:
-        specifier: ^11.4.3
-        version: 11.4.6(eslint@8.33.0)
+        specifier: ^11.8.0
+        version: 11.8.0(eslint@8.33.0)
       eslint-plugin-n:
         specifier: ^16.0.0
         version: 16.0.0(eslint@8.33.0)
@@ -794,7 +794,7 @@ importers:
         version: 1.0.2
       '@nullvoxpopuli/eslint-configs':
         specifier: ^3.0.4
-        version: 3.1.1(@babel/core@7.20.12)(@babel/eslint-parser@7.19.1)(@typescript-eslint/eslint-plugin@5.50.0)(@typescript-eslint/parser@5.50.0)(eslint-config-prettier@8.6.0)(eslint-plugin-ember@11.4.6)(eslint-plugin-qunit@7.3.4)(eslint@8.33.0)(prettier@2.8.3)
+        version: 3.1.1(@babel/core@7.20.12)(@babel/eslint-parser@7.19.1)(@typescript-eslint/eslint-plugin@5.50.0)(@typescript-eslint/parser@5.50.0)(eslint-config-prettier@8.6.0)(eslint-plugin-ember@11.8.0)(eslint-plugin-qunit@7.3.4)(eslint@8.33.0)(prettier@2.8.3)
       '@tsconfig/ember':
         specifier: ^2.0.0
         version: 2.0.0
@@ -955,8 +955,8 @@ importers:
         specifier: ^8.5.0
         version: 8.6.0(eslint@8.33.0)
       eslint-plugin-ember:
-        specifier: ^11.4.3
-        version: 11.4.6(eslint@8.33.0)
+        specifier: ^11.8.0
+        version: 11.8.0(eslint@8.33.0)
       eslint-plugin-n:
         specifier: ^16.0.0
         version: 16.0.0(eslint@8.33.0)
@@ -4150,12 +4150,6 @@ packages:
       '@glimmer/env': 0.1.7
     dev: true
 
-  /@glimmer/interfaces@0.84.2:
-    resolution: {integrity: sha512-tMZxQpOddUVmHEOuripkNqVR7ba0K4doiYnFd4WyswqoHPlxqpBujbIamQ+bWCWEF0U4yxsXKa31ekS/JHkiBQ==}
-    dependencies:
-      '@simple-dom/interface': 1.4.0
-    dev: true
-
   /@glimmer/interfaces@0.84.3:
     resolution: {integrity: sha512-dk32ykoNojt0mvEaIW6Vli5MGTbQo58uy3Epj7ahCgTHmWOKuw/0G83f2UmFprRwFx689YTXG38I/vbpltEjzg==}
     dependencies:
@@ -4170,15 +4164,6 @@ packages:
       '@glimmer/interfaces': 0.84.3
       '@glimmer/util': 0.84.3
       '@glimmer/validator': 0.84.3
-    dev: true
-
-  /@glimmer/syntax@0.84.2:
-    resolution: {integrity: sha512-SPBd1tpIR9XeaXsXsMRCnKz63eLnIZ0d5G9QC4zIBFBC3pQdtG0F5kWeuRVCdfTIFuR+5WBMfk5jvg+3gbQhjg==}
-    dependencies:
-      '@glimmer/interfaces': 0.84.2
-      '@glimmer/util': 0.84.2
-      '@handlebars/parser': 2.0.0
-      simple-html-tokenizer: 0.5.11
     dev: true
 
   /@glimmer/syntax@0.84.3:
@@ -4198,14 +4183,6 @@ packages:
 
   /@glimmer/util@0.44.0:
     resolution: {integrity: sha512-duAsm30uVK9jSysElCbLyU6QQYO2X9iLDLBIBUcCqck9qN1o3tK2qWiHbGK5d6g8E2AJ4H88UrfElkyaJlGrwg==}
-
-  /@glimmer/util@0.84.2:
-    resolution: {integrity: sha512-VbhzE2s4rmU+qJF3gGBTL1IDjq+/G2Th51XErS8MQVMCmE4CU2pdwSzec8PyOowqCGUOrVIWuMzEI6VoPM4L4w==}
-    dependencies:
-      '@glimmer/env': 0.1.7
-      '@glimmer/interfaces': 0.84.2
-      '@simple-dom/interface': 1.4.0
-    dev: true
 
   /@glimmer/util@0.84.3:
     resolution: {integrity: sha512-qFkh6s16ZSRuu2rfz3T4Wp0fylFj3HBsONGXQcrAdZjdUaIS6v3pNj6mecJ71qRgcym9Hbaq/7/fefIwECUiKw==}
@@ -4531,7 +4508,7 @@ packages:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.15.0
 
-  /@nullvoxpopuli/eslint-configs@3.1.1(@babel/core@7.20.12)(@babel/eslint-parser@7.19.1)(@typescript-eslint/eslint-plugin@5.50.0)(@typescript-eslint/parser@5.50.0)(eslint-config-prettier@8.6.0)(eslint-plugin-ember@11.4.6)(eslint-plugin-qunit@7.3.4)(eslint@8.33.0)(prettier@2.8.3):
+  /@nullvoxpopuli/eslint-configs@3.1.1(@babel/core@7.20.12)(@babel/eslint-parser@7.19.1)(@typescript-eslint/eslint-plugin@5.50.0)(@typescript-eslint/parser@5.50.0)(eslint-config-prettier@8.6.0)(eslint-plugin-ember@11.8.0)(eslint-plugin-qunit@7.3.4)(eslint@8.33.0)(prettier@2.8.3):
     resolution: {integrity: sha512-7ERkp5DJCC/5RryMD27Kc6NWJsT19rZab5MuaeDEXND6fGiNSnVkjh/b38Qh7U3VGzG8YRZ5VMa9BnhWO29BoA==}
     engines: {node: '>= v16.0.0'}
     peerDependencies:
@@ -4567,7 +4544,7 @@ packages:
       eslint: 8.33.0
       eslint-import-resolver-typescript: 3.5.3(eslint-plugin-import@2.27.5)(eslint@8.33.0)
       eslint-plugin-decorator-position: 5.0.2(@babel/eslint-parser@7.19.1)(eslint@8.33.0)
-      eslint-plugin-ember: 11.4.6(eslint@8.33.0)
+      eslint-plugin-ember: 11.8.0(eslint@8.33.0)
       eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.50.0)(eslint-import-resolver-typescript@3.5.3)(eslint@8.33.0)
       eslint-plugin-json: 3.1.0
       eslint-plugin-n: 15.6.1(eslint@8.33.0)
@@ -4582,7 +4559,7 @@ packages:
       - supports-color
     dev: true
 
-  /@nullvoxpopuli/eslint-configs@3.1.1(@babel/core@7.20.12)(@babel/eslint-parser@7.19.1)(@typescript-eslint/eslint-plugin@5.50.0)(@typescript-eslint/parser@5.50.0)(eslint-config-prettier@8.6.0)(eslint-plugin-ember@11.4.6)(eslint@8.33.0)(prettier@2.8.3):
+  /@nullvoxpopuli/eslint-configs@3.1.1(@babel/core@7.20.12)(@babel/eslint-parser@7.19.1)(@typescript-eslint/eslint-plugin@5.50.0)(@typescript-eslint/parser@5.50.0)(eslint-config-prettier@8.6.0)(eslint-plugin-ember@11.8.0)(eslint@8.33.0)(prettier@2.8.3):
     resolution: {integrity: sha512-7ERkp5DJCC/5RryMD27Kc6NWJsT19rZab5MuaeDEXND6fGiNSnVkjh/b38Qh7U3VGzG8YRZ5VMa9BnhWO29BoA==}
     engines: {node: '>= v16.0.0'}
     peerDependencies:
@@ -4618,7 +4595,7 @@ packages:
       eslint: 8.33.0
       eslint-import-resolver-typescript: 3.5.3(eslint-plugin-import@2.27.5)(eslint@8.33.0)
       eslint-plugin-decorator-position: 5.0.2(@babel/eslint-parser@7.19.1)(eslint@8.33.0)
-      eslint-plugin-ember: 11.4.6(eslint@8.33.0)
+      eslint-plugin-ember: 11.8.0(eslint@8.33.0)
       eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.50.0)(eslint-import-resolver-typescript@3.5.3)(eslint@8.33.0)
       eslint-plugin-json: 3.1.0
       eslint-plugin-n: 15.6.1(eslint@8.33.0)
@@ -4632,7 +4609,7 @@ packages:
       - supports-color
     dev: true
 
-  /@nullvoxpopuli/eslint-configs@3.1.1(@babel/core@7.20.12)(@babel/eslint-parser@7.19.1)(eslint-config-prettier@8.6.0)(eslint-plugin-ember@11.4.6)(eslint-plugin-qunit@7.3.4)(eslint@8.33.0)(prettier@2.8.3):
+  /@nullvoxpopuli/eslint-configs@3.1.1(@babel/core@7.20.12)(@babel/eslint-parser@7.19.1)(eslint-config-prettier@8.6.0)(eslint-plugin-ember@11.8.0)(eslint-plugin-qunit@7.3.4)(eslint@8.33.0)(prettier@2.8.3):
     resolution: {integrity: sha512-7ERkp5DJCC/5RryMD27Kc6NWJsT19rZab5MuaeDEXND6fGiNSnVkjh/b38Qh7U3VGzG8YRZ5VMa9BnhWO29BoA==}
     engines: {node: '>= v16.0.0'}
     peerDependencies:
@@ -4666,7 +4643,7 @@ packages:
       eslint: 8.33.0
       eslint-import-resolver-typescript: 3.5.3(eslint-plugin-import@2.27.5)(eslint@8.33.0)
       eslint-plugin-decorator-position: 5.0.2(@babel/eslint-parser@7.19.1)(eslint@8.33.0)
-      eslint-plugin-ember: 11.4.6(eslint@8.33.0)
+      eslint-plugin-ember: 11.8.0(eslint@8.33.0)
       eslint-plugin-import: 2.27.5(eslint-import-resolver-typescript@3.5.3)(eslint@8.33.0)
       eslint-plugin-json: 3.1.0
       eslint-plugin-n: 15.6.1(eslint@8.33.0)
@@ -4681,7 +4658,7 @@ packages:
       - supports-color
     dev: true
 
-  /@nullvoxpopuli/eslint-configs@3.1.1(@babel/core@7.21.4)(@babel/eslint-parser@7.19.1)(@typescript-eslint/eslint-plugin@5.50.0)(@typescript-eslint/parser@5.50.0)(eslint-config-prettier@8.6.0)(eslint-plugin-ember@11.4.6)(eslint@8.33.0)(prettier@2.8.3):
+  /@nullvoxpopuli/eslint-configs@3.1.1(@babel/core@7.21.4)(@babel/eslint-parser@7.19.1)(@typescript-eslint/eslint-plugin@5.50.0)(@typescript-eslint/parser@5.50.0)(eslint-config-prettier@8.6.0)(eslint-plugin-ember@11.8.0)(eslint@8.33.0)(prettier@2.8.3):
     resolution: {integrity: sha512-7ERkp5DJCC/5RryMD27Kc6NWJsT19rZab5MuaeDEXND6fGiNSnVkjh/b38Qh7U3VGzG8YRZ5VMa9BnhWO29BoA==}
     engines: {node: '>= v16.0.0'}
     peerDependencies:
@@ -4717,7 +4694,7 @@ packages:
       eslint: 8.33.0
       eslint-import-resolver-typescript: 3.5.3(eslint-plugin-import@2.27.5)(eslint@8.33.0)
       eslint-plugin-decorator-position: 5.0.2(@babel/eslint-parser@7.19.1)(eslint@8.33.0)
-      eslint-plugin-ember: 11.4.6(eslint@8.33.0)
+      eslint-plugin-ember: 11.8.0(eslint@8.33.0)
       eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.50.0)(eslint-import-resolver-typescript@3.5.3)(eslint@8.33.0)
       eslint-plugin-json: 3.1.0
       eslint-plugin-n: 15.6.1(eslint@8.33.0)
@@ -10357,23 +10334,23 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-plugin-ember@11.4.6(eslint@8.33.0):
-    resolution: {integrity: sha512-ak+gDkZrOQUjpLYiDWJA1D2jWJy0MYTf409Ki6du06+vYNifuMJIFpJhH9oKsD1FPU1sQylzhHcOeiHfbQTWmA==}
+  /eslint-plugin-ember@11.8.0(eslint@8.33.0):
+    resolution: {integrity: sha512-oZ6My7LlbyhNCguHuyBnajGbpU5+raQ5zkaF9Vqe8EkWf3Ji2uJZH7BxzMMcR4gAuyx5qTUZRXVs42km1nTzVg==}
     engines: {node: 14.* || 16.* || >= 18}
     peerDependencies:
       eslint: '>= 7'
     dependencies:
       '@ember-data/rfc395-data': 0.0.4
-      '@glimmer/syntax': 0.84.2
+      '@glimmer/syntax': 0.84.3
       css-tree: 2.3.1
       ember-rfc176-data: 0.3.18
-      ember-template-imports: 3.4.1
+      ember-template-imports: 3.4.2
       eslint: 8.33.0
       eslint-utils: 3.0.0(eslint@8.33.0)
       estraverse: 5.3.0
       lodash.camelcase: 4.3.0
       lodash.kebabcase: 4.1.1
-      magic-string: 0.27.0
+      magic-string: 0.30.0
       requireindex: 1.2.0
       snake-case: 3.0.4
     transitivePeerDependencies:
@@ -13212,6 +13189,13 @@ packages:
 
   /magic-string@0.27.0:
     resolution: {integrity: sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==}
+    engines: {node: '>=12'}
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.4.14
+    dev: true
+
+  /magic-string@0.30.0:
+    resolution: {integrity: sha512-LA+31JYDJLs82r2ScLrlz1GjSgu66ZV518eyWT+S8VhyQn/JL0u9MeBOvQMGYiPk1DBiSN9DDMOcXvigJZaViQ==}
     engines: {node: '>=12'}
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.14

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -97,7 +97,7 @@
     "ember-try": "^2.0.0",
     "eslint": "^8.32.0",
     "eslint-config-prettier": "^8.5.0",
-    "eslint-plugin-ember": "^11.4.3",
+    "eslint-plugin-ember": "^11.8.0",
     "eslint-plugin-n": "^16.0.0",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^4.2.1",

--- a/test-app/tests/integration/components/checkbox-field-test.gts
+++ b/test-app/tests/integration/components/checkbox-field-test.gts
@@ -1,5 +1,4 @@
 /* eslint-disable no-undef -- Until https://github.com/ember-cli/eslint-plugin-ember/issues/1747 is resolved... */
-/* eslint-disable simple-import-sort/imports,padding-line-between-statements,decorator-position/decorator-position -- Can't fix these manually, without --fix working in .gts */
 
 import { click, find, render, setupOnerror } from '@ember/test-helpers';
 import { module, test } from 'qunit';
@@ -73,6 +72,7 @@ module('Integration | Component | Fields | CheckboxField', function (hooks) {
     assert.dom(error).hasAttribute('id');
 
     let errorId = error?.getAttribute('id') || '';
+
     assert.ok(errorId, 'Expected errorId to be truthy');
 
     // For the checkbox-field component, the only aria-describedby
@@ -81,6 +81,7 @@ module('Integration | Component | Fields | CheckboxField', function (hooks) {
     // wrapping <label> element
     let describedby =
       find('[data-checkbox]')?.getAttribute('aria-describedby') || '';
+
     assert.ok(
       describedby.includes(errorId),
       'Expected errorId to be included in the aria-describedby'
@@ -99,6 +100,7 @@ module('Integration | Component | Fields | CheckboxField', function (hooks) {
     </template>);
 
     let labelFor = find('[data-control] > label')?.getAttribute('for') || '';
+
     assert.ok(labelFor, 'Expected the id attribute of the label to be truthy');
 
     assert

--- a/test-app/tests/integration/components/checkbox-group-field-test.gts
+++ b/test-app/tests/integration/components/checkbox-group-field-test.gts
@@ -1,5 +1,4 @@
 /* eslint-disable no-undef -- Until https://github.com/ember-cli/eslint-plugin-ember/issues/1747 is resolved... */
-/* eslint-disable simple-import-sort/imports,padding-line-between-statements,decorator-position/decorator-position -- Can't fix these manually, without --fix working in .gts */
 
 import { click, render, setupOnerror } from '@ember/test-helpers';
 import { module, test } from 'qunit';

--- a/test-app/tests/integration/components/checkbox-test.gts
+++ b/test-app/tests/integration/components/checkbox-test.gts
@@ -1,6 +1,4 @@
 /* eslint-disable no-undef -- Until https://github.com/ember-cli/eslint-plugin-ember/issues/1747 is resolved... */
-/* eslint-disable simple-import-sort/imports,padding-line-between-statements,decorator-position/decorator-position -- Can't fix these manually, without --fix working in .gts */
-
 import { click, render } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 

--- a/test-app/tests/integration/components/field-test.gts
+++ b/test-app/tests/integration/components/field-test.gts
@@ -1,6 +1,4 @@
 /* eslint-disable no-undef -- Until https://github.com/ember-cli/eslint-plugin-ember/issues/1747 is resolved... */
-/* eslint-disable simple-import-sort/imports,padding-line-between-statements,decorator-position/decorator-position -- Can't fix these manually, without --fix working in .gts */
-
 import { findAll, render } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 
@@ -65,6 +63,7 @@ module('Integration | Component | Field', function (hooks) {
     assert.dom(label).hasText('label', 'Expected to have label text "label"');
 
     const children = findAll('[data-test-field] > div');
+
     assert.strictEqual(
       children.length,
       2,

--- a/test-app/tests/integration/components/file-input-field-test.gts
+++ b/test-app/tests/integration/components/file-input-field-test.gts
@@ -1,7 +1,6 @@
 /* eslint-disable no-undef -- Until https://github.com/ember-cli/eslint-plugin-ember/issues/1747 is resolved... */
-/* eslint-disable simple-import-sort/imports,padding-line-between-statements,decorator-position/decorator-position -- Can't fix these manually, without --fix working in .gts */
-import { find, render, setupOnerror, triggerEvent } from '@ember/test-helpers';
 import { tracked } from '@glimmer/tracking';
+import { find, render, setupOnerror, triggerEvent } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 
 import FileInputField from '@crowdstrike/ember-toucan-core/components/form/fields/file-input';
@@ -129,6 +128,7 @@ module('Integration | Component | Fields | FileInput', function (hooks) {
     assert.dom(error).hasAttribute('id');
 
     let errorId = error?.getAttribute('id') ?? '';
+
     assert.ok(errorId, 'Expected errorId to be truthy');
 
     // For the file input field component, the only aria-describedby
@@ -137,6 +137,7 @@ module('Integration | Component | Fields | FileInput', function (hooks) {
     // wrapping <label> element
     let describedby =
       find('[data-file-input-field]')?.getAttribute('aria-describedby') ?? '';
+
     assert.ok(
       describedby.includes(errorId),
       'Expected errorId to be included in the aria-describedby'
@@ -161,6 +162,7 @@ module('Integration | Component | Fields | FileInput', function (hooks) {
     </template>);
 
     let labelFor = find('label')?.getAttribute('for') ?? '';
+
     assert.ok(labelFor, 'Expected the id attribute of the label to be truthy');
 
     assert
@@ -336,10 +338,12 @@ module('Integration | Component | Fields | FileInput', function (hooks) {
     }
 
     let ctx = new Context();
+
     ctx.triggerText = 'Browse Files';
 
     const realOnChange = (files: File[]) => {
       ctx.currentFiles = files;
+
       if (ctx.currentFiles.length > 0) {
         ctx.triggerText = 'Replace files';
       }

--- a/test-app/tests/integration/components/file-input-test.gts
+++ b/test-app/tests/integration/components/file-input-test.gts
@@ -1,5 +1,4 @@
 /* eslint-disable no-undef -- Until https://github.com/ember-cli/eslint-plugin-ember/issues/1747 is resolved... */
-/* eslint-disable simple-import-sort/imports,padding-line-between-statements,decorator-position/decorator-position -- Can't fix these manually, without --fix working in .gts */
 import { render } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 

--- a/test-app/tests/integration/components/form/file-input/delete-button-test.gts
+++ b/test-app/tests/integration/components/form/file-input/delete-button-test.gts
@@ -1,5 +1,4 @@
 /* eslint-disable no-undef -- Until https://github.com/ember-cli/eslint-plugin-ember/issues/1747 is resolved... */
-/* eslint-disable simple-import-sort/imports,padding-line-between-statements,decorator-position/decorator-position -- Can't fix these manually, without --fix working in .gts */
 import { render, triggerEvent } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 

--- a/test-app/tests/integration/components/form/file-input/list-item-test.gts
+++ b/test-app/tests/integration/components/form/file-input/list-item-test.gts
@@ -1,5 +1,4 @@
 /* eslint-disable no-undef -- Until https://github.com/ember-cli/eslint-plugin-ember/issues/1747 is resolved... */
-/* eslint-disable simple-import-sort/imports,padding-line-between-statements,decorator-position/decorator-position -- Can't fix these manually, without --fix working in .gts */
 import { render, triggerEvent } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 

--- a/test-app/tests/integration/components/form/file-input/list-test.gts
+++ b/test-app/tests/integration/components/form/file-input/list-test.gts
@@ -1,5 +1,4 @@
 /* eslint-disable no-undef -- Until https://github.com/ember-cli/eslint-plugin-ember/issues/1747 is resolved... */
-/* eslint-disable simple-import-sort/imports,padding-line-between-statements,decorator-position/decorator-position -- Can't fix these manually, without --fix working in .gts */
 import { render } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 

--- a/test-app/tests/integration/components/input-field-test.gts
+++ b/test-app/tests/integration/components/input-field-test.gts
@@ -1,10 +1,8 @@
 /* eslint-disable no-undef -- Until https://github.com/ember-cli/eslint-plugin-ember/issues/1747 is resolved... */
-/* eslint-disable simple-import-sort/imports,padding-line-between-statements,decorator-position/decorator-position -- Can't fix these manually, without --fix working in .gts */
 import { fillIn, find, render, setupOnerror } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 
 import InputField from '@crowdstrike/ember-toucan-core/components/form/fields/input';
-
 import { setupRenderingTest } from 'test-app/tests/helpers';
 
 module('Integration | Component | Fields | Input', function (hooks) {
@@ -116,6 +114,7 @@ module('Integration | Component | Fields | Input', function (hooks) {
       .dom(hint)
       .hasText('Hint text visible here', 'Expected to have hint text "error"');
     assert.dom(hint).hasAttribute('id');
+
     const hintId = find(hint)?.getAttribute('id') || '';
     const describedby = find(input)?.getAttribute('aria-describedby') || '';
 
@@ -149,9 +148,11 @@ module('Integration | Component | Fields | Input', function (hooks) {
     </template>);
 
     const errorId = find('[data-error]')?.getAttribute('id') || '';
+
     assert.ok(errorId, 'Expected errorId to be truthy');
 
     const hintId = find('[data-hint]')?.getAttribute('id') || '';
+
     assert.ok(hintId, 'Expected hintId to be truthy');
 
     assert

--- a/test-app/tests/integration/components/input-test.gts
+++ b/test-app/tests/integration/components/input-test.gts
@@ -1,6 +1,4 @@
 /* eslint-disable no-undef -- Until https://github.com/ember-cli/eslint-plugin-ember/issues/1747 is resolved... */
-/* eslint-disable simple-import-sort/imports,padding-line-between-statements,decorator-position/decorator-position -- Can't fix these manually, without --fix working in .gts */
-
 import { fillIn, render } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 

--- a/test-app/tests/integration/components/radio-field-test.gts
+++ b/test-app/tests/integration/components/radio-field-test.gts
@@ -1,6 +1,4 @@
 /* eslint-disable no-undef -- Until https://github.com/ember-cli/eslint-plugin-ember/issues/1747 is resolved... */
-/* eslint-disable simple-import-sort/imports,padding-line-between-statements,decorator-position/decorator-position -- Can't fix these manually, without --fix working in .gts */
-
 import { click, find, render, setupOnerror } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 
@@ -66,6 +64,7 @@ module('Integration | Component | Fields | Radio', function (hooks) {
     </template>);
 
     let labelFor = find('[data-control] > label')?.getAttribute('for') || '';
+
     assert.ok(labelFor, 'Expected the id attribute of the label to be truthy');
 
     assert

--- a/test-app/tests/integration/components/radio-group-field-test.gts
+++ b/test-app/tests/integration/components/radio-group-field-test.gts
@@ -1,6 +1,4 @@
 /* eslint-disable no-undef -- Until https://github.com/ember-cli/eslint-plugin-ember/issues/1747 is resolved... */
-/* eslint-disable simple-import-sort/imports,padding-line-between-statements,decorator-position/decorator-position -- Can't fix these manually, without --fix working in .gts */
-
 import { click, render, setupOnerror } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 

--- a/test-app/tests/integration/components/radio-test.gts
+++ b/test-app/tests/integration/components/radio-test.gts
@@ -1,6 +1,4 @@
 /* eslint-disable no-undef -- Until https://github.com/ember-cli/eslint-plugin-ember/issues/1747 is resolved... */
-/* eslint-disable simple-import-sort/imports,padding-line-between-statements,decorator-position/decorator-position -- Can't fix these manually, without --fix working in .gts */
-
 import { click, render, setupOnerror } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 

--- a/test-app/tests/integration/components/textarea-field-test.gts
+++ b/test-app/tests/integration/components/textarea-field-test.gts
@@ -1,7 +1,5 @@
 /* eslint-disable no-undef -- Until https://github.com/ember-cli/eslint-plugin-ember/issues/1747 is resolved... */
-/* eslint-disable simple-import-sort/imports,padding-line-between-statements,decorator-position/decorator-position -- Can't fix these manually, without --fix working in .gts */
-
-import { find, fillIn, render, setupOnerror } from '@ember/test-helpers';
+import { fillIn, find, render, setupOnerror } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 
 import TextareaField from '@crowdstrike/ember-toucan-core/components/form/fields/textarea';
@@ -45,10 +43,12 @@ module('Integration | Component | Fields | Textarea', function (hooks) {
     assert.dom(hint).hasAttribute('id');
 
     let hintId = hint?.getAttribute('id') || '';
+
     assert.ok(hintId, 'Expected hintId to be truthy');
 
     let describedby =
       find('[data-textarea]')?.getAttribute('aria-describedby') || '';
+
     assert.ok(
       describedby.includes(hintId),
       'Expected hintId to be included in the aria-describedby'
@@ -78,10 +78,12 @@ module('Integration | Component | Fields | Textarea', function (hooks) {
     assert.dom(error).hasAttribute('id');
 
     let errorId = error?.getAttribute('id') || '';
+
     assert.ok(errorId, 'Expected errorId to be truthy');
 
     let describedby =
       find('[data-textarea]')?.getAttribute('aria-describedby') || '';
+
     assert.ok(
       describedby.includes(errorId),
       'Expected errorId to be included in the aria-describedby'
@@ -105,9 +107,11 @@ module('Integration | Component | Fields | Textarea', function (hooks) {
     </template>);
 
     let errorId = find('[data-error]')?.getAttribute('id') || '';
+
     assert.ok(errorId, 'Expected errorId to be truthy');
 
     let hintId = find('[data-hint]')?.getAttribute('id') || '';
+
     assert.ok(hintId, 'Expected hintId to be truthy');
 
     assert
@@ -223,7 +227,7 @@ module('Integration | Component | Fields | Textarea', function (hooks) {
     </template>);
   });
 
-  test('it renders a `<:secondary>` block that tracks the textarea value length', async function(assert) {
+  test('it renders a `<:secondary>` block that tracks the textarea value length', async function (assert) {
     await render(<template>
       <TextareaField @label="Label" @value="Hello" data-textarea>
         <:secondary as |secondary|>
@@ -237,6 +241,5 @@ module('Integration | Component | Fields | Textarea', function (hooks) {
     await fillIn('[data-textarea]', 'Hello Hello');
 
     assert.dom('[data-character]').hasText('11 / 255');
-
   });
 });

--- a/test-app/tests/integration/components/textarea-test.gts
+++ b/test-app/tests/integration/components/textarea-test.gts
@@ -1,6 +1,4 @@
 /* eslint-disable no-undef -- Until https://github.com/ember-cli/eslint-plugin-ember/issues/1747 is resolved... */
-/* eslint-disable simple-import-sort/imports,padding-line-between-statements,decorator-position/decorator-position -- Can't fix these manually, without --fix working in .gts */
-
 import { fillIn, render } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 

--- a/test-app/tests/integration/components/toucan-form/form-checkbox-group-test.gts
+++ b/test-app/tests/integration/components/toucan-form/form-checkbox-group-test.gts
@@ -1,10 +1,9 @@
 /* eslint-disable no-undef -- Until https://github.com/ember-cli/eslint-plugin-ember/issues/1747 is resolved... */
-/* eslint-disable simple-import-sort/imports,padding-line-between-statements,decorator-position/decorator-position -- Can't fix these manually, without --fix working in .gts */
 import { render } from '@ember/test-helpers';
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'test-app/tests/helpers';
 
 import ToucanForm from '@crowdstrike/ember-toucan-form/components/toucan-form';
+import { setupRenderingTest } from 'test-app/tests/helpers';
 
 interface TestData {
   checkboxes?: Array<string>;

--- a/test-app/tests/integration/components/toucan-form/form-checkbox-test.gts
+++ b/test-app/tests/integration/components/toucan-form/form-checkbox-test.gts
@@ -1,10 +1,9 @@
 /* eslint-disable no-undef -- Until https://github.com/ember-cli/eslint-plugin-ember/issues/1747 is resolved... */
-/* eslint-disable simple-import-sort/imports,padding-line-between-statements,decorator-position/decorator-position -- Can't fix these manually, without --fix working in .gts */
 import { render } from '@ember/test-helpers';
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'test-app/tests/helpers';
 
 import ToucanForm from '@crowdstrike/ember-toucan-form/components/toucan-form';
+import { setupRenderingTest } from 'test-app/tests/helpers';
 
 interface TestData {
   checked?: boolean;

--- a/test-app/tests/integration/components/toucan-form/form-input-test.gts
+++ b/test-app/tests/integration/components/toucan-form/form-input-test.gts
@@ -1,10 +1,9 @@
 /* eslint-disable no-undef -- Until https://github.com/ember-cli/eslint-plugin-ember/issues/1747 is resolved... */
-/* eslint-disable simple-import-sort/imports,padding-line-between-statements,decorator-position/decorator-position -- Can't fix these manually, without --fix working in .gts */
 import { render } from '@ember/test-helpers';
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'test-app/tests/helpers';
 
 import ToucanForm from '@crowdstrike/ember-toucan-form/components/toucan-form';
+import { setupRenderingTest } from 'test-app/tests/helpers';
 
 interface TestData {
   text?: string;

--- a/test-app/tests/integration/components/toucan-form/form-radio-group-test.gts
+++ b/test-app/tests/integration/components/toucan-form/form-radio-group-test.gts
@@ -1,10 +1,9 @@
 /* eslint-disable no-undef -- Until https://github.com/ember-cli/eslint-plugin-ember/issues/1747 is resolved... */
-/* eslint-disable simple-import-sort/imports,padding-line-between-statements,decorator-position/decorator-position -- Can't fix these manually, without --fix working in .gts */
 import { render } from '@ember/test-helpers';
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'test-app/tests/helpers';
 
 import ToucanForm from '@crowdstrike/ember-toucan-form/components/toucan-form';
+import { setupRenderingTest } from 'test-app/tests/helpers';
 
 interface TestData {
   radio?: string;

--- a/test-app/tests/integration/components/toucan-form/form-textarea-test.gts
+++ b/test-app/tests/integration/components/toucan-form/form-textarea-test.gts
@@ -1,10 +1,9 @@
 /* eslint-disable no-undef -- Until https://github.com/ember-cli/eslint-plugin-ember/issues/1747 is resolved... */
-/* eslint-disable simple-import-sort/imports,padding-line-between-statements,decorator-position/decorator-position -- Can't fix these manually, without --fix working in .gts */
 import { render } from '@ember/test-helpers';
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'test-app/tests/helpers';
 
 import ToucanForm from '@crowdstrike/ember-toucan-form/components/toucan-form';
+import { setupRenderingTest } from 'test-app/tests/helpers';
 
 interface TestData {
   text?: string;

--- a/test-app/tests/integration/components/toucan-form/toucan-form-test.gts
+++ b/test-app/tests/integration/components/toucan-form/toucan-form-test.gts
@@ -1,10 +1,9 @@
 /* eslint-disable no-undef -- Until https://github.com/ember-cli/eslint-plugin-ember/issues/1747 is resolved... */
-/* eslint-disable simple-import-sort/imports,padding-line-between-statements,decorator-position/decorator-position -- Can't fix these manually, without --fix working in .gts */
 import { click, fillIn, render } from '@ember/test-helpers';
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'test-app/tests/helpers';
 
 import ToucanForm from '@crowdstrike/ember-toucan-form/components/toucan-form';
+import { setupRenderingTest } from 'test-app/tests/helpers';
 
 import type { ErrorRecord } from 'ember-headless-form';
 


### PR DESCRIPTION
## 🚀 Description

This PR upgrades us to the latest `eslint-plugin-ember` and removes the `eslint-disable` comments in our `gts` files.  Fixed via:

- https://github.com/ember-cli/eslint-plugin-ember/issues/1750
- https://github.com/ember-cli/eslint-plugin-ember/pull/1853

With this change, you can now click the lightbulb in VS Code > Auto-fix all issues.  Or via the CLI you can do `pnpm lint:js:fix` to resolve all eslint issues automatically.

Closes #43 

---

## 🔬 How to Test

- Green build
---

## 📸 Images/Videos of Functionality

N/A
