### PR TITLE
chore: Autocomplete tweaks

### DIFF
--- a/.changeset/smart-mice-crash.md
+++ b/.changeset/smart-mice-crash.md
@@ -1,0 +1,6 @@
+---
+'@crowdstrike/ember-toucan-core': minor
+'@crowdstrike/ember-toucan-form': minor
+---
+
+Removed from Autocomplete support for `@options` as an array of objects.

--- a/.changeset/twelve-gifts-camp.md
+++ b/.changeset/twelve-gifts-camp.md
@@ -13,7 +13,6 @@ If you're using `toucan-core`, the control and field components are exposed:
   @options={{this.options}}
   @contentClass='z-10'
   @selected={{this.selected}}
-  @optionKey='label'
   @noResultsText='No results'
   placeholder='Colors'
   as |autocomplete|
@@ -30,7 +29,6 @@ If you're using `toucan-core`, the control and field components are exposed:
   @label='Label'
   @noResultsText='No results'
   @onChange={{this.onChange}}
-  @optionKey='label'
   @options={{this.options}}
   @selected={{this.selected}}
   placeholder='Colors'

--- a/docs/components/autocomplete-field/demo/base-demo.md
+++ b/docs/components/autocomplete-field/demo/base-demo.md
@@ -6,14 +6,13 @@
   @label='Label'
   @noResultsText='No results'
   @onChange={{this.onChange}}
-  @optionKey='label'
   @options={{this.options}}
   @selected={{this.selected}}
   placeholder='Colors'
   as |autocomplete|
 >
   <autocomplete.Option>
-    {{autocomplete.option.label}}
+    {{autocomplete.option}}
   </autocomplete.Option>
 </Form::Fields::Autocomplete>
 ```
@@ -56,14 +55,14 @@ export default class extends Component {
       label: 'Teal',
       name: 'teal',
     },
-  ];
+  ].map(({ label }) => label);
 
   @action
   onChange(option) {
     this.selected = option;
     console.log(option);
 
-    if (option.label !== 'Blue') {
+    if (option !== 'Blue') {
       this.errorMessage = 'Please select "Blue"';
       return;
     }

--- a/docs/components/autocomplete/demo/base-demo.md
+++ b/docs/components/autocomplete/demo/base-demo.md
@@ -5,13 +5,12 @@
     @options={{this.options}}
     @contentClass='z-10'
     @selected={{this.selected}}
-    @optionKey='label'
     @noResultsText='No results'
     placeholder='Colors'
     as |autocomplete|
   >
     <autocomplete.Option>
-      {{autocomplete.option.label}}
+      {{autocomplete.option}}
     </autocomplete.Option>
   </Form::Controls::Autocomplete>
 
@@ -34,14 +33,13 @@
     @options={{this.options}}
     @contentClass='z-10'
     @selected={{this.selected3}}
-    @optionKey='label'
-    @onFilter={{this.onFilterBy}}
+    @onFilter={{this.onFilter}}
     @noResultsText='No results'
     placeholder='Colors w/ Filtering'
     as |autocomplete|
   >
     <autocomplete.Option>
-      {{autocomplete.option.label}}
+      {{autocomplete.option}}
     </autocomplete.Option>
   </Form::Controls::Autocomplete>
 </div>
@@ -93,7 +91,7 @@ export default class extends Component {
       name: 'teal',
       value: 'teal',
     },
-  ];
+  ].map(({ label }) => label);
 
   options2 = [
     'Billy',
@@ -127,16 +125,14 @@ export default class extends Component {
   }
 
   @action
-  onFilterBy(input) {
-    console.log(`filtering with the value "${input}"`);
+  onFilter(value) {
+    console.log(`filtering with the value "${value}"`);
 
-    if (input.length > 0) {
-      return this.options.filter((option) =>
-        option.label.toLowerCase().startsWith(input.toLowerCase())
-      );
-    } else {
-      return this.options;
-    }
+    return value === ''
+      ? this.options
+      : this.options.filter((option) => {
+        return option.toLowerCase().includes(value.toLowerCase())
+      });
   }
 }
 ```

