### PR TITLE
fix: Update typescript version tests to include 5.0 and 5.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,8 @@ jobs:
         typescript-scenario:
           - typescript@4.8
           - typescript@4.9
+          - typescript@5.0
+          - typescript@5.1
     steps:
       - uses: actions/checkout@v3
       - name: TurboRepo local server


### PR DESCRIPTION
## 🚀 Description

Testing for newer versions of typescript. 

- [x] added: typescript version test for typescript@5.0
- [x]  added: typescript version test for typescript@5.1


## 🔬 How to Test

CI should be ✅ 

---

## 📸 Images/Videos of Functionality

N/A