### PR TITLE
Add form.Multiselect support to ToucanForm component

### DIFF
--- a/.changeset/spicy-suits-pay.md
+++ b/.changeset/spicy-suits-pay.md
@@ -1,0 +1,26 @@
+---
+'@crowdstrike/ember-toucan-form': patch
+---
+
+Added `form.Multiselect` support.
+
+```hbs
+<ToucanForm @data={{data}} as |form|>
+  <form.Multiselect
+    @label='Label'
+    @hint='Hint'
+    @name='selection'
+    @options={{this.options}}
+  >
+    <:noResults>No results</:noResults>
+
+    <:remove as |remove|>
+      <remove.Remove @label={{(concat 'Remove' ' ' remove.option)}} />
+    </:remove>
+
+    <:default as |multiselect|>
+      <multiselect.Option>{{multiselect.option}}</multiselect.Option>
+    </:default>
+  </form.Multiselect>
+</ToucanForm>
+```

--- a/docs/toucan-form/changeset-validation/demo/base-demo.md
+++ b/docs/toucan-form/changeset-validation/demo/base-demo.md
@@ -40,6 +40,24 @@
     </autocomplete.Option>
   </form.Autocomplete>
 
+  <form.Multiselect
+    @contentClass='z-10'
+    @label='Multiselect'
+    @name='multiselect'
+    @optionKey='label'
+    @options={{this.options}}
+  >
+    <:noResults>No results</:noResults>
+
+    <:remove as |remove|>
+      <remove.Remove @label={{(concat 'Remove' ' ' remove.option.label)}} />
+    </:remove>
+
+    <:default as |multiselect|>
+      <multiselect.Option>{{multiselect.option.label}}</multiselect.Option>
+    </:default>
+  </form.Multiselect>
+
   <form.FileInput
     @label='Files to attach'
     @trigger='Select files'