--- a/docs/components/autocomplete/index.md
+++ b/docs/components/autocomplete/index.md
@@ -88,77 +88,6 @@ export default class extends Component {
 }
 ```
 
-## Option Key
-
-Optional.
-
-The `@optionKey` argument is used when your `@options` take the shape of an array of objects. The `@optionKey` is used to determine two things internally:
-
-1. The displayed value inside of the input of the autocomplete
-2. Used as the key in the default filtering scenario where we filter `@options`. To properly filter the `@options` based on the user input from the textbox, we need to know how to compare the entered value to each object. The `@optionKey` tells us which key of the object to use for this filtering.
-
-In the example below, we set `@optionKey='label'`. Our `@options` objects have a `label` key and we want the label of the selected option to be used for the selected value, as well as for filtering as the user types.
-
-```hbs
-<Form::Controls::Autocomplete
-  @onChange={{this.handleChange}}
-  @options={{this.options}}
-  @optionKey='label'
-  @selected={{this.selected}}
-  as |autocomplete|
->
-  <autocomplete.Option>
-    {{autocomplete.option.label}}
-  </autocomplete.Option>
-</Form::Controls::Autocomplete>
-```
-
-```js
-import Component from '@glimmer/component';
-import { action } from '@ember/object';
-import { tracked } from '@glimmer/tracking';
-
-export default class extends Component {
-  @tracked selected;
-
-  options = [
-    {
-      label: 'Blue',
-      value: 'blue',
-    },
-    {
-      label: 'Green',
-      value: 'green',
-    },
-    {
-      label: 'Yellow',
-      value: 'yellow',
-    },
-    {
-      label: 'Orange',
-      value: 'orange',
-    },
-    {
-      label: 'Red',
-      value: 'red',
-    },
-    {
-      label: 'Purple',
-      value: 'purple',
-    },
-    {
-      label: 'Teal',
-      value: 'teal',
-    },
-  ];
-
-  @action
-  handleChange(option) {
-    this.selected = option;
-  }
-}
-```
-
 ## onFilter
 
 Optional.
@@ -170,7 +99,6 @@ By default, when `@options` are an array of strings, the built-in filtering does
   @onFilter={{this.handleFilter}}
   @onChange={{this.handleChange}}
   @options={{this.options}}
-  @optionKey='label'
   @selected={{this.selected}}
   as |autocomplete|
 >

--- a/docs/toucan-form/changeset-validation/demo/base-demo.md
+++ b/docs/toucan-form/changeset-validation/demo/base-demo.md
@@ -32,11 +32,10 @@
     @name='color'
     @noResultsText='No results'
     @options={{this.options}}
-    @optionKey='label'
     as |autocomplete|
   >
     <autocomplete.Option>
-      {{autocomplete.option.label}}
+      {{autocomplete.option}}
     </autocomplete.Option>
   </form.Autocomplete>
 

--- a/packages/ember-toucan-core/src/components/form/controls/autocomplete.hbs
+++ b/packages/ember-toucan-core/src/components/form/controls/autocomplete.hbs
@@ -30,7 +30,11 @@
       }}
       {{on
         "blur"
-        (if this.isDisabledOrReadOnlyOrWithoutOptions this.noop this.resetValue)
+        (if
+          this.isDisabledOrReadOnlyOrWithoutOptions
+          this.noop
+          this.resetEverything
+        )
       }}
       {{on
         "click"
@@ -41,7 +45,9 @@
       {{on
         "click"
         (if
-          this.isDisabledOrReadOnlyOrWithoutOptions this.noop this.selectInput
+          this.isDisabledOrReadOnlyOrWithoutOptions
+          this.noop
+          this.highlightInputValue
         )
       }}
       {{on

--- a/packages/ember-toucan-core/src/components/form/fields/autocomplete.hbs
+++ b/packages/ember-toucan-core/src/components/form/fields/autocomplete.hbs
@@ -56,7 +56,6 @@
         @noResultsText={{@noResultsText}}
         @onChange={{@onChange}}
         @onFilter={{@onFilter}}
-        @optionKey={{@optionKey}}
         @options={{@options}}
         @selected={{@selected}}
         ...attributes

--- a/packages/ember-toucan-core/src/components/form/fields/autocomplete.ts
+++ b/packages/ember-toucan-core/src/components/form/fields/autocomplete.ts
@@ -5,16 +5,9 @@ import LockIcon from '../../../-private/icons/lock';
 
 import type { AssertBlockOrArg } from '../../../-private/assert-block-or-argument-exists';
 import type { ErrorMessage } from '../../../-private/types';
-import type {
-  Option as ControlOption,
-  ToucanFormAutocompleteControlComponentSignature,
-} from '../controls/autocomplete';
+import type { ToucanFormAutocompleteControlComponentSignature } from '../controls/autocomplete';
 
-export type Option = ControlOption;
-
-export interface ToucanFormAutocompleteFieldComponentSignature<
-  OPTION extends ControlOption
-> {
+export interface ToucanFormAutocompleteFieldComponentSignature {
   Element: HTMLInputElement;
   Args: {
     /**
@@ -56,7 +49,7 @@ export interface ToucanFormAutocompleteFieldComponentSignature<
     /**
      * The function called when a new selection is made.
      */
-    onChange?: ToucanFormAutocompleteControlComponentSignature<OPTION>['Args']['onChange'];
+    onChange?: ToucanFormAutocompleteControlComponentSignature['Args']['onChange'];
 
     /**
      * The function called when a user types into the textbox.
@@ -64,23 +57,13 @@ export interface ToucanFormAutocompleteFieldComponentSignature<
      * Typically used for making a request to the server and populating
      * `@options` with the results.
      */
-    onFilter?: ToucanFormAutocompleteControlComponentSignature<OPTION>['Args']['onFilter'];
-
-    /**
-     * When `@options` is an array of objects, `@selected` is also an object.
-     * The `@optionKey` is used to determine which key of the object should
-     * be used for both filtering and displayed the selected value in the
-     * textbox.
-     */
-    optionKey?: ToucanFormAutocompleteControlComponentSignature<OPTION>['Args']['optionKey'];
+    onFilter?: ToucanFormAutocompleteControlComponentSignature['Args']['onFilter'];
 
     /**
      * `@options` forms the content of this component.
-     *
-     * To support a variety of data shapes, `@options` is typed as `unknown[]` and treated as though it were opaque.
-     * `@options` is simply iterated over then passed back to you as a block parameter (`select.option`).
+     * `@options` is iterated over then passed back to you as a block parameter (`select.option`).
      */
-    options?: ToucanFormAutocompleteControlComponentSignature<OPTION>['Args']['options'];
+    options?: ToucanFormAutocompleteControlComponentSignature['Args']['options'];
 
     /**
      * A test selector for targeting the root element of the field.
@@ -89,20 +72,18 @@ export interface ToucanFormAutocompleteFieldComponentSignature<
     rootTestSelector?: string;
 
     /**
-     * The currently selected option.  If `@options` is an array of strings, provide a string.  If `@options` is an array of objects, pass the entire object and use `@optionKey`.
+     * The currently selected option.
      */
-    selected?: ToucanFormAutocompleteControlComponentSignature<OPTION>['Args']['selected'];
+    selected?: ToucanFormAutocompleteControlComponentSignature['Args']['selected'];
   };
   Blocks: {
-    default: ToucanFormAutocompleteControlComponentSignature<OPTION>['Blocks']['default'];
+    default: ToucanFormAutocompleteControlComponentSignature['Blocks']['default'];
     label: [];
     hint: [];
   };
 }
 
-export default class ToucanFormAutocompleteFieldComponent<
-  OPTION extends ControlOption
-> extends Component<ToucanFormAutocompleteFieldComponentSignature<OPTION>> {
+export default class ToucanFormAutocompleteFieldComponent extends Component<ToucanFormAutocompleteFieldComponentSignature> {
   LockIcon = LockIcon;
 
   assertBlockOrArgumentExists = ({

--- a/packages/ember-toucan-form/src/-private/autocomplete-field.hbs
+++ b/packages/ember-toucan-form/src/-private/autocomplete-field.hbs
@@ -30,7 +30,6 @@
       @onChange={{field.setValue}}
       @onFilter={{@onFilter}}
       @options={{@options}}
-      @optionKey={{@optionKey}}
       @rootTestSelector={{@rootTestSelector}}
       @selected={{this.assertSelected field.value}}
       name={{@name}}
@@ -55,7 +54,6 @@
       @onChange={{field.setValue}}
       @onFilter={{@onFilter}}
       @options={{@options}}
-      @optionKey={{@optionKey}}
       @rootTestSelector={{@rootTestSelector}}
       @selected={{this.assertSelected field.value}}
       name={{@name}}
@@ -80,7 +78,6 @@
       @onChange={{field.setValue}}
       @onFilter={{@onFilter}}
       @options={{@options}}
-      @optionKey={{@optionKey}}
       @rootTestSelector={{@rootTestSelector}}
       @selected={{this.assertSelected field.value}}
       name={{@name}}
@@ -105,7 +102,6 @@
       @onChange={{field.setValue}}
       @onFilter={{@onFilter}}
       @options={{@options}}
-      @optionKey={{@optionKey}}
       @rootTestSelector={{@rootTestSelector}}
       @selected={{this.assertSelected field.value}}
       name={{@name}}

--- a/packages/ember-toucan-form/src/-private/autocomplete-field.ts
+++ b/packages/ember-toucan-form/src/-private/autocomplete-field.ts
@@ -3,10 +3,7 @@ import { assert } from '@ember/debug';
 import { action } from '@ember/object';
 
 import type { HeadlessFormBlock, UserData } from './types';
-import type {
-  Option,
-  ToucanFormAutocompleteFieldComponentSignature as BaseAutocompleteFieldSignature,
-} from '@crowdstrike/ember-toucan-core/components/form/fields/autocomplete';
+import type { ToucanFormAutocompleteFieldComponentSignature as BaseAutocompleteFieldSignature } from '@crowdstrike/ember-toucan-core/components/form/fields/autocomplete';
 import type { FormData, FormKey, ValidationError } from 'ember-headless-form';
 
 export interface ToucanFormAutocompleteFieldComponentSignature<
@@ -14,10 +11,7 @@ export interface ToucanFormAutocompleteFieldComponentSignature<
   KEY extends FormKey<FormData<DATA>> = FormKey<FormData<DATA>>
 > {
   Element: HTMLInputElement;
-  Args: Omit<
-    BaseAutocompleteFieldSignature<Option>['Args'],
-    'error' | 'onChange'
-  > & {
+  Args: Omit<BaseAutocompleteFieldSignature['Args'], 'error' | 'onChange'> & {
     /**
      * The name of your field, which must match a property of the `@data` passed to the form
      */
@@ -28,12 +22,7 @@ export interface ToucanFormAutocompleteFieldComponentSignature<
      */
     form: HeadlessFormBlock<DATA>;
   };
-  // TODO: How do we get this to play nicely with our
-  // generic in toucan-core?
-  // `BaseAutocompleteFieldSignature<Option>['Blocks'];`
-  // gives a glint error!
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  Blocks: BaseAutocompleteFieldSignature<any>['Blocks'];
+  Blocks: BaseAutocompleteFieldSignature['Blocks'];
 }
 
 export default class ToucanFormAutocompleteFieldComponent<
@@ -57,16 +46,14 @@ export default class ToucanFormAutocompleteFieldComponent<
   };
 
   @action
-  assertSelected(value: unknown): Option {
+  assertSelected(value: unknown) {
     assert(
-      `Only string or object values are expected for ${String(
+      `A string or \`undefined\` is expected for ${String(
         this.args.name
       )}, but you passed ${typeof value}`,
-      typeof value === 'undefined' ||
-        typeof value === 'string' ||
-        typeof value === 'object'
+     typeof value === 'string' || value === undefined
     );
 
-    return value as string | Record<string, unknown>;
+    return value;
   }
 }

