### PR TITLE
[WIP] || feat: Add disabled lock to input

### DIFF
--- a/docs/components/input-field/demo/base-demo.md
+++ b/docs/components/input-field/demo/base-demo.md
@@ -1,12 +1,14 @@
 ```hbs template
-<Form::Fields::Input
-  @label='Label'
-  @hint='Type "input" into the field'
-  @error={{this.errorMessage}}
-  @value={{this.value}}
-  @onChange={{this.handleChange}}
-  type='text'
-/>
+<div class='max-w-xs'>
+  <Form::Fields::Input
+    @label='Label'
+    @hint='Type "input" into the field'
+    @error={{this.errorMessage}}
+    @value={{this.value}}
+    @onChange={{this.handleChange}}
+    type='text'
+  />
+</div>
 ```
 
 ```js component

--- a/docs/components/input-field/index.md
+++ b/docs/components/input-field/index.md
@@ -220,6 +220,16 @@ Target the error block via `data-error`.
   />
 </div>
 
+### InputField with label, long value, and isDisabled
+
+<div class='mb-4 w-64'>
+  <Form::Fields::Input
+    @label='Label'
+    @isDisabled={{true}}
+    @value='Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur ornare rhoncus enim ac efficitur. Curabitur convallis sed libero sit amet aliquet. In venenatis metus quam, eu sodales tellus aliquet non'
+  />
+</div>
+
 ### InputField with a value
 
 <div class='mb-4 w-64'>
@@ -305,5 +315,15 @@ Target the error block via `data-error`.
     @label='Label'
     @isReadOnly={{true}}
     @value="Input value"
+  />
+</div>
+
+### InputField with isReadOnly and a long value
+
+<div class='mb-4 w-64'>
+  <Form::Fields::Input
+    @label='Label'
+    @isReadOnly={{true}}
+    @value="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur ornare rhoncus enim ac efficitur. Curabitur convallis sed libero sit amet aliquet. In venenatis metus quam, eu sodales tellus aliquet non"
   />
 </div>

--- a/packages/ember-toucan-core/src/-private/components/control.hbs
+++ b/packages/ember-toucan-core/src/-private/components/control.hbs
@@ -1,3 +1,3 @@
-<div ...attributes>
+<div class="relative" ...attributes>
   {{yield}}
 </div>

--- a/packages/ember-toucan-core/src/components/form/fields/input.hbs
+++ b/packages/ember-toucan-core/src/components/form/fields/input.hbs
@@ -37,9 +37,10 @@
     {{/if}}
     <field.Control class="mt-1.5 flex">
       <Form::Controls::Input
-        id={{field.id}}
         aria-describedby="{{if @hint field.hintId}} {{if @error field.errorId}}"
         aria-invalid={{if @error "true"}}
+        class="w-full truncate {{if this.isDisabledOrReadOnly 'pr-6'}}"
+        id={{field.id}}
         @isDisabled={{@isDisabled}}
         @isReadOnly={{@isReadOnly}}
         @value={{@value}}
@@ -48,6 +49,26 @@
         {{on "input" this.handleCount}}
         ...attributes
       />
+
+      {{#if this.isDisabledOrReadOnly}}
+        <div
+          class="text-disabled pointer-events-none absolute inset-y-0 right-0 flex items-center pr-1"
+          data-adornments
+        >
+          <svg
+            width="24"
+            height="24"
+            viewBox="0 0 24 24"
+            fill="currentColor"
+            aria-hidden="true"
+            data-lock-icon
+          ><g><path d="M11.5 12v3h1v-3h-1Z" /><path
+                fill-rule="evenodd"
+                clip-rule="evenodd"
+                d="M9 9.5V9a3 3 0 1 1 6 0v.5h.5A1.5 1.5 0 0 1 17 11v5a1.5 1.5 0 0 1-1.5 1.5h-7A1.5 1.5 0 0 1 7 16v-5a1.5 1.5 0 0 1 1.5-1.5H9Zm1-.5a2 2 0 1 1 4 0v.5h-4V9Zm-2 2a.5.5 0 0 1 .5-.5h7a.5.5 0 0 1 .5.5v5a.5.5 0 0 1-.5.5h-7A.5.5 0 0 1 8 16v-5Z"
+              /></g></svg>
+        </div>
+      {{/if}}
     </field.Control>
 
     {{#if (has-block "secondary")}}

--- a/packages/ember-toucan-core/src/components/form/fields/input.ts
+++ b/packages/ember-toucan-core/src/components/form/fields/input.ts
@@ -91,4 +91,8 @@ export default class ToucanFormInputFieldComponent extends Component<ToucanFormI
   get hasError() {
     return Boolean(this.args?.error);
   }
+
+  get isDisabledOrReadOnly() {
+    return this.args?.isDisabled || this.args?.isReadOnly;
+  }
 }

--- a/test-app/tests/integration/components/input-field-test.gts
+++ b/test-app/tests/integration/components/input-field-test.gts
@@ -25,6 +25,7 @@ module('Integration | Component | Fields | Input', function (hooks) {
     assert.dom(input).hasAttribute('type', 'text');
     assert.dom(input).hasAttribute('id');
     assert.dom(input).hasNoClass('shadow-error-outline');
+    assert.dom('[data-lock-icon]').doesNotExist();
   });
 
   test('it throws an assertion error if no `@label` or `:label` is provided', async function (assert) {
@@ -216,19 +217,21 @@ module('Integration | Component | Fields | Input', function (hooks) {
     assert.dom('[data-character]').hasText('11 / 255');
   });
 
-  test('it disables the input using `@isDisabled`', async function (assert) {
+  test('it disables the input using `@isDisabled` and displays the lock icon', async function (assert) {
     await render(<template>
       <InputField @label="Label" @isDisabled={{true}} data-input />
     </template>);
 
     assert.dom('[data-input]').isDisabled();
+    assert.dom('[data-lock-icon]').exists();
   });
 
-  test('it sets readonly on the input using `@isReadOnly`', async function (assert) {
+  test('it sets readonly on the input using `@isReadOnly` and displays the lock icon', async function (assert) {
     await render(<template>
       <InputField @label="Label" @isReadOnly={{true}} data-input />
     </template>);
 
     assert.dom('[data-input]').hasAttribute('readonly');
+    assert.dom('[data-lock-icon]').exists();
   });
 });


### PR DESCRIPTION
## 🚀 Description

Adds the disabled lock icon to our input.  Starting with input and will add to the other form components soon™.  This is going into a feature branch at the moment so I can iteratively add it to all components without merging into `main` directly.

---

## 🔬 How to Test

- TBD

---

## 📸 Images/Videos of Functionality

- TBD