@@ -65,12 +83,13 @@ export default class extends Component {
   data = {};
 
   validations = {
-    comment: validatePresence(true),
     color: validatePresence(true),
+    comment: validatePresence(true),
     files: validatePresence(true),
     firstName: validatePresence(true),
     fruit: validatePresence(true),
     lastName: validatePresence(true),
+    multiselect: validatePresence(true),
     terms: validatePresence(true),
     vegetable: validatePresence(true),
   };
@@ -107,7 +126,7 @@ export default class extends Component {
   ];
 
   handleSubmit(data) {
-    console.log({ data });
+    console.log({ data: data.get('pendingData') });
 
     alert(
       `Form submitted with:\n${Object.entries(data.get('pendingData'))

--- a/packages/ember-toucan-core/src/template-registry.ts
+++ b/packages/ember-toucan-core/src/template-registry.ts
@@ -36,6 +36,7 @@ export default interface Registry {
   'Form::Controls::Textarea': typeof TextareaControlComponent;
   'Form::FileInput::List': typeof FormFileInputListComponent;
   'Form::FileInput::DeleteButton': typeof FormFileInputDeleteButtonComponent;
+  'Form::Fields::Multiselect': typeof MultiselectFieldComponent;
   'Form::Fields::FileInput': typeof FormFileInputFieldComponent;
   'Form::Fields::Multiselect': typeof MultiselectFieldComponent;
   'Form::Fields::Radio': typeof RadioFieldComponent;

--- a/packages/ember-toucan-core/src/template-registry.ts
+++ b/packages/ember-toucan-core/src/template-registry.ts
@@ -36,7 +36,6 @@ export default interface Registry {
   'Form::Controls::Textarea': typeof TextareaControlComponent;
   'Form::FileInput::List': typeof FormFileInputListComponent;
   'Form::FileInput::DeleteButton': typeof FormFileInputDeleteButtonComponent;
-  'Form::Fields::Multiselect': typeof MultiselectFieldComponent;
   'Form::Fields::FileInput': typeof FormFileInputFieldComponent;
   'Form::Fields::Multiselect': typeof MultiselectFieldComponent;
   'Form::Fields::Radio': typeof RadioFieldComponent;

--- a/packages/ember-toucan-form/src/-private/multiselect-field.hbs
+++ b/packages/ember-toucan-form/src/-private/multiselect-field.hbs
@@ -1,0 +1,186 @@
+{{!
+  Regarding Conditionals
+
+  This looks really messy, but Form::Fields::Multiselect exposes named blocks; HOWEVER,
+  we cannot conditionally render named blocks due to https://github.com/emberjs/rfcs/issues/735.
+
+  We *can* conditionally render components though, based on the blocks and argument combinations
+  users provide us.  This is very brittle, but until https://github.com/emberjs/rfcs/issues/735
+  is resolved and a solution is found, this appears to be the only way to truly expose
+  conditional named blocks.
+
+  ---
+
+  Regarding glint-expect-error
+
+  "@onChange" of the component expects a an array typed value, but field.setValue is generic,
+  accepting anything that DATA[KEY] could be. Similar case with "@selected", but there casting is easy.
+}}
+<@form.Field @name={{@name}} as |field|>
+  {{#if (this.hasOnlyLabelBlock (has-block 'label') (has-block 'hint'))}}
+    <Form::Fields::Multiselect
+      @contentClass={{@contentClass}}
+      @error={{this.mapErrors field.rawErrors}}
+      @hint={{@hint}}
+      @isDisabled={{@isDisabled}}
+      @isReadOnly={{@isReadOnly}}
+      @label={{@label}}
+      {{! @glint-expect-error }}
+      @onChange={{field.setValue}}
+      @onFilter={{@onFilter}}
+      @options={{@options}}
+      @optionKey={{@optionKey}}
+      @rootTestSelector={{@rootTestSelector}}
+      @selected={{this.assertSelected field.value}}
+      name={{@name}}
+      ...attributes
+    >
+      <:label>{{yield to='label'}}</:label>
+
+      <:noResults>{{yield to='noResults'}}</:noResults>
+
+      <:remove as |remove|>
+        {{yield
+          (hash
+            Remove=(component (ensure-safe-component remove.Remove))
+            option=remove.option
+          )
+          to='remove'
+        }}
+      </:remove>
+
+      <:default as |multiselect|>
+        {{yield
+          (hash
+            Option=(component (ensure-safe-component multiselect.Option))
+            option=multiselect.option
+          )
+        }}
+      </:default>
+    </Form::Fields::Multiselect>
+  {{else if (this.hasHintAndLabelBlocks (has-block 'label') (has-block 'hint'))
+  }}
+    <Form::Fields::Multiselect
+      @contentClass={{@contentClass}}
+      @error={{this.mapErrors field.rawErrors}}
+      @hint={{@hint}}
+      @isDisabled={{@isDisabled}}
+      @isReadOnly={{@isReadOnly}}
+      @label={{@label}}
+      {{! @glint-expect-error }}
+      @onChange={{field.setValue}}
+      @onFilter={{@onFilter}}
+      @options={{@options}}
+      @optionKey={{@optionKey}}
+      @rootTestSelector={{@rootTestSelector}}
+      @selected={{this.assertSelected field.value}}
+      name={{@name}}
+      ...attributes
+    >
+      <:label>{{yield to='label'}}</:label>
+      <:hint>{{yield to='hint'}}</:hint>
+
+      <:noResults>{{yield to='noResults'}}</:noResults>
+
+      <:remove as |remove|>
+        {{yield
+          (hash
+            Remove=(component (ensure-safe-component remove.Remove))
+            option=remove.option
+          )
+          to='remove'
+        }}
+      </:remove>
+
+      <:default as |multiselect|>
+        {{yield
+          (hash
+            Option=(component (ensure-safe-component multiselect.Option))
+            option=multiselect.option
+          )
+        }}
+      </:default>
+    </Form::Fields::Multiselect>
+  {{else if (this.hasLabelArgAndHintBlock @label (has-block 'hint'))}}
+    <Form::Fields::Multiselect
+      @contentClass={{@contentClass}}
+      @error={{this.mapErrors field.rawErrors}}
+      @hint={{@hint}}
+      @isDisabled={{@isDisabled}}
+      @isReadOnly={{@isReadOnly}}
+      @label={{@label}}
+      {{! @glint-expect-error }}
+      @onChange={{field.setValue}}
+      @onFilter={{@onFilter}}
+      @options={{@options}}
+      @optionKey={{@optionKey}}
+      @rootTestSelector={{@rootTestSelector}}
+      @selected={{this.assertSelected field.value}}
+      name={{@name}}
+      ...attributes
+    >
+      <:hint>{{yield to='hint'}}</:hint>
+
+      <:noResults>{{yield to='noResults'}}</:noResults>
+
+      <:remove as |remove|>
+        {{yield
+          (hash
+            Remove=(component (ensure-safe-component remove.Remove))
+            option=remove.option
+          )
+          to='remove'
+        }}
+      </:remove>
+
+      <:default as |multiselect|>
+        {{yield
+          (hash
+            Option=(component (ensure-safe-component multiselect.Option))
+            option=multiselect.option
+          )
+        }}
+      </:default>
+    </Form::Fields::Multiselect>
+  {{else}}
+    {{! Argument-only case }}
+    <Form::Fields::Multiselect
+      @contentClass={{@contentClass}}
+      @error={{this.mapErrors field.rawErrors}}
+      @hint={{@hint}}
+      @isDisabled={{@isDisabled}}
+      @isReadOnly={{@isReadOnly}}
+      @label={{@label}}
+      {{! @glint-expect-error }}
+      @onChange={{field.setValue}}
+      @onFilter={{@onFilter}}
+      @options={{@options}}
+      @optionKey={{@optionKey}}
+      @rootTestSelector={{@rootTestSelector}}
+      @selected={{this.assertSelected field.value}}
+      name={{@name}}
+      ...attributes
+    >
+      <:noResults>{{yield to='noResults'}}</:noResults>
+
+      <:remove as |remove|>
+        {{yield
+          (hash
+            Remove=(component (ensure-safe-component remove.Remove))
+            option=remove.option
+          )
+          to='remove'
+        }}
+      </:remove>
+
+      <:default as |multiselect|>
+        {{yield
+          (hash
+            Option=(component (ensure-safe-component multiselect.Option))
+            option=multiselect.option
+          )
+        }}
+      </:default>
+    </Form::Fields::Multiselect>
+  {{/if}}
+</@form.Field>

--- a/packages/ember-toucan-form/src/-private/multiselect-field.ts
+++ b/packages/ember-toucan-form/src/-private/multiselect-field.ts
@@ -1,0 +1,67 @@
+import Component from '@glimmer/component';
+import { assert } from '@ember/debug';
+import { action } from '@ember/object';
+
+import type { HeadlessFormBlock, UserData } from './types';
+import type {
+  Option,
+  ToucanFormMultiselectFieldComponentSignature as BaseMultiselectFieldSignature,
+} from '@crowdstrike/ember-toucan-core/components/form/fields/multiselect';
+import type { FormData, FormKey, ValidationError } from 'ember-headless-form';
+
+export interface ToucanFormMultiselectFieldComponentSignature<
+  DATA extends UserData,
+  KEY extends FormKey<FormData<DATA>> = FormKey<FormData<DATA>>
+> {
+  Element: HTMLInputElement;
+  Args: Omit<
+    BaseMultiselectFieldSignature<Option>['Args'],
+    'error' | 'onChange'
+  > & {
+    /**
+     * The name of your field, which must match a property of the `@data` passed to the form
+     */
+    name: KEY;
+
+    /*
+     * @internal
+     */
+    form: HeadlessFormBlock<DATA>;
+  };
+  // This will be updated to be typed properly with Clinton's work
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  Blocks: BaseMultiselectFieldSignature<any>['Blocks'];
+}
+
+export default class ToucanFormMultiselectFieldComponent<
+  DATA extends UserData,
+  KEY extends FormKey<FormData<DATA>> = FormKey<FormData<DATA>>
+> extends Component<ToucanFormMultiselectFieldComponentSignature<DATA, KEY>> {
+  hasOnlyLabelBlock = (hasLabel: boolean, hasHint: boolean) =>
+    hasLabel && !hasHint;
+  hasHintAndLabelBlocks = (hasLabel: boolean, hasHint: boolean) =>
+    hasLabel && hasHint;
+  hasLabelArgAndHintBlock = (hasLabel: string | undefined, hasHint: boolean) =>
+    hasLabel && hasHint;
+
+  mapErrors = (errors?: ValidationError[]) => {
+    if (!errors) {
+      return;
+    }
+
+    // @todo we need to figure out what to do when message is undefined
+    return errors.map((error) => error.message ?? error.type);
+  };
+
+  @action
+  assertSelected(value: unknown): Option[] | undefined {
+    assert(
+      `Only array values are expected for ${String(
+        this.args.name
+      )}, but you passed ${typeof value}`,
+      typeof value === 'undefined' || Array.isArray(value)
+    );
+
+    return value;
+  }
+}

--- a/packages/ember-toucan-form/src/components/toucan-form.hbs
+++ b/packages/ember-toucan-form/src/components/toucan-form.hbs
@@ -27,6 +27,9 @@
       Input=(component
         (ensure-safe-component this.InputFieldComponent) form=form
       )
+      Multiselect=(component
+        (ensure-safe-component this.MultiselectFieldComponent) form=form
+      )
       RadioGroup=(component
         (ensure-safe-component this.RadioGroupFieldComponent) form=form
       )

--- a/packages/ember-toucan-form/src/components/toucan-form.ts
+++ b/packages/ember-toucan-form/src/components/toucan-form.ts
@@ -5,6 +5,7 @@ import CheckboxFieldComponent from '../-private/checkbox-field';
 import CheckboxGroupFieldComponent from '../-private/checkbox-group-field';
 import FileInputFieldComponent from '../-private/file-input-field';
 import InputFieldComponent from '../-private/input-field';
+import MultiselectFieldComponent from '../-private/multiselect-field';
 import RadioGroupFieldComponent from '../-private/radio-group-field';
 import TextareaFieldComponent from '../-private/textarea-field';
 
@@ -38,6 +39,10 @@ export interface ToucanFormComponentSignature<
         Field: HeadlessFormBlock<DATA>['Field'];
         FileInput: WithBoundArgs<typeof FileInputFieldComponent<DATA>, 'form'>;
         Input: WithBoundArgs<typeof InputFieldComponent<DATA>, 'form'>;
+        Multiselect: WithBoundArgs<
+          typeof MultiselectFieldComponent<DATA>,
+          'form'
+        >;
         RadioGroup: WithBoundArgs<
           typeof RadioGroupFieldComponent<DATA>,
           'form'
@@ -68,12 +73,13 @@ export default class ToucanFormComponent<
   DATA extends UserData,
   SUBMISSION_VALUE
 > extends Component<ToucanFormComponentSignature<DATA, SUBMISSION_VALUE>> {
+  AutocompleteFieldComponent = AutocompleteFieldComponent<DATA>;
   CheckboxComponent = CheckboxFieldComponent<DATA>;
   CheckboxGroupComponent = CheckboxGroupFieldComponent<DATA>;
   FileInputFieldComponent = FileInputFieldComponent<DATA>;
   InputFieldComponent = InputFieldComponent<DATA>;
+  MultiselectFieldComponent = MultiselectFieldComponent<DATA>;
   RadioGroupFieldComponent = RadioGroupFieldComponent<DATA>;
-  AutocompleteFieldComponent = AutocompleteFieldComponent<DATA>;
   TextareaFieldComponent = TextareaFieldComponent<DATA>;
 
   get validateOn() {

--- a/test-app/tests/integration/components/toucan-form/form-multiselect-test.gts
+++ b/test-app/tests/integration/components/toucan-form/form-multiselect-test.gts
@@ -1,0 +1,149 @@
+import { render } from '@ember/test-helpers';
+import { module, test } from 'qunit';
+
+import ToucanForm from '@crowdstrike/ember-toucan-form/components/toucan-form';
+import { setupRenderingTest } from 'test-app/tests/helpers';
+
+const options = ['blue', 'red', 'yellow'];
+
+interface TestData {
+  selection?: string[];
+}
+
+module('Integration | Component | ToucanForm | Multiselect', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders `@label` and `@hint` component arguments', async function (assert) {
+    const data: TestData = {
+      selection: undefined,
+    };
+
+    await render(<template>
+      <ToucanForm @data={{data}} as |form|>
+        <form.Multiselect
+          @label="Label"
+          @hint="Hint"
+          @name="selection"
+          @options={{options}}
+          data-multiselect
+        >
+          <:noResults>No results</:noResults>
+
+          <:remove as |remove|>
+            <remove.Remove @label="Remove" />
+          </:remove>
+
+          <:default as |multiselect|>
+            <multiselect.Option>{{multiselect.option}}</multiselect.Option>
+          </:default>
+        </form.Multiselect>
+      </ToucanForm>
+    </template>);
+
+    assert.dom('[data-label]').exists();
+    assert.dom('[data-hint]').exists();
+  });
+
+  test('it renders a `:label` named block with a `@hint` argument', async function (assert) {
+    const data: TestData = {
+      selection: undefined,
+    };
+
+    await render(<template>
+      <ToucanForm @data={{data}} as |form|>
+        <form.Multiselect
+          @hint="Hint"
+          @name="selection"
+          @options={{options}}
+          data-autocomplete
+        >
+          <:label><span data-label-block>Label</span></:label>
+
+          <:noResults>No results</:noResults>
+
+          <:remove as |remove|>
+            <remove.Remove @label="Remove" />
+          </:remove>
+
+          <:default as |multiselect|>
+            <multiselect.Option>{{multiselect.option}}</multiselect.Option>
+          </:default>
+        </form.Multiselect>
+      </ToucanForm>
+    </template>);
+
+    assert.dom('[data-label-block]').exists();
+
+    // NOTE: `data-hint` comes from `@hint`.
+    assert.dom('[data-hint]').exists();
+    assert.dom('[data-hint]').hasText('Hint');
+  });
+
+  test('it renders a `:hint` named block with a `@label` argument', async function (assert) {
+    const data: TestData = {
+      selection: undefined,
+    };
+
+    await render(<template>
+      <ToucanForm @data={{data}} as |form|>
+        <form.Multiselect
+          @label="Label"
+          @name="selection"
+          @options={{options}}
+          data-autocomplete
+        >
+          <:hint><span data-hint-block>Hint</span></:hint>
+
+          <:noResults>No results</:noResults>
+
+          <:remove as |remove|>
+            <remove.Remove @label="Remove" />
+          </:remove>
+
+          <:default as |multiselect|>
+            <multiselect.Option>{{multiselect.option}}</multiselect.Option>
+          </:default>
+        </form.Multiselect>
+      </ToucanForm>
+    </template>);
+
+    // NOTE: `data-label` comes from `@label`.
+    assert.dom('[data-label]').exists();
+    assert.dom('[data-label]').hasText('Label');
+
+    assert.dom('[data-hint-block]').exists();
+  });
+
+  test('it renders both a `:label` and `:hint` named block', async function (assert) {
+    const data: TestData = {
+      selection: undefined,
+    };
+
+    await render(<template>
+      <ToucanForm @data={{data}} as |form|>
+        <form.Multiselect
+          @name="selection"
+          @options={{options}}
+          data-autocomplete
+        >
+          <:label><span data-label-block>Label</span></:label>
+          <:hint><span data-hint-block>Hint</span></:hint>
+
+          <:noResults>No results</:noResults>
+
+          <:remove as |remove|>
+            <remove.Remove @label="Remove" />
+          </:remove>
+
+          <:default as |multiselect|>
+            <multiselect.Option>{{multiselect.option}}</multiselect.Option>
+          </:default>
+
+        </form.Multiselect>
+      </ToucanForm>
+    </template>);
+
+    assert.dom('[data-label-block]').exists();
+    assert.dom('[data-hint-block]').exists();
+  });
+});


### PR DESCRIPTION
## 🚀 Description

This PR exposes `form.Multiselect` from `ToucanForm`.

---

## 🔬 How to Test

- Green build
- Visit https://baf6a022.ember-toucan-core.pages.dev/docs/toucan-form/changeset-validation
- Click submit
- Verify an error is displayed for the multi select
- Select an option and then blur the input
- Verify the error is removed

---

## 📸 Images/Videos of Functionality

<img width="560" alt="Screenshot 2023-07-24 at 9 23 40 AM" src="https://github.com/CrowdStrike/ember-toucan-core/assets/8069555/d23cf287-5d56-46ac-9b8a-4b2d0d7b9c54">
