### PR TITLE
fix: button flex grow

### DIFF
--- a/.changeset/curly-pants-yawn.md
+++ b/.changeset/curly-pants-yawn.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/ember-toucan-core': patch
+---
+
+fixes flex-grow for disabled button

--- a/packages/ember-toucan-core/src/components/button.hbs
+++ b/packages/ember-toucan-core/src/components/button.hbs
@@ -9,7 +9,7 @@
     {{yield to="loading"}}
     <span class="sr-only" data-loading>{{yield}}</span>
   {{else if @isDisabled}}
-    <span class="flex items-center gap-x-2">
+    <span class="flex flex-grow items-center gap-x-2">
       {{yield}}
       {{yield to="disabled"}}
     </span>


### PR DESCRIPTION
## 🚀 Description
If the button is the child of a flex parent then,
when disabled, the yielded content wrapping span
needs a flex-grow CSS property to ensure that the
label can expand, and push the button width out
to fill the full width of the parent

---

## 🔬 How to Test

<!-- Please provide steps to test the functionality added/removed. Preview URLs are generated with each build.  We normally use the preview URLs and ask folks to review specific functionality based on them (e.g., "go to this page, view the new CSS changes"). -->

---

## 📸 Images/Videos of Functionality

<!-- For visual changes, it's extremely helpful to include screenshots, gifs, or videos of what has changed.  Before and After images are also super helpful! -->
