### PR TITLE
docs: Link to fields from control docs

### DIFF
--- a/docs/components/autocomplete/index.md
+++ b/docs/components/autocomplete/index.md
@@ -1,7 +1,7 @@
 # Autocomplete
 
 Provides a Toucan-styled autocomplete with filtering.
-If you are building forms, you may be interested in the AutocompleteField component instead.
+If you are building forms, you may be interested in the [AutocompleteField](./autocomplete-field) component instead.
 
 ## Popover z-index
 

--- a/docs/components/checkbox/index.md
+++ b/docs/components/checkbox/index.md
@@ -1,6 +1,6 @@
 # Checkbox
 
-Provides a Toucan-styled [checkbox element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox). If you are building forms, you may be interested in the CheckboxField component instead.
+Provides a Toucan-styled [checkbox element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox). If you are building forms, you may be interested in the [CheckboxField](./checkbox-field) component instead.
 
 ## Checked State
 

--- a/docs/components/input/index.md
+++ b/docs/components/input/index.md
@@ -1,6 +1,6 @@
 # Input
 
-Provides a Toucan-styled [input element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input). If you are building forms, you may be interested in the InputField component instead.
+Provides a Toucan-styled [input element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input). If you are building forms, you may be interested in the [InputField](./input-field) component instead.
 
 ## Value
 

--- a/docs/components/radio/index.md
+++ b/docs/components/radio/index.md
@@ -1,6 +1,6 @@
 # Radio
 
-Provides a Toucan-styled [radio element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/radio). If you are building forms, you may be interested in the RadioField component instead.
+Provides a Toucan-styled [radio element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/radio). If you are building forms, you may be interested in the [RadioField](./radio-field) component instead.
 
 ## Value
 

--- a/docs/components/textarea/index.md
+++ b/docs/components/textarea/index.md
@@ -1,6 +1,6 @@
 # Textarea
 
-Provides a Toucan-styled [textarea element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea). If you are building forms, you may be interested in the TextareaField component instead.
+Provides a Toucan-styled [textarea element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea). If you are building forms, you may be interested in the [TextareaField](./textarea-field) component instead.
 
 ## Value
 


### PR DESCRIPTION
## 🚀 Description

This addresses some PR feedback from @nicolechung on a previous PR, where we link to the Field components from the Controls.

---

## 🔬 How to Test

- Green build

---

## 📸 Images/Videos of Functionality

N/A