--- a/test-app/tests/integration/components/autocomplete-test.gts
+++ b/test-app/tests/integration/components/autocomplete-test.gts
@@ -188,33 +188,6 @@ module('Integration | Component | Autocomplete', function (hooks) {
     assert.dom('[data-autocomplete]').hasValue('blue');
   });
 
-  test('it sets the value attribute via `@selected` and `@optionKey` when `@selected` is an object', async function (assert) {
-    let options = [
-      {
-        label: 'Blue',
-        value: 'blue',
-      },
-    ];
-
-    let selected = options[0];
-
-    await render(<template>
-      <Autocomplete
-        @selected={{selected}}
-        @options={{options}}
-        @optionKey="label"
-        data-autocomplete
-        as |autocomplete|
-      >
-        <autocomplete.Option data-option>
-          {{autocomplete.option.label}}
-        </autocomplete.Option>
-      </Autocomplete>
-    </template>);
-
-    assert.dom('[data-autocomplete]').hasValue('Blue');
-  });
-
   test('it sets `aria-selected` properly on the list item that is currently selected', async function (assert) {
     await render(<template>
       <Autocomplete
@@ -240,7 +213,7 @@ module('Integration | Component | Autocomplete', function (hooks) {
       .hasAttribute('aria-selected', 'false');
   });
 
-  test('it provides default filtering when `@options` is an array of strings', async function (assert) {
+  test('it provides default filtering', async function (assert) {
     await render(<template>
       <Autocomplete @options={{testColors}} data-autocomplete as |autocomplete|>
         <autocomplete.Option>{{autocomplete.option}}</autocomplete.Option>
@@ -262,48 +235,6 @@ module('Integration | Component | Autocomplete', function (hooks) {
     await fillIn('[data-autocomplete]', 'red');
     assert.dom('[role="option"]').exists({ count: 1 });
     assert.dom('[role="option"]').hasText('red');
-  });
-
-  test('it provides default filtering when `@options` is an array of objects and is provided with `@optionKey`', async function (assert) {
-    let options = [
-      {
-        label: 'Blue',
-        value: 'blue',
-      },
-      {
-        label: 'Red',
-        value: 'red',
-      },
-    ];
-
-    await render(<template>
-      <Autocomplete
-        @options={{options}}
-        @optionKey="label"
-        data-autocomplete
-        as |autocomplete|
-      >
-        <autocomplete.Option>{{autocomplete.option.label}}</autocomplete.Option>
-      </Autocomplete>
-    </template>);
-
-    await fillIn('[data-autocomplete]', 'blue');
-
-    // Filtering works as we expect
-    assert.dom('[role="option"]').exists({ count: 1 });
-    // NOTE: We should be using option.label (capitalized "Blue" instead of "blue")
-    assert.dom('[role="option"]').hasText('Blue');
-
-    // Resetting the filter by clearing the input should
-    // display all available options
-    await fillIn('[data-autocomplete]', '');
-    assert.dom('[role="option"]').exists({ count: 2 });
-
-    // Verify we can filter again after clearing
-    await fillIn('[data-autocomplete]', 'red');
-    assert.dom('[role="option"]').exists({ count: 1 });
-    // NOTE: We should be using option.label (capitalized "Red" instead of "red")
-    assert.dom('[role="option"]').hasText('Red');
   });
 
   test('it uses the provided `@noResultsText` when no results are found with filtering', async function (assert) {
@@ -403,7 +334,7 @@ module('Integration | Component | Autocomplete', function (hooks) {
   test('it uses the results from `@onFilter` to populate the filtered options', async function (assert) {
     assert.expect(5);
 
-    let handleFilter = (value: unknown) => {
+    let handleFilter = (value: string) => {
       assert.strictEqual(
         value,
         'y',
@@ -429,7 +360,6 @@ module('Integration | Component | Autocomplete', function (hooks) {
     await fillIn('[data-autocomplete]', 'y');
 
     assert.verifySteps(['onFilter']);
-
     assert.dom('[role="option"]').exists({ count: 1 });
     assert.dom('[role="option"]').hasText('yellow');
   });
@@ -762,7 +692,7 @@ module('Integration | Component | Autocomplete', function (hooks) {
     assert.verifySteps(['handleChange']);
   });
 
-  test('it reverts to the selected option when a user enters garbage after previously having a valid selection (with `@selected` as a string)', async function (assert) {
+  test('it reverts to the selected option when a user enters garbage after previously having a valid selection', async function (assert) {
     assert.expect(3);
 
     let handleChange = () => {
@@ -796,67 +726,6 @@ module('Integration | Component | Autocomplete', function (hooks) {
 
     // Verify the input is reset to our `@selected` option
     assert.dom('[data-autocomplete]').hasValue('blue');
-
-    // NOTE: We do not expect the `@onChange`  to be called in this
-    // case as we are only visually resetting to the previously
-    // selected value
-    assert.verifySteps([]);
-
-    // We want to verify the original options are re-displayed
-    // rather than the input being filtered to garbage
-    await click('[data-autocomplete]');
-
-    assert.dom('[role="option"]').exists({ count: 2 });
-  });
-
-  test('it reverts to the selected option when a user enters garbage after previously having a valid selection (with `@selected` as an object)', async function (assert) {
-    assert.expect(3);
-
-    let options = [
-      {
-        label: 'Blue',
-        value: 'blue',
-      },
-      {
-        label: 'Red',
-        value: 'red',
-      },
-    ];
-
-    let selected = options[0];
-
-    let handleChange = () => {
-      assert.step('do-not-expect-this-to-be-called!');
-    };
-
-    // NOTE: We have a selected option
-    // NOTE: We add an input tag so we have something to blur to (by focusing another element)
-    await render(<template>
-      <Autocomplete
-        @selected={{selected}}
-        @options={{options}}
-        @optionKey="label"
-        @onChange={{handleChange}}
-        data-autocomplete
-        as |autocomplete|
-      >
-        <autocomplete.Option>{{autocomplete.option.label}}</autocomplete.Option>
-      </Autocomplete>
-
-      {{! template-lint-disable require-input-label }}
-      <input placeholder="test" data-input />
-    </template>);
-
-    await click('[data-autocomplete]');
-
-    // Enter garbage into the input
-    await fillIn('[data-autocomplete]', 'some-garbage');
-
-    // Now blur the elment
-    await click('[data-input]');
-
-    // Verify the input is reset to our `@selected` option
-    assert.dom('[data-autocomplete]').hasValue('Blue');
 
     // NOTE: We do not expect the `@onChange`  to be called in this
     // case as we are only visually resetting to the previously


### PR DESCRIPTION
## 🚀 Description

### Only accept an array of strings for `@options`

The consumer is currently allowed to pass either an array of strings _or_ an array of objects. @ynotdraw and I talked about it. We think removing support for arrays of objects makes for an overall better component. 

This change does move some work to the consumer. If the consumer's data structure is anything other than an array of strings, the consumer will now have to do a lookup after `@onChange(selected: string)` is called to find the selected object in the `@options` array. Consumers will also have to map their data to our `string[]` structure, though this is easily done.

Despite this additional work for the consumer, we think that the **disadvantages** of supporting an array of objects make this change worthwhile:

#### The implementation is more complex

Various [conditionals](https://github.com/CrowdStrike/ember-toucan-core/pull/226/files#diff-837203e404c8fe1aa1e4644e395e8232a778a58071bc041170df58b22e60eeebL126) and [casts](https://github.com/CrowdStrike/ember-toucan-core/pull/226/files#diff-837203e404c8fe1aa1e4644e395e8232a778a58071bc041170df58b22e60eeebL256) [were added throughout](https://github.com/CrowdStrike/ember-toucan-core/pull/226/files#diff-f56c38f7ff91374f94b1488051f8a53a8b5d006e36303ced4c084d3e697ee333L70) to support the two data structures.

#### The API is more complex

 A generic (`OPTION`) was [added](https://github.com/CrowdStrike/ember-toucan-core/pull/226/files#diff-837203e404c8fe1aa1e4644e395e8232a778a58071bc041170df58b22e60eeebL105) to (I believe) support `Form`. @ynotdraw can give you details if you're curious.

The [`@optionKey`](https://github.com/CrowdStrike/ember-toucan-core/pull/226/files#diff-837203e404c8fe1aa1e4644e395e8232a778a58071bc041170df58b22e60eeebL75) argument was added and required to be passed by the consumer when `@options` is an object.

#### The slope is slippery

What about consumers who want to supply an array of objects where the desired data doesn't reside on the top level of each object in the array? Or maybe the consumer has an array of arrays or a mix of arrays and objects? 

The permutations are endless, and we're bound to encounter all of them given enough consumers. Thus supporting an array of objects isn't just that—it's supporting arbitrary data structures, which is not the business we want to be in.

### Various tweaks and nitpicks

🤷‍♂️

## 🔬 How to Test (Copied from the [original PR](https://github.com/CrowdStrike/ember-toucan-core/pull/200))

Navigate to [https://ebf80b3e.ember-toucan-core.pages.dev/docs/components/autocomplete](https://ebf80b3e.ember-toucan-core.pages.dev/docs/components/autocomplete)

- Mouse
  1. Click the Colors select control
  1. Verify the list of options opens and is displayed
  1. Type b
  1. Verify only blue is shown
  1. Click "Blue"
  1. Verify the popover closes and "Blue" is selected

- Keyboard
  1. Click the Colors select control
  1. Verify the list of options opens and is displayed
  1. Type b
  1. Verify only blue is shown
  1. Press the ENTER key
  1. Verify the popover closes and "Blue" is selected
