### PR TITLE
Add lock icon for disabled and readonly states

### DIFF
--- a/.changeset/fluffy-cameras-drum.md
+++ b/.changeset/fluffy-cameras-drum.md
@@ -1,0 +1,6 @@
+---
+'@crowdstrike/ember-toucan-core': patch
+'@crowdstrike/ember-toucan-form': patch
+---
+
+Add a lock icon to readonly and disabled states for all form components.

--- a/docs/components/checkbox-field/index.md
+++ b/docs/components/checkbox-field/index.md
@@ -204,7 +204,7 @@ Target the error block via `data-error`.
 <div class='mb-4 w-64'>
   <Form::Fields::Checkbox
   >
-    <:label>Label <svg class="inline w-4 h-4 -mt-1" xmlns="http://www.w3.org/2000/svg" width="24" height="24" stroke="currentColor" viewBox="0 0 24 24"><path d="M12 3a9 9 0 11-6.364 2.636A8.972 8.972 0 0112 3zm0 4.7v5.2m0 3.39v.01" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg></:label>
+    <:label>Label <svg class="inline w-4 h-4" xmlns="http://www.w3.org/2000/svg" width="24" height="24" stroke="currentColor" viewBox="0 0 24 24"><path d="M12 3a9 9 0 11-6.364 2.636A8.972 8.972 0 0112 3zm0 4.7v5.2m0 3.39v.01" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg></:label>
     <:hint>Select <a href="https://www.crowdstrike.com/">link</a></:hint>
   </Form::Fields::Checkbox>
 </div>

--- a/docs/components/checkbox-field/index.md
+++ b/docs/components/checkbox-field/index.md
@@ -204,7 +204,7 @@ Target the error block via `data-error`.
 <div class='mb-4 w-64'>
   <Form::Fields::Checkbox
   >
-    <:label>Label <svg class="inline" xmlns="http://www.w3.org/2000/svg" width="24" height="24" stroke="currentColor" viewBox="0 0 24 24"><path d="M12 3a9 9 0 11-6.364 2.636A8.972 8.972 0 0112 3zm0 4.7v5.2m0 3.39v.01" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg></:label>
+    <:label>Label <svg class="inline w-4 h-4 -mt-1" xmlns="http://www.w3.org/2000/svg" width="24" height="24" stroke="currentColor" viewBox="0 0 24 24"><path d="M12 3a9 9 0 11-6.364 2.636A8.972 8.972 0 0112 3zm0 4.7v5.2m0 3.39v.01" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg></:label>
     <:hint>Select <a href="https://www.crowdstrike.com/">link</a></:hint>
   </Form::Fields::Checkbox>
 </div>

