### PR TITLE
Style character counter when current is greater than max

### DIFF
--- a/.changeset/cyan-dots-speak.md
+++ b/.changeset/cyan-dots-speak.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/ember-toucan-core': patch
+---
+
+Adds error styling when the current character length is greater than maximum character length for the input and textarea components using the character counter.

--- a/packages/ember-toucan-core/src/components/form/controls/character-count.hbs
+++ b/packages/ember-toucan-core/src/components/form/controls/character-count.hbs
@@ -1,3 +1,6 @@
-<span ...attributes>{{@current}}
+<span
+  class="{{if this.isCurrentGreaterThanMax 'text-critical'}}"
+  ...attributes
+>{{@current}}
   /
   {{@max}}</span>

--- a/packages/ember-toucan-core/src/components/form/controls/character-count.ts
+++ b/packages/ember-toucan-core/src/components/form/controls/character-count.ts
@@ -32,4 +32,12 @@ export default class ToucanFormControlCharacterCount extends Component<ToucanFor
     );
     super(owner, args);
   }
+
+  /**
+   * Determines if the current input length is greater than the provided
+   * maximum length.  If so, a CSS class is applied.
+   */
+  get isCurrentGreaterThanMax() {
+    return this.args.current > this.args.max;
+  }
 }

--- a/test-app/tests/integration/components/character-count-test.gts
+++ b/test-app/tests/integration/components/character-count-test.gts
@@ -8,14 +8,12 @@ module('Integration | Component | Controls | CharacterCount', function (hooks) {
   setupRenderingTest(hooks);
 
   test('it renders', async function (assert) {
-
     await render(<template>
       <CharacterCount @current={{5}} @max={{100}} data-character-count />
     </template>);
 
-    assert
-      .dom('[data-character-count]')
-      .hasText('5 / 100');
+    assert.dom('[data-character-count]').hasText('5 / 100');
+    assert.dom('[data-character-count]').doesNotHaveClass('text-critical');
   });
 
   test('it throws an error if no @current arg is provided', async function (assert) {
@@ -23,12 +21,9 @@ module('Integration | Component | Controls | CharacterCount', function (hooks) {
 
     setupOnerror((e: Error) => {
       assert.ok(
-        e.message.includes(
-          'An "@current" argument is required'
-        ),
+        e.message.includes('An "@current" argument is required'),
         'Expected assertion error message'
       );
-
     });
     await render(<template>
       {{! @glint-expect-error: we are missing the @current arg, so an error is expected }}
@@ -41,17 +36,21 @@ module('Integration | Component | Controls | CharacterCount', function (hooks) {
 
     setupOnerror((e: Error) => {
       assert.ok(
-        e.message.includes(
-          'An "@max" argument is required'
-        ),
+        e.message.includes('An "@max" argument is required'),
         'Expected assertion error message'
       );
-
     });
     await render(<template>
       {{! @glint-expect-error: we are missing the @max arg, so an error is expected }}
       <CharacterCount @current={{100}} data-character-count />
     </template>);
+  });
 
-  })
+  test('it sets `text-critical` when `@current` is greater than `@max`', async function (assert) {
+    await render(<template>
+      <CharacterCount @current={{101}} @max={{100}} data-character-count />
+    </template>);
+
+    assert.dom('[data-character-count]').hasClass('text-critical');
+  });
 });


### PR DESCRIPTION
## 🚀 Description

This adds styling as requested by design when the current character length is greater than the maximum.

---

## 🔬 How to Test

- Go to https://a9a80cf2.ember-toucan-core.pages.dev/docs/components/textarea-field#textareafield-with-character-count-with-a-single-error
- Type over the maximum characters
- Verify the character count text turns red
- Now do the same thing with https://a9a80cf2.ember-toucan-core.pages.dev/docs/components/input-field#inputfield-with-character-count-with-single-error

---

## 📸 Images/Videos of Functionality

https://github.com/CrowdStrike/ember-toucan-core/assets/8069555/628139b8-284c-4149-ac73-55dc6f8410ce


https://github.com/CrowdStrike/ember-toucan-core/assets/8069555/8769739f-bc31-4607-b0c6-0881be36e8ab