--- a/docs/components/checkbox-group-field/index.md
+++ b/docs/components/checkbox-group-field/index.md
@@ -237,7 +237,7 @@ Consumers have direct access to the underlying [checkbox element](https://develo
       <group.CheckboxField @label='Option 2' @value='option-2' />
       <group.CheckboxField @label='Option 3' @value='option-3' />
     </:default>
-    <:label>Label <svg class="inline" xmlns="http://www.w3.org/2000/svg" width="24" height="24" stroke="currentColor" viewBox="0 0 24 24"><path d="M12 3a9 9 0 11-6.364 2.636A8.972 8.972 0 0112 3zm0 4.7v5.2m0 3.39v.01" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg></:label>
+    <:label>Label <svg class="inline w-4 h-4 -mt-1" xmlns="http://www.w3.org/2000/svg" width="24" height="24" stroke="currentColor" viewBox="0 0 24 24"><path d="M12 3a9 9 0 11-6.364 2.636A8.972 8.972 0 0112 3zm0 4.7v5.2m0 3.39v.01" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg></:label>
     <:hint>Select an option <a href="https://www.crowdstrike.com/">link</a></:hint>
   </Form::Fields::CheckboxGroup>
 </div>

--- a/docs/components/checkbox-group-field/index.md
+++ b/docs/components/checkbox-group-field/index.md
@@ -237,7 +237,7 @@ Consumers have direct access to the underlying [checkbox element](https://develo
       <group.CheckboxField @label='Option 2' @value='option-2' />
       <group.CheckboxField @label='Option 3' @value='option-3' />
     </:default>
-    <:label>Label <svg class="inline w-4 h-4 -mt-1" xmlns="http://www.w3.org/2000/svg" width="24" height="24" stroke="currentColor" viewBox="0 0 24 24"><path d="M12 3a9 9 0 11-6.364 2.636A8.972 8.972 0 0112 3zm0 4.7v5.2m0 3.39v.01" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg></:label>
+    <:label>Label <svg class="inline w-4 h-4" xmlns="http://www.w3.org/2000/svg" width="24" height="24" stroke="currentColor" viewBox="0 0 24 24"><path d="M12 3a9 9 0 11-6.364 2.636A8.972 8.972 0 0112 3zm0 4.7v5.2m0 3.39v.01" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg></:label>
     <:hint>Select an option <a href="https://www.crowdstrike.com/">link</a></:hint>
   </Form::Fields::CheckboxGroup>
 </div>

--- a/docs/components/file-input-field/index.md
+++ b/docs/components/file-input-field/index.md
@@ -250,7 +250,7 @@ Target the trash icon button via `data-delete-file`.
     @deleteLabel='Delete file'
     @trigger='Browse Files'
   >
-  <:label>Label <svg class="inline w-4 h-4 -mt-1" xmlns="http://www.w3.org/2000/svg" width="24" height="24" stroke="currentColor" viewBox="0 0 24 24"><path d="M12 3a9 9 0 11-6.364 2.636A8.972 8.972 0 0112 3zm0 4.7v5.2m0 3.39v.01" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg></:label>
+  <:label>Label <svg class="inline w-4 h-4" xmlns="http://www.w3.org/2000/svg" width="24" height="24" stroke="currentColor" viewBox="0 0 24 24"><path d="M12 3a9 9 0 11-6.364 2.636A8.972 8.972 0 0112 3zm0 4.7v5.2m0 3.39v.01" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg></:label>
   <:hint>Hint text <a href="https://www.crowdstrike.com/">link</a></:hint>
   </Form::Fields::FileInput>
 </div>

--- a/docs/components/file-input-field/index.md
+++ b/docs/components/file-input-field/index.md
@@ -250,7 +250,7 @@ Target the trash icon button via `data-delete-file`.
     @deleteLabel='Delete file'
     @trigger='Browse Files'
   >
-  <:label>Label <svg class="inline" xmlns="http://www.w3.org/2000/svg" width="24" height="24" stroke="currentColor" viewBox="0 0 24 24"><path d="M12 3a9 9 0 11-6.364 2.636A8.972 8.972 0 0112 3zm0 4.7v5.2m0 3.39v.01" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg></:label>
+  <:label>Label <svg class="inline w-4 h-4 -mt-1" xmlns="http://www.w3.org/2000/svg" width="24" height="24" stroke="currentColor" viewBox="0 0 24 24"><path d="M12 3a9 9 0 11-6.364 2.636A8.972 8.972 0 0112 3zm0 4.7v5.2m0 3.39v.01" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg></:label>
   <:hint>Hint text <a href="https://www.crowdstrike.com/">link</a></:hint>
   </Form::Fields::FileInput>
 </div>

--- a/docs/components/input-field/index.md
+++ b/docs/components/input-field/index.md
@@ -177,7 +177,7 @@ Target the error block via `data-error`.
 <div class='mb-4 w-64'>
   <Form::Fields::Input
   >
-  <:label>Label <svg class="inline w-4 h-4 -mt-1" xmlns="http://www.w3.org/2000/svg" width="24" height="24" stroke="currentColor" viewBox="0 0 24 24"><path d="M12 3a9 9 0 11-6.364 2.636A8.972 8.972 0 0112 3zm0 4.7v5.2m0 3.39v.01" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg></:label>
+  <:label>Label <svg class="inline w-4 h-4" xmlns="http://www.w3.org/2000/svg" width="24" height="24" stroke="currentColor" viewBox="0 0 24 24"><path d="M12 3a9 9 0 11-6.364 2.636A8.972 8.972 0 0112 3zm0 4.7v5.2m0 3.39v.01" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg></:label>
   <:hint>Hint text <a href="https://www.crowdstrike.com/">link</a></:hint>
   </Form::Fields::Input>
 </div>

--- a/docs/components/input-field/index.md
+++ b/docs/components/input-field/index.md
@@ -177,7 +177,7 @@ Target the error block via `data-error`.
 <div class='mb-4 w-64'>
   <Form::Fields::Input
   >
-  <:label>Label <svg class="inline" xmlns="http://www.w3.org/2000/svg" width="24" height="24" stroke="currentColor" viewBox="0 0 24 24"><path d="M12 3a9 9 0 11-6.364 2.636A8.972 8.972 0 0112 3zm0 4.7v5.2m0 3.39v.01" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg></:label>
+  <:label>Label <svg class="inline w-4 h-4 -mt-1" xmlns="http://www.w3.org/2000/svg" width="24" height="24" stroke="currentColor" viewBox="0 0 24 24"><path d="M12 3a9 9 0 11-6.364 2.636A8.972 8.972 0 0112 3zm0 4.7v5.2m0 3.39v.01" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg></:label>
   <:hint>Hint text <a href="https://www.crowdstrike.com/">link</a></:hint>
   </Form::Fields::Input>
 </div>

--- a/docs/components/radio-field/index.md
+++ b/docs/components/radio-field/index.md
@@ -186,7 +186,7 @@ Target the hint block via `data-hint`.
     @name='options-b'
     @value='option-1'
   >
-  <:label>Label <svg class="inline w-4 h-4 -mt-1" xmlns="http://www.w3.org/2000/svg" width="24" height="24" stroke="currentColor" viewBox="0 0 24 24"><path d="M12 3a9 9 0 11-6.364 2.636A8.972 8.972 0 0112 3zm0 4.7v5.2m0 3.39v.01" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg></:label>
+  <:label>Label <svg class="inline w-4 h-4" xmlns="http://www.w3.org/2000/svg" width="24" height="24" stroke="currentColor" viewBox="0 0 24 24"><path d="M12 3a9 9 0 11-6.364 2.636A8.972 8.972 0 0112 3zm0 4.7v5.2m0 3.39v.01" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg></:label>
   <:hint>Hint text <a href="https://www.crowdstrike.com/">link</a></:hint>
   </Form::Fields::Radio>
 </div>

--- a/docs/components/radio-field/index.md
+++ b/docs/components/radio-field/index.md
@@ -186,7 +186,7 @@ Target the hint block via `data-hint`.
     @name='options-b'
     @value='option-1'
   >
-  <:label>Label <svg class="inline" xmlns="http://www.w3.org/2000/svg" width="24" height="24" stroke="currentColor" viewBox="0 0 24 24"><path d="M12 3a9 9 0 11-6.364 2.636A8.972 8.972 0 0112 3zm0 4.7v5.2m0 3.39v.01" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg></:label>
+  <:label>Label <svg class="inline w-4 h-4 -mt-1" xmlns="http://www.w3.org/2000/svg" width="24" height="24" stroke="currentColor" viewBox="0 0 24 24"><path d="M12 3a9 9 0 11-6.364 2.636A8.972 8.972 0 0112 3zm0 4.7v5.2m0 3.39v.01" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg></:label>
   <:hint>Hint text <a href="https://www.crowdstrike.com/">link</a></:hint>
   </Form::Fields::Radio>
 </div>

--- a/docs/components/radio-group-field/index.md
+++ b/docs/components/radio-group-field/index.md
@@ -245,7 +245,7 @@ Consumers have direct access to the underlying [radio element](https://developer
       <group.RadioField @label='Option 2' @value='option-2' />
       <group.RadioField @label='Option 3' @value='option-3' />
     </:default>
-  <:label>Label <svg class="inline" xmlns="http://www.w3.org/2000/svg" width="24" height="24" stroke="currentColor" viewBox="0 0 24 24"><path d="M12 3a9 9 0 11-6.364 2.636A8.972 8.972 0 0112 3zm0 4.7v5.2m0 3.39v.01" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg></:label>
+  <:label>Label <svg class="inline w-4 h-4 -mt-1" xmlns="http://www.w3.org/2000/svg" width="24" height="24" stroke="currentColor" viewBox="0 0 24 24"><path d="M12 3a9 9 0 11-6.364 2.636A8.972 8.972 0 0112 3zm0 4.7v5.2m0 3.39v.01" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg></:label>
   <:hint>Select an option <a href="https://www.crowdstrike.com/">link</a></:hint>
   </Form::Fields::RadioGroup>
 </div>

--- a/docs/components/radio-group-field/index.md
+++ b/docs/components/radio-group-field/index.md
@@ -245,7 +245,7 @@ Consumers have direct access to the underlying [radio element](https://developer
       <group.RadioField @label='Option 2' @value='option-2' />
       <group.RadioField @label='Option 3' @value='option-3' />
     </:default>
-  <:label>Label <svg class="inline w-4 h-4 -mt-1" xmlns="http://www.w3.org/2000/svg" width="24" height="24" stroke="currentColor" viewBox="0 0 24 24"><path d="M12 3a9 9 0 11-6.364 2.636A8.972 8.972 0 0112 3zm0 4.7v5.2m0 3.39v.01" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg></:label>
+  <:label>Label <svg class="inline w-4 h-4" xmlns="http://www.w3.org/2000/svg" width="24" height="24" stroke="currentColor" viewBox="0 0 24 24"><path d="M12 3a9 9 0 11-6.364 2.636A8.972 8.972 0 0112 3zm0 4.7v5.2m0 3.39v.01" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg></:label>
   <:hint>Select an option <a href="https://www.crowdstrike.com/">link</a></:hint>
   </Form::Fields::RadioGroup>
 </div>

--- a/docs/components/textarea-field/index.md
+++ b/docs/components/textarea-field/index.md
@@ -198,7 +198,7 @@ Target the error block via `data-error`.
 <div class='mb-4 w-64'>
   <Form::Fields::Textarea
   >
-  <:label>Label <svg class="inline" xmlns="http://www.w3.org/2000/svg" width="24" height="24" stroke="currentColor" viewBox="0 0 24 24"><path d="M12 3a9 9 0 11-6.364 2.636A8.972 8.972 0 0112 3zm0 4.7v5.2m0 3.39v.01" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg></:label>
+  <:label>Label <svg class="inline w-4 h-4 -mt-1" xmlns="http://www.w3.org/2000/svg" width="24" height="24" stroke="currentColor" viewBox="0 0 24 24"><path d="M12 3a9 9 0 11-6.364 2.636A8.972 8.972 0 0112 3zm0 4.7v5.2m0 3.39v.01" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg></:label>
   <:hint>Select an option <a href="https://www.crowdstrike.com/">link</a></:hint>
   </Form::Fields::Textarea>
 </div>
@@ -242,7 +242,7 @@ Target the error block via `data-error`.
   />
 </div>
 
-### TextareaField with character count 
+### TextareaField with character count
 
 <div class='mb-4 w-64'>
   <Form::Fields::Textarea
@@ -256,7 +256,7 @@ Target the error block via `data-error`.
   </Form::Fields::Textarea>
 </div>
 
-### TextareaField with character count with a single error 
+### TextareaField with character count with a single error
 
 <div class='mb-4 w-64'>
   <Form::Fields::Textarea
@@ -271,7 +271,7 @@ Target the error block via `data-error`.
   </Form::Fields::Textarea>
 </div>
 
-### TextareaField with character count with multiple errors 
+### TextareaField with character count with multiple errors
 
 <div class='mb-4 w-64'>
   <Form::Fields::Textarea

--- a/docs/components/textarea-field/index.md
+++ b/docs/components/textarea-field/index.md
@@ -198,7 +198,7 @@ Target the error block via `data-error`.
 <div class='mb-4 w-64'>
   <Form::Fields::Textarea
   >
-  <:label>Label <svg class="inline w-4 h-4 -mt-1" xmlns="http://www.w3.org/2000/svg" width="24" height="24" stroke="currentColor" viewBox="0 0 24 24"><path d="M12 3a9 9 0 11-6.364 2.636A8.972 8.972 0 0112 3zm0 4.7v5.2m0 3.39v.01" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg></:label>
+  <:label>Label <svg class="inline w-4 h-4" xmlns="http://www.w3.org/2000/svg" width="24" height="24" stroke="currentColor" viewBox="0 0 24 24"><path d="M12 3a9 9 0 11-6.364 2.636A8.972 8.972 0 0112 3zm0 4.7v5.2m0 3.39v.01" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg></:label>
   <:hint>Select an option <a href="https://www.crowdstrike.com/">link</a></:hint>
   </Form::Fields::Textarea>
 </div>

--- a/packages/ember-toucan-core/src/-private/components/lock-icon.hbs
+++ b/packages/ember-toucan-core/src/-private/components/lock-icon.hbs
@@ -1,13 +1,19 @@
 <svg
-  width="24"
-  height="24"
-  viewBox="0 0 24 24"
+  width="12"
+  height="12"
+  viewBox="0 0 12 12"
   fill="currentColor"
   aria-hidden="true"
+  class="text-disabled"
   data-lock-icon
   ...attributes
-><g><path d="M11.5 12v3h1v-3h-1Z" /><path
+>
+  <g>
+    <path d="M5.5 6v3h1V6h-1Z" />
+    <path
       fill-rule="evenodd"
       clip-rule="evenodd"
-      d="M9 9.5V9a3 3 0 1 1 6 0v.5h.5A1.5 1.5 0 0 1 17 11v5a1.5 1.5 0 0 1-1.5 1.5h-7A1.5 1.5 0 0 1 7 16v-5a1.5 1.5 0 0 1 1.5-1.5H9Zm1-.5a2 2 0 1 1 4 0v.5h-4V9Zm-2 2a.5.5 0 0 1 .5-.5h7a.5.5 0 0 1 .5.5v5a.5.5 0 0 1-.5.5h-7A.5.5 0 0 1 8 16v-5Z"
-    /></g></svg>
+      d="M3 3.5V3a3 3 0 0 1 6 0v.5h.5A1.5 1.5 0 0 1 11 5v5a1.5 1.5 0 0 1-1.5 1.5h-7A1.5 1.5 0 0 1 1 10V5a1.5 1.5 0 0 1 1.5-1.5H3ZM4 3a2 2 0 1 1 4 0v.5H4V3ZM2 5a.5.5 0 0 1 .5-.5h7a.5.5 0 0 1 .5.5v5a.5.5 0 0 1-.5.5h-7A.5.5 0 0 1 2 10V5Z"
+    />
+  </g>
+</svg>

--- a/packages/ember-toucan-core/src/-private/components/lock-icon.hbs
+++ b/packages/ember-toucan-core/src/-private/components/lock-icon.hbs
@@ -1,0 +1,13 @@
+<svg
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="currentColor"
+  aria-hidden="true"
+  data-lock-icon
+  ...attributes
+><g><path d="M11.5 12v3h1v-3h-1Z" /><path
+      fill-rule="evenodd"
+      clip-rule="evenodd"
+      d="M9 9.5V9a3 3 0 1 1 6 0v.5h.5A1.5 1.5 0 0 1 17 11v5a1.5 1.5 0 0 1-1.5 1.5h-7A1.5 1.5 0 0 1 7 16v-5a1.5 1.5 0 0 1 1.5-1.5H9Zm1-.5a2 2 0 1 1 4 0v.5h-4V9Zm-2 2a.5.5 0 0 1 .5-.5h7a.5.5 0 0 1 .5.5v5a.5.5 0 0 1-.5.5h-7A.5.5 0 0 1 8 16v-5Z"
+    /></g></svg>

--- a/packages/ember-toucan-core/src/-private/components/lock-icon.ts
+++ b/packages/ember-toucan-core/src/-private/components/lock-icon.ts
@@ -1,0 +1,11 @@
+import templateOnlyComponent from '@ember/component/template-only';
+
+export interface ToucanLockIconComponentSignature {
+  Element: Element;
+  Args: {};
+  Blocks: {
+    default: [];
+  };
+}
+
+export default templateOnlyComponent<ToucanLockIconComponentSignature>();

--- a/packages/ember-toucan-core/src/-private/components/lock-icon.ts
+++ b/packages/ember-toucan-core/src/-private/components/lock-icon.ts
@@ -4,7 +4,7 @@ export interface ToucanLockIconComponentSignature {
   Element: SVGElement;
   Args: {};
   Blocks: {
-    default: never;
+    default: [];
   };
 }
 

--- a/packages/ember-toucan-core/src/-private/components/lock-icon.ts
+++ b/packages/ember-toucan-core/src/-private/components/lock-icon.ts
@@ -1,7 +1,7 @@
 import templateOnlyComponent from '@ember/component/template-only';
 
 export interface ToucanLockIconComponentSignature {
-  Element: Element;
+  Element: SVGElement;
   Args: {};
   Blocks: {
     default: [];

--- a/packages/ember-toucan-core/src/-private/components/lock-icon.ts
+++ b/packages/ember-toucan-core/src/-private/components/lock-icon.ts
@@ -4,7 +4,7 @@ export interface ToucanLockIconComponentSignature {
   Element: SVGElement;
   Args: {};
   Blocks: {
-    default: [];
+    default: never;
   };
 }
 

--- a/packages/ember-toucan-core/src/components/form/fields/checkbox-group.hbs
+++ b/packages/ember-toucan-core/src/components/form/fields/checkbox-group.hbs
@@ -22,8 +22,8 @@
           {{@label}}
         {{/if}}
 
-        {{#if @isDisabled}}
-          <this.LockIcon class="-ml-1 -mt-1 inline-block" />
+        {{#if this.isReadOnlyOrDisabled}}
+          <this.LockIcon class="text-disabled -ml-1 -mt-1 inline-block" />
         {{/if}}
       </legend>
     {{/if}}

--- a/packages/ember-toucan-core/src/components/form/fields/checkbox-group.hbs
+++ b/packages/ember-toucan-core/src/components/form/fields/checkbox-group.hbs
@@ -15,7 +15,10 @@
         )
       )
     }}
-      <legend class="type-md-tight text-body-and-labels block" data-label>
+      <legend
+        class="type-md-tight text-body-and-labels flex items-center gap-1.5"
+        data-label
+      >
         {{#if (has-block "label")}}
           {{yield to="label"}}
         {{else}}
@@ -23,7 +26,7 @@
         {{/if}}
 
         {{#if this.isReadOnlyOrDisabled}}
-          <this.LockIcon class="text-disabled -ml-1 -mt-0.5 inline-block" />
+          <this.LockIcon />
         {{/if}}
       </legend>
     {{/if}}

--- a/packages/ember-toucan-core/src/components/form/fields/checkbox-group.hbs
+++ b/packages/ember-toucan-core/src/components/form/fields/checkbox-group.hbs
@@ -56,7 +56,7 @@
             isDisabled=@isDisabled
             isReadOnly=@isReadOnly
             selectedValues=@value
-            isInAGroup=true
+            isGrouped=true
           )
         )
       }}

--- a/packages/ember-toucan-core/src/components/form/fields/checkbox-group.hbs
+++ b/packages/ember-toucan-core/src/components/form/fields/checkbox-group.hbs
@@ -23,7 +23,7 @@
         {{/if}}
 
         {{#if this.isReadOnlyOrDisabled}}
-          <this.LockIcon class="text-disabled -ml-1 -mt-1 inline-block" />
+          <this.LockIcon class="text-disabled -ml-1 -mt-0.5 inline-block" />
         {{/if}}
       </legend>
     {{/if}}

--- a/packages/ember-toucan-core/src/components/form/fields/checkbox-group.hbs
+++ b/packages/ember-toucan-core/src/components/form/fields/checkbox-group.hbs
@@ -21,6 +21,10 @@
         {{else}}
           {{@label}}
         {{/if}}
+
+        {{#if @isDisabled}}
+          <this.LockIcon class="-ml-1 -mt-1 inline-block" />
+        {{/if}}
       </legend>
     {{/if}}
 

--- a/packages/ember-toucan-core/src/components/form/fields/checkbox-group.hbs
+++ b/packages/ember-toucan-core/src/components/form/fields/checkbox-group.hbs
@@ -56,6 +56,7 @@
             isDisabled=@isDisabled
             isReadOnly=@isReadOnly
             selectedValues=@value
+            isInAGroup=true
           )
         )
       }}

--- a/packages/ember-toucan-core/src/components/form/fields/checkbox-group.ts
+++ b/packages/ember-toucan-core/src/components/form/fields/checkbox-group.ts
@@ -2,6 +2,7 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 
 import assertBlockOrArgumentExists from '../../../-private/assert-block-or-argument-exists';
+import LockIcon from '../../../-private/components/lock-icon';
 import CheckboxFieldComponent from './checkbox';
 
 import type { AssertBlockOrArg } from '../../../-private/assert-block-or-argument-exists';
@@ -74,6 +75,7 @@ export interface ToucanFormCheckboxGroupFieldComponentSignature {
 
 export default class ToucanFormCheckboxGroupFieldComponent extends Component<ToucanFormCheckboxGroupFieldComponentSignature> {
   CheckboxFieldComponent = CheckboxFieldComponent;
+  LockIcon = LockIcon;
 
   assertBlockOrArgumentExists = ({
     blockExists,

--- a/packages/ember-toucan-core/src/components/form/fields/checkbox-group.ts
+++ b/packages/ember-toucan-core/src/components/form/fields/checkbox-group.ts
@@ -85,6 +85,10 @@ export default class ToucanFormCheckboxGroupFieldComponent extends Component<Tou
   }: AssertBlockOrArg) =>
     assertBlockOrArgumentExists({ blockExists, argName, arg, isRequired });
 
+  get isReadOnlyOrDisabled() {
+    return this.args?.isDisabled || this.args?.isReadOnly;
+  }
+
   @action
   handleInput(_: boolean, e: Event | InputEvent): void {
     let value = this.args.value ? [...this.args.value] : [];

--- a/packages/ember-toucan-core/src/components/form/fields/checkbox.hbs
+++ b/packages/ember-toucan-core/src/components/form/fields/checkbox.hbs
@@ -48,7 +48,9 @@
               {{/if}}
 
               {{#if this.isDisabledOrDisabledAndNotInAGroup}}
-                <this.LockIcon class="text-disabled -ml-1 -mt-1 inline-block" />
+                <this.LockIcon
+                  class="text-disabled -ml-0.5 -mt-1 inline-block"
+                />
               {{/if}}
             </span>
           {{/if}}

--- a/packages/ember-toucan-core/src/components/form/fields/checkbox.hbs
+++ b/packages/ember-toucan-core/src/components/form/fields/checkbox.hbs
@@ -47,8 +47,8 @@
                 {{@label}}
               {{/if}}
 
-              {{#if this.isDisabledAndNotInAGroup}}
-                <this.LockIcon class="-ml-1 -mt-1 inline-block" />
+              {{#if this.isDisabledOrDisabledAndNotInAGroup}}
+                <this.LockIcon class="text-disabled -ml-1 -mt-1 inline-block" />
               {{/if}}
             </span>
           {{/if}}

--- a/packages/ember-toucan-core/src/components/form/fields/checkbox.hbs
+++ b/packages/ember-toucan-core/src/components/form/fields/checkbox.hbs
@@ -37,7 +37,7 @@
             )
           }}
             <span
-              class="type-md-tight block leading-4
+              class="type-md-tight flex items-center gap-1.5 leading-4
                 {{if @isDisabled 'text-disabled' 'text-titles-and-attributes'}}"
               data-label
             >
@@ -48,9 +48,7 @@
               {{/if}}
 
               {{#if this.isDisabledOrDisabledAndNotInAGroup}}
-                <this.LockIcon
-                  class="text-disabled -ml-0.5 -mt-1 inline-block"
-                />
+                <this.LockIcon />
               {{/if}}
             </span>
           {{/if}}

--- a/packages/ember-toucan-core/src/components/form/fields/checkbox.hbs
+++ b/packages/ember-toucan-core/src/components/form/fields/checkbox.hbs
@@ -46,6 +46,10 @@
               {{else}}
                 {{@label}}
               {{/if}}
+
+              {{#if this.isDisabledAndNotInAGroup}}
+                <this.LockIcon class="-ml-1 -mt-1 inline-block" />
+              {{/if}}
             </span>
           {{/if}}
 

--- a/packages/ember-toucan-core/src/components/form/fields/checkbox.ts
+++ b/packages/ember-toucan-core/src/components/form/fields/checkbox.ts
@@ -49,7 +49,7 @@ export interface ToucanFormCheckboxFieldComponentSignature {
      *
      * @internal
      */
-    isInAGroup?: boolean;
+    isGrouped?: boolean;
 
     /**
      * Provide a string to this argument to render inside of the label tag.
@@ -137,9 +137,9 @@ export default class ToucanFormCheckboxFieldComponent extends Component<ToucanFo
    * checkbox group.
    */
   get isDisabledOrDisabledAndNotInAGroup() {
-    let { isDisabled, isInAGroup, isReadOnly } = this.args;
+    let { isDisabled, isGrouped, isReadOnly } = this.args;
 
-    if (isInAGroup) {
+    if (isGrouped) {
       return false;
     }
 

--- a/packages/ember-toucan-core/src/components/form/fields/checkbox.ts
+++ b/packages/ember-toucan-core/src/components/form/fields/checkbox.ts
@@ -2,6 +2,7 @@ import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
 
 import assertBlockOrArgumentExists from '../../../-private/assert-block-or-argument-exists';
+import LockIcon from '../../../-private/components/lock-icon';
 
 import type { AssertBlockOrArg } from '../../../-private/assert-block-or-argument-exists';
 import type { ErrorMessage } from '../../../-private/types';
@@ -41,6 +42,14 @@ export interface ToucanFormCheckboxFieldComponentSignature {
      * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox#indeterminate_state_checkboxes
      */
     isIndeterminate?: ToucanFormCheckboxControlComponentSignature['Args']['isIndeterminate'];
+
+    /**
+     * Helps us determine if we are in a checkbox-group or not. This should only be applied internally
+     * when using CheckboxGroup.
+     *
+     * @internal
+     */
+    isInAGroup?: boolean;
 
     /**
      * Provide a string to this argument to render inside of the label tag.
@@ -88,6 +97,8 @@ export interface ToucanFormCheckboxFieldComponentSignature {
 }
 
 export default class ToucanFormCheckboxFieldComponent extends Component<ToucanFormCheckboxFieldComponentSignature> {
+  LockIcon = LockIcon;
+
   assertBlockOrArgumentExists = ({
     blockExists,
     argName,
@@ -118,5 +129,13 @@ export default class ToucanFormCheckboxFieldComponent extends Component<ToucanFo
     }
 
     return this.args.selectedValues?.includes(this.args.value);
+  }
+
+  /**
+   * We want to add a lock icon when a checkbox-field is used by itself and is disabled,
+   * but we do *not* want that icon rendered when we are inside of a group and disabled.
+   */
+  get isDisabledAndNotInAGroup() {
+    return !this.args?.isInAGroup && this.args?.isDisabled;
   }
 }

--- a/packages/ember-toucan-core/src/components/form/fields/checkbox.ts
+++ b/packages/ember-toucan-core/src/components/form/fields/checkbox.ts
@@ -132,10 +132,17 @@ export default class ToucanFormCheckboxFieldComponent extends Component<ToucanFo
   }
 
   /**
-   * We want to add a lock icon when a checkbox-field is used by itself and is disabled,
-   * but we do *not* want that icon rendered when we are inside of a group and disabled.
+   * We want to add a lock icon when a checkbox-field is used by itself and is disabled
+   * or readonly, but we do *not* want that icon rendered when we are inside of a
+   * checkbox group.
    */
-  get isDisabledAndNotInAGroup() {
-    return !this.args?.isInAGroup && this.args?.isDisabled;
+  get isDisabledOrDisabledAndNotInAGroup() {
+    let { isDisabled, isInAGroup, isReadOnly } = this.args;
+
+    if (isInAGroup) {
+      return false;
+    }
+
+    return isDisabled || isReadOnly;
   }
 }

--- a/packages/ember-toucan-core/src/components/form/fields/file-input.hbs
+++ b/packages/ember-toucan-core/src/components/form/fields/file-input.hbs
@@ -20,6 +20,10 @@
           {{else}}
             {{@label}}
           {{/if}}
+
+          {{#if @isDisabled}}
+            <this.LockIcon class="-ml-1 -mt-1 inline-block" />
+          {{/if}}
         </span>
       {{/if}}
 

--- a/packages/ember-toucan-core/src/components/form/fields/file-input.hbs
+++ b/packages/ember-toucan-core/src/components/form/fields/file-input.hbs
@@ -22,7 +22,7 @@
           {{/if}}
 
           {{#if this.isReadOnlyOrDisabled}}
-            <this.LockIcon class="text-disabled -ml-1 -mt-1 inline-block" />
+            <this.LockIcon class="text-disabled -ml-1 -mt-0.5 inline-block" />
           {{/if}}
         </span>
       {{/if}}

--- a/packages/ember-toucan-core/src/components/form/fields/file-input.hbs
+++ b/packages/ember-toucan-core/src/components/form/fields/file-input.hbs
@@ -21,8 +21,8 @@
             {{@label}}
           {{/if}}
 
-          {{#if @isDisabled}}
-            <this.LockIcon class="-ml-1 -mt-1 inline-block" />
+          {{#if this.isReadOnlyOrDisabled}}
+            <this.LockIcon class="text-disabled -ml-1 -mt-1 inline-block" />
           {{/if}}
         </span>
       {{/if}}

--- a/packages/ember-toucan-core/src/components/form/fields/file-input.hbs
+++ b/packages/ember-toucan-core/src/components/form/fields/file-input.hbs
@@ -14,7 +14,7 @@
           )
         )
       }}
-        <span data-label>
+        <span class="flex items-center gap-1.5" data-label>
           {{#if (has-block "label")}}
             {{yield to="label"}}
           {{else}}
@@ -22,7 +22,7 @@
           {{/if}}
 
           {{#if this.isReadOnlyOrDisabled}}
-            <this.LockIcon class="text-disabled -ml-1 -mt-0.5 inline-block" />
+            <this.LockIcon />
           {{/if}}
         </span>
       {{/if}}

--- a/packages/ember-toucan-core/src/components/form/fields/file-input.ts
+++ b/packages/ember-toucan-core/src/components/form/fields/file-input.ts
@@ -113,6 +113,10 @@ export default class ToucanFormFileInputFieldComponent extends Component<ToucanF
     return Boolean(this.args?.error);
   }
 
+  get isReadOnlyOrDisabled() {
+    return this.args?.isDisabled || this.args?.isReadOnly;
+  }
+
   @action
   handleChange(field: { id: string }) {
     if (this.args.isReadOnly) {

--- a/packages/ember-toucan-core/src/components/form/fields/file-input.ts
+++ b/packages/ember-toucan-core/src/components/form/fields/file-input.ts
@@ -3,6 +3,7 @@ import { assert } from '@ember/debug';
 import { action } from '@ember/object';
 
 import assertBlockOrArgumentExists from '../../../-private/assert-block-or-argument-exists';
+import LockIcon from '../../../-private/components/lock-icon';
 
 import type { AssertBlockOrArg } from '../../../-private/assert-block-or-argument-exists';
 import type { ErrorMessage } from '../../../-private/types';
@@ -81,6 +82,8 @@ export interface ToucanFormFileInputFieldComponentSignature {
 }
 
 export default class ToucanFormFileInputFieldComponent extends Component<ToucanFormFileInputFieldComponentSignature> {
+  LockIcon = LockIcon;
+
   assertBlockOrArgumentExists = ({
     blockExists,
     argName,

--- a/packages/ember-toucan-core/src/components/form/fields/input.hbs
+++ b/packages/ember-toucan-core/src/components/form/fields/input.hbs
@@ -13,7 +13,11 @@
         )
       )
     }}
-      <field.Label for={{field.id}} data-label>
+      <field.Label
+        class="flex items-center gap-1.5"
+        for={{field.id}}
+        data-label
+      >
         {{#if (has-block "label")}}
           {{yield to="label"}}
         {{else}}
@@ -21,7 +25,7 @@
         {{/if}}
 
         {{#if this.isReadOnlyOrDisabled}}
-          <this.LockIcon class="text-disabled -ml-1 -mt-0.5 inline-block" />
+          <this.LockIcon />
         {{/if}}
       </field.Label>
     {{/if}}

--- a/packages/ember-toucan-core/src/components/form/fields/input.hbs
+++ b/packages/ember-toucan-core/src/components/form/fields/input.hbs
@@ -21,7 +21,7 @@
         {{/if}}
 
         {{#if this.isReadOnlyOrDisabled}}
-          <this.LockIcon class="text-disabled -ml-1 -mt-1 inline-block" />
+          <this.LockIcon class="text-disabled -ml-1 -mt-0.5 inline-block" />
         {{/if}}
       </field.Label>
     {{/if}}

--- a/packages/ember-toucan-core/src/components/form/fields/input.hbs
+++ b/packages/ember-toucan-core/src/components/form/fields/input.hbs
@@ -19,6 +19,10 @@
         {{else}}
           {{@label}}
         {{/if}}
+
+        {{#if @isDisabled}}
+          <this.LockIcon class="-ml-1 -mt-1 inline-block" />
+        {{/if}}
       </field.Label>
     {{/if}}
 

--- a/packages/ember-toucan-core/src/components/form/fields/input.hbs
+++ b/packages/ember-toucan-core/src/components/form/fields/input.hbs
@@ -20,8 +20,8 @@
           {{@label}}
         {{/if}}
 
-        {{#if @isDisabled}}
-          <this.LockIcon class="-ml-1 -mt-1 inline-block" />
+        {{#if this.isReadOnlyOrDisabled}}
+          <this.LockIcon class="text-disabled -ml-1 -mt-1 inline-block" />
         {{/if}}
       </field.Label>
     {{/if}}

--- a/packages/ember-toucan-core/src/components/form/fields/input.ts
+++ b/packages/ember-toucan-core/src/components/form/fields/input.ts
@@ -4,6 +4,7 @@ import { assert } from '@ember/debug';
 import { action } from '@ember/object';
 
 import assertBlockOrArgumentExists from '../../../-private/assert-block-or-argument-exists';
+import LockIcon from '../../../-private/components/lock-icon';
 import CharacterCount from '../../../components/form/controls/character-count';
 
 import type { AssertBlockOrArg } from '../../../-private/assert-block-or-argument-exists';
@@ -69,6 +70,7 @@ export default class ToucanFormInputFieldComponent extends Component<ToucanFormI
   @tracked count = this.args.value?.length ?? 0;
 
   CharacterCount = CharacterCount;
+  LockIcon = LockIcon;
 
   assertBlockOrArgumentExists = ({
     blockExists,

--- a/packages/ember-toucan-core/src/components/form/fields/input.ts
+++ b/packages/ember-toucan-core/src/components/form/fields/input.ts
@@ -80,6 +80,14 @@ export default class ToucanFormInputFieldComponent extends Component<ToucanFormI
   }: AssertBlockOrArg) =>
     assertBlockOrArgumentExists({ blockExists, argName, arg, isRequired });
 
+  get hasError() {
+    return Boolean(this.args?.error);
+  }
+
+  get isReadOnlyOrDisabled() {
+    return this.args?.isDisabled || this.args?.isReadOnly;
+  }
+
   @action
   handleCount(event: Event | InputEvent): void {
     assert(
@@ -88,9 +96,5 @@ export default class ToucanFormInputFieldComponent extends Component<ToucanFormI
     );
 
     this.count = event.target?.value.length ?? 0;
-  }
-
-  get hasError() {
-    return Boolean(this.args?.error);
   }
 }

--- a/packages/ember-toucan-core/src/components/form/fields/radio-group.hbs
+++ b/packages/ember-toucan-core/src/components/form/fields/radio-group.hbs
@@ -26,7 +26,7 @@
         {{/if}}
 
         {{#if this.isReadOnlyOrDisabled}}
-          <this.LockIcon class="text-disabled -ml-1 -mt-1 inline-block" />
+          <this.LockIcon class="text-disabled -ml-1 -mt-0.5 inline-block" />
         {{/if}}
       </legend>
     {{/if}}

--- a/packages/ember-toucan-core/src/components/form/fields/radio-group.hbs
+++ b/packages/ember-toucan-core/src/components/form/fields/radio-group.hbs
@@ -18,7 +18,10 @@
         )
       )
     }}
-      <legend class="type-md-tight text-body-and-labels block" data-label>
+      <legend
+        class="type-md-tight text-body-and-labels flex items-center gap-1.5"
+        data-label
+      >
         {{#if (has-block "label")}}
           {{yield to="label"}}
         {{else}}
@@ -26,7 +29,7 @@
         {{/if}}
 
         {{#if this.isReadOnlyOrDisabled}}
-          <this.LockIcon class="text-disabled -ml-1 -mt-0.5 inline-block" />
+          <this.LockIcon />
         {{/if}}
       </legend>
     {{/if}}

--- a/packages/ember-toucan-core/src/components/form/fields/radio-group.hbs
+++ b/packages/ember-toucan-core/src/components/form/fields/radio-group.hbs
@@ -24,6 +24,10 @@
         {{else}}
           {{@label}}
         {{/if}}
+
+        {{#if @isDisabled}}
+          <this.LockIcon class="-ml-1 -mt-1 inline-block" />
+        {{/if}}
       </legend>
     {{/if}}
 

--- a/packages/ember-toucan-core/src/components/form/fields/radio-group.hbs
+++ b/packages/ember-toucan-core/src/components/form/fields/radio-group.hbs
@@ -25,8 +25,8 @@
           {{@label}}
         {{/if}}
 
-        {{#if @isDisabled}}
-          <this.LockIcon class="-ml-1 -mt-1 inline-block" />
+        {{#if this.isReadOnlyOrDisabled}}
+          <this.LockIcon class="text-disabled -ml-1 -mt-1 inline-block" />
         {{/if}}
       </legend>
     {{/if}}

--- a/packages/ember-toucan-core/src/components/form/fields/radio-group.ts
+++ b/packages/ember-toucan-core/src/components/form/fields/radio-group.ts
@@ -2,6 +2,7 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 
 import assertBlockOrArgumentExists from '../../../-private/assert-block-or-argument-exists';
+import LockIcon from '../../../-private/components/lock-icon';
 import RadioFieldComponent from './radio';
 
 import type { AssertBlockOrArg } from '../../../-private/assert-block-or-argument-exists';
@@ -75,6 +76,7 @@ export interface ToucanFormRadioGroupFieldComponentSignature {
 
 export default class ToucanFormRadioGroupFieldComponent extends Component<ToucanFormRadioGroupFieldComponentSignature> {
   RadioFieldComponent = RadioFieldComponent;
+  LockIcon = LockIcon;
 
   assertBlockOrArgumentExists = ({
     blockExists,

--- a/packages/ember-toucan-core/src/components/form/fields/radio-group.ts
+++ b/packages/ember-toucan-core/src/components/form/fields/radio-group.ts
@@ -86,6 +86,10 @@ export default class ToucanFormRadioGroupFieldComponent extends Component<Toucan
   }: AssertBlockOrArg) =>
     assertBlockOrArgumentExists({ blockExists, argName, arg, isRequired });
 
+  get isReadOnlyOrDisabled() {
+    return this.args?.isDisabled || this.args?.isReadOnly;
+  }
+
   @action
   handleInput(value: string, e: Event | InputEvent): void {
     this.args.onChange?.(value, e);

--- a/packages/ember-toucan-core/src/components/form/fields/textarea.hbs
+++ b/packages/ember-toucan-core/src/components/form/fields/textarea.hbs
@@ -13,7 +13,11 @@
         )
       )
     }}
-      <field.Label for={{field.id}} data-label>
+      <field.Label
+        class="flex items-center gap-1.5"
+        for={{field.id}}
+        data-label
+      >
         {{#if (has-block "label")}}
           {{yield to="label"}}
         {{else}}
@@ -21,7 +25,7 @@
         {{/if}}
 
         {{#if this.isReadOnlyOrDisabled}}
-          <this.LockIcon class="text-disabled -ml-1 -mt-0.5 inline-block" />
+          <this.LockIcon />
         {{/if}}
       </field.Label>
     {{/if}}

--- a/packages/ember-toucan-core/src/components/form/fields/textarea.hbs
+++ b/packages/ember-toucan-core/src/components/form/fields/textarea.hbs
@@ -21,7 +21,7 @@
         {{/if}}
 
         {{#if this.isReadOnlyOrDisabled}}
-          <this.LockIcon class="text-disabled -ml-1 -mt-1 inline-block" />
+          <this.LockIcon class="text-disabled -ml-1 -mt-0.5 inline-block" />
         {{/if}}
       </field.Label>
     {{/if}}

--- a/packages/ember-toucan-core/src/components/form/fields/textarea.hbs
+++ b/packages/ember-toucan-core/src/components/form/fields/textarea.hbs
@@ -19,6 +19,10 @@
         {{else}}
           {{@label}}
         {{/if}}
+
+        {{#if @isDisabled}}
+          <this.LockIcon class="-ml-1 -mt-1 inline-block" />
+        {{/if}}
       </field.Label>
     {{/if}}
 

--- a/packages/ember-toucan-core/src/components/form/fields/textarea.hbs
+++ b/packages/ember-toucan-core/src/components/form/fields/textarea.hbs
@@ -20,8 +20,8 @@
           {{@label}}
         {{/if}}
 
-        {{#if @isDisabled}}
-          <this.LockIcon class="-ml-1 -mt-1 inline-block" />
+        {{#if this.isReadOnlyOrDisabled}}
+          <this.LockIcon class="text-disabled -ml-1 -mt-1 inline-block" />
         {{/if}}
       </field.Label>
     {{/if}}

--- a/packages/ember-toucan-core/src/components/form/fields/textarea.ts
+++ b/packages/ember-toucan-core/src/components/form/fields/textarea.ts
@@ -87,6 +87,14 @@ export default class ToucanFormTextareaFieldComponent extends Component<ToucanFo
     super(owner, args);
   }
 
+  get hasError() {
+    return Boolean(this.args?.error);
+  }
+
+  get isReadOnlyOrDisabled() {
+    return this.args?.isDisabled || this.args?.isReadOnly;
+  }
+
   @action
   handleCount(event: Event | InputEvent): void {
     assert(
@@ -94,9 +102,5 @@ export default class ToucanFormTextareaFieldComponent extends Component<ToucanFo
       event.target instanceof HTMLTextAreaElement
     );
     this.count = event.target?.value.length ?? 0;
-  }
-
-  get hasError() {
-    return Boolean(this.args?.error);
   }
 }

--- a/packages/ember-toucan-core/src/components/form/fields/textarea.ts
+++ b/packages/ember-toucan-core/src/components/form/fields/textarea.ts
@@ -4,6 +4,7 @@ import { assert } from '@ember/debug';
 import { action } from '@ember/object';
 
 import assertBlockOrArgumentExists from '../../../-private/assert-block-or-argument-exists';
+import LockIcon from '../../../-private/components/lock-icon';
 import CharacterCount from '../../../components/form/controls/character-count';
 
 import type { AssertBlockOrArg } from '../../../-private/assert-block-or-argument-exists';
@@ -69,6 +70,8 @@ export default class ToucanFormTextareaFieldComponent extends Component<ToucanFo
   @tracked count = this.args.value?.length ?? 0;
 
   CharacterCount = CharacterCount;
+  LockIcon = LockIcon;
+
   assertBlockOrArgumentExists = ({
     blockExists,
     argName,

--- a/test-app/tests/integration/components/checkbox-field-test.gts
+++ b/test-app/tests/integration/components/checkbox-field-test.gts
@@ -34,6 +34,8 @@ module('Integration | Component | Fields | CheckboxField', function (hooks) {
     assert
       .dom('[data-root-field="test"] > [data-control]')
       .hasNoClass('shadow-error-outline');
+
+    assert.dom('[data-lock-icon]').doesNotExist();
   });
 
   test('it renders with a hint', async function (assert) {
@@ -112,12 +114,14 @@ module('Integration | Component | Fields | CheckboxField', function (hooks) {
       );
   });
 
-  test('it disables the checkbox using `@isDisabled`', async function (assert) {
+  test('it disables the checkbox using `@isDisabled` and renders a lock icon', async function (assert) {
     await render(<template>
       <CheckboxField @label="Label" @isDisabled={{true}} data-checkbox />
     </template>);
 
     assert.dom('[data-checkbox]').isDisabled();
+
+    assert.dom('[data-lock-icon]').exists();
   });
 
   test('it sets readonly on the checkbox using `@isReadOnly`', async function (assert) {

--- a/test-app/tests/integration/components/checkbox-field-test.gts
+++ b/test-app/tests/integration/components/checkbox-field-test.gts
@@ -124,12 +124,14 @@ module('Integration | Component | Fields | CheckboxField', function (hooks) {
     assert.dom('[data-lock-icon]').exists();
   });
 
-  test('it sets readonly on the checkbox using `@isReadOnly`', async function (assert) {
+  test('it sets readonly on the checkbox using `@isReadOnly` and renders a lock icon', async function (assert) {
     await render(<template>
       <CheckboxField @label="Label" @isReadOnly={{true}} data-checkbox />
     </template>);
 
     assert.dom('[data-checkbox]').hasAttribute('readonly');
+
+    assert.dom('[data-lock-icon]').exists();
   });
 
   test('it spreads attributes to the underlying checkbox', async function (assert) {

--- a/test-app/tests/integration/components/checkbox-group-field-test.gts
+++ b/test-app/tests/integration/components/checkbox-group-field-test.gts
@@ -18,6 +18,8 @@ module('Integration | Component | Fields | CheckboxGroup', function (hooks) {
     assert.dom('[data-group-field]').hasNoAttribute('aria-invalid');
 
     assert.dom('[data-label]').hasText('Label');
+
+    assert.dom('[data-lock-icon]').doesNotExist();
   });
 
   test('it renders yielded CheckboxFields', async function (assert) {
@@ -151,7 +153,7 @@ module('Integration | Component | Fields | CheckboxGroup', function (hooks) {
     assert.dom('[data-checkbox-2]').isChecked();
   });
 
-  test('it disables the fieldset and all child checkboxes using `@isDisabled` at the root', async function (assert) {
+  test('it disables the fieldset and all child checkboxes using `@isDisabled` at the root and renders a lock icon', async function (assert) {
     await render(<template>
       <CheckboxGroupField
         @label="Label"
@@ -176,6 +178,8 @@ module('Integration | Component | Fields | CheckboxGroup', function (hooks) {
     assert.dom('[data-group-field]').isDisabled();
     assert.dom('[data-checkbox-1]').isDisabled();
     assert.dom('[data-checkbox-2]').isDisabled();
+
+    assert.dom('[data-lock-icon]').exists();
   });
 
   test('it sets an individual checkbox to disabled with `@isDisabled`', async function (assert) {

--- a/test-app/tests/integration/components/checkbox-group-field-test.gts
+++ b/test-app/tests/integration/components/checkbox-group-field-test.gts
@@ -222,7 +222,7 @@ module('Integration | Component | Fields | CheckboxGroup', function (hooks) {
     assert.dom('[data-checkbox-1]').hasAttribute('readonly');
   });
 
-  test('it sets readonly on all child checkboxes using `@isReadOnly` at the root', async function (assert) {
+  test('it sets readonly on all child checkboxes using `@isReadOnly` at the root and renders a lock icon', async function (assert) {
     await render(<template>
       <CheckboxGroupField
         @label="Label"
@@ -246,6 +246,8 @@ module('Integration | Component | Fields | CheckboxGroup', function (hooks) {
 
     assert.dom('[data-checkbox-1]').hasAttribute('readonly');
     assert.dom('[data-checkbox-2]').hasAttribute('readonly');
+
+    assert.dom('[data-lock-icon]').exists();
   });
 
   test('it calls `@onChange` when a checkbox is clicked and can update `@value`', async function (assert) {

--- a/test-app/tests/integration/components/file-input-field-test.gts
+++ b/test-app/tests/integration/components/file-input-field-test.gts
@@ -194,7 +194,7 @@ module('Integration | Component | Fields | FileInput', function (hooks) {
     assert.dom('[data-lock-icon]').exists();
   });
 
-  test('it sets readonly on the input using `@isReadOnly`', async function (assert) {
+  test('it sets readonly on the input using `@isReadOnly` and renders a lock icon', async function (assert) {
     await render(<template>
       <FileInputField
         @deleteLabel="Delete File"
@@ -207,6 +207,8 @@ module('Integration | Component | Fields | FileInput', function (hooks) {
     </template>);
 
     assert.dom('[data-file-input-field]').hasAttribute('readonly');
+
+    assert.dom('[data-lock-icon]').exists();
   });
 
   test('it spreads attributes to the underlying file-input-field', async function (assert) {

--- a/test-app/tests/integration/components/file-input-field-test.gts
+++ b/test-app/tests/integration/components/file-input-field-test.gts
@@ -76,6 +76,8 @@ module('Integration | Component | Fields | FileInput', function (hooks) {
       .doesNotExist(
         'Expected hint block not to be displayed as an error was not provided'
       );
+
+    assert.dom('[data-lock-icon]').doesNotExist();
   });
 
   test('it renders with a hint', async function (assert) {
@@ -174,7 +176,7 @@ module('Integration | Component | Fields | FileInput', function (hooks) {
       );
   });
 
-  test('it disables the file input using @isDisabled', async function (assert) {
+  test('it disables the file input using `@isDisabled` and renders a lock icon', async function (assert) {
     await render(<template>
       <FileInputField
         @deleteLabel="Delete File"
@@ -188,6 +190,8 @@ module('Integration | Component | Fields | FileInput', function (hooks) {
 
     assert.dom('[data-file-input-field]').isDisabled();
     assert.dom('[data-file-input-field]').hasClass('text-disabled');
+
+    assert.dom('[data-lock-icon]').exists();
   });
 
   test('it sets readonly on the input using `@isReadOnly`', async function (assert) {

--- a/test-app/tests/integration/components/input-field-test.gts
+++ b/test-app/tests/integration/components/input-field-test.gts
@@ -25,6 +25,8 @@ module('Integration | Component | Fields | Input', function (hooks) {
     assert.dom(input).hasAttribute('type', 'text');
     assert.dom(input).hasAttribute('id');
     assert.dom(input).hasNoClass('shadow-error-outline');
+
+    assert.dom('[data-lock-icon]').doesNotExist();
   });
 
   test('it throws an assertion error if no `@label` or `:label` is provided', async function (assert) {
@@ -216,12 +218,14 @@ module('Integration | Component | Fields | Input', function (hooks) {
     assert.dom('[data-character]').hasText('11 / 255');
   });
 
-  test('it disables the input using `@isDisabled`', async function (assert) {
+  test('it disables the input using `@isDisabled` and renders a lock icon', async function (assert) {
     await render(<template>
       <InputField @label="Label" @isDisabled={{true}} data-input />
     </template>);
 
     assert.dom('[data-input]').isDisabled();
+
+    assert.dom('[data-lock-icon]').exists();
   });
 
   test('it sets readonly on the input using `@isReadOnly`', async function (assert) {

--- a/test-app/tests/integration/components/input-field-test.gts
+++ b/test-app/tests/integration/components/input-field-test.gts
@@ -228,11 +228,13 @@ module('Integration | Component | Fields | Input', function (hooks) {
     assert.dom('[data-lock-icon]').exists();
   });
 
-  test('it sets readonly on the input using `@isReadOnly`', async function (assert) {
+  test('it sets readonly on the input using `@isReadOnly` and renders a lock icon', async function (assert) {
     await render(<template>
       <InputField @label="Label" @isReadOnly={{true}} data-input />
     </template>);
 
     assert.dom('[data-input]').hasAttribute('readonly');
+
+    assert.dom('[data-lock-icon]').exists();
   });
 });

--- a/test-app/tests/integration/components/radio-group-field-test.gts
+++ b/test-app/tests/integration/components/radio-group-field-test.gts
@@ -151,7 +151,7 @@ module('Integration | Component | Fields | RadioGroup', function (hooks) {
     assert.dom('[data-radio-1]').hasAttribute('readonly');
   });
 
-  test('it sets readonly on all child radios using `@isReadOnly` at the root', async function (assert) {
+  test('it sets readonly on all child radios using `@isReadOnly` at the root and renders a lock icon', async function (assert) {
     await render(<template>
       <RadioGroupField
         @label="Label"
@@ -167,6 +167,8 @@ module('Integration | Component | Fields | RadioGroup', function (hooks) {
 
     assert.dom('[data-radio-1]').hasAttribute('readonly');
     assert.dom('[data-radio-2]').hasAttribute('readonly');
+
+    assert.dom('[data-lock-icon]').exists();
   });
 
   test('it calls `@onChange` when a radio is clicked and can update `@value`', async function (assert) {

--- a/test-app/tests/integration/components/radio-group-field-test.gts
+++ b/test-app/tests/integration/components/radio-group-field-test.gts
@@ -18,6 +18,8 @@ module('Integration | Component | Fields | RadioGroup', function (hooks) {
     assert.dom('[data-group-field]').hasAttribute('aria-required');
 
     assert.dom('[data-label]').hasText('Label');
+
+    assert.dom('[data-lock-icon]').doesNotExist();
   });
 
   test('it sets "role" by default', async function (assert) {
@@ -98,7 +100,7 @@ module('Integration | Component | Fields | RadioGroup', function (hooks) {
     assert.dom('[data-radio-2]').isChecked();
   });
 
-  test('it disables the fieldset and all child radios using `@isDisabled` at the root', async function (assert) {
+  test('it disables the fieldset and all child radios using `@isDisabled` at the root and renders a lock icon', async function (assert) {
     await render(<template>
       <RadioGroupField
         @label="Label"
@@ -115,6 +117,8 @@ module('Integration | Component | Fields | RadioGroup', function (hooks) {
     assert.dom('[data-group-field]').isDisabled();
     assert.dom('[data-radio-1]').isDisabled();
     assert.dom('[data-radio-2]').isDisabled();
+
+    assert.dom('[data-lock-icon]').exists();
   });
 
   test('it sets an individual radio to disabled with `@isDisabled`', async function (assert) {

--- a/test-app/tests/integration/components/textarea-field-test.gts
+++ b/test-app/tests/integration/components/textarea-field-test.gts
@@ -132,12 +132,14 @@ module('Integration | Component | Fields | Textarea', function (hooks) {
     assert.dom('[data-lock-icon]').exists();
   });
 
-  test('it sets readonly on the textarea using `@isReadOnly`', async function (assert) {
+  test('it sets readonly on the textarea using `@isReadOnly` and renders a lock icon', async function (assert) {
     await render(<template>
       <TextareaField @label="Label" @isReadOnly={{true}} data-textarea />
     </template>);
 
     assert.dom('[data-textarea]').hasAttribute('readonly');
+
+    assert.dom('[data-lock-icon]').exists();
   });
 
   test('it spreads attributes to the underlying textarea', async function (assert) {

--- a/test-app/tests/integration/components/textarea-field-test.gts
+++ b/test-app/tests/integration/components/textarea-field-test.gts
@@ -30,6 +30,8 @@ module('Integration | Component | Fields | Textarea', function (hooks) {
       .doesNotExist(
         'Expected hint block not to be displayed as an error was not provided'
       );
+
+    assert.dom('[data-lock-icon]').doesNotExist();
   });
 
   test('it renders with a hint', async function (assert) {
@@ -119,13 +121,15 @@ module('Integration | Component | Fields | Textarea', function (hooks) {
       .hasAttribute('aria-describedby', `${errorId} ${hintId}`);
   });
 
-  test('it disables the textarea using `@isDisabled`', async function (assert) {
+  test('it disables the textarea using `@isDisabled` and renders a lock icon', async function (assert) {
     await render(<template>
       <TextareaField @label="Label" @isDisabled={{true}} data-textarea />
     </template>);
 
     assert.dom('[data-textarea]').isDisabled();
     assert.dom('[data-textarea]').hasClass('text-disabled');
+
+    assert.dom('[data-lock-icon]').exists();
   });
 
   test('it sets readonly on the textarea using `@isReadOnly`', async function (assert) {


### PR DESCRIPTION
## 🚀 Description

This PR adds the lock icon for disabled and readonly states according to our designs.

---

## 🔬 How to Test

- Visit https://844e929c.ember-toucan-core.pages.dev/docs/components/checkbox-group-field and the following components
  - checkbox-field
  - checkbox-group-field
  - file-input-field
  - input-field
  - radio-group-field
  - textarea-field
- Scroll down to the "All UI States" section(s)
- Verify the lock icon appears for both disabled and readonly states

---

## 📸 Images/Videos of Functionality

### Iconography

While I was in here, I adjusted some of the iconography in our demos to be a bit closer to what we'd prefer.

| BEFORE  | AFTER |
| ------------- | ------------- |
| <img width="416" alt="Screenshot 2023-06-20 at 7 56 19 PM" src="https://github.com/CrowdStrike/ember-toucan-core/assets/8069555/269b0285-450d-4486-89f1-48192992a23f">  | <img width="400" alt="Screenshot 2023-06-20 at 7 56 39 PM" src="https://github.com/CrowdStrike/ember-toucan-core/assets/8069555/7024f6a9-4a53-4ccd-a539-d56607478fdd">  |





### Readonly + Disabled Locks

A few before and after pictures of the readonly and disabled states.

| BEFORE  | AFTER |
| ------------- | ------------- |
| <img width="370" alt="Screenshot 2023-06-20 at 7 52 01 PM" src="https://github.com/CrowdStrike/ember-toucan-core/assets/8069555/6cb14c3c-1855-4e9c-9bf9-ca248d68343c">  | <img width="376" alt="Screenshot 2023-06-20 at 7 51 30 PM" src="https://github.com/CrowdStrike/ember-toucan-core/assets/8069555/003c15b3-a63c-4f03-aa6c-725773f9a3bc">  |
| <img width="408" alt="Screenshot 2023-06-20 at 7 52 45 PM" src="https://github.com/CrowdStrike/ember-toucan-core/assets/8069555/1599c92e-3f95-40ff-a54e-b76e68ccb3d7">  | <img width="410" alt="Screenshot 2023-06-20 at 7 53 03 PM" src="https://github.com/CrowdStrike/ember-toucan-core/assets/8069555/d5b6b318-1e1a-4265-b3c6-1e027234ec7c">  |
| <img width="543" alt="Screenshot 2023-06-20 at 7 55 04 PM" src="https://github.com/CrowdStrike/ember-toucan-core/assets/8069555/ed40fde1-bdc9-4551-97ed-509228800c54">  | <img width="537" alt="Screenshot 2023-06-20 at 7 54 54 PM" src="https://github.com/CrowdStrike/ember-toucan-core/assets/8069555/acb62271-4931-4b27-8e13-ba80f9ac10df"> |





