### PR TITLE
chore: Multiselect tweaks

### DIFF
--- a/docs/components/autocomplete/index.md
+++ b/docs/components/autocomplete/index.md
@@ -13,7 +13,7 @@ A CSS class to add to this component's content container. Commonly used to speci
 
 ## Options
 
-`@options` forms the content of this component. To support a variety of data shapes, `@options` is typed as `unknown[]` and treated as though it were opaque. `@options` is simply iterated over then passed back to you as a block parameter (`autocomplete.option`).
+`@options` forms the content of this component. 
 
 ```hbs
 <Form::Controls::Autocomplete
@@ -30,7 +30,7 @@ A CSS class to add to this component's content container. Commonly used to speci
 
 ## Selected
 
-The currently selected option. Can be either an object or a string. If `@options` is an array of strings, provide a string. If `@options` is an array of objects, pass the entire object. Works in combination with `@onChange`.
+The currently selected option.
 
 ```hbs
 <Form::Controls::Autocomplete
@@ -154,7 +154,7 @@ export default class extends Component {
 
   @action
   handleFilter(value) {
-    return this.options.filter((option) => option.label === value);
+    return this.options.filter((option) => option === value);
   }
 }
 ```

--- a/docs/components/multiselect-field/demo/base-demo.md
+++ b/docs/components/multiselect-field/demo/base-demo.md
@@ -5,7 +5,6 @@
     @hint='Select a color'
     @contentClass='z-10'
     @onChange={{this.onChange}}
-    @optionKey='label'
     @options={{this.options}}
     @selected={{this.selected}}
     placeholder='Colors'
@@ -13,12 +12,12 @@
     <:noResults>No results</:noResults>
 
     <:remove as |remove|>
-      <remove.Remove @label={{(concat 'Remove' ' ' remove.option.label)}} />
+      <remove.Remove @label={{(concat 'Remove' ' ' remove.option)}} />
     </:remove>
 
     <:default as |multiselect|>
       <multiselect.Option>
-        {{multiselect.option.label}}
+        {{multiselect.option}}
       </multiselect.Option>
     </:default>
   </Form::Fields::Multiselect>
@@ -69,7 +68,7 @@ export default class extends Component {
       name: 'teal',
       value: 'teal',
     },
-  ];
+  ].map(({ label }) => label);
 
   @action
   onChange(option) {

--- a/docs/components/multiselect-field/index.md
+++ b/docs/components/multiselect-field/index.md
@@ -155,7 +155,6 @@ A `:noResults` block is required and exposed to allow consumers to specify text 
 <Form::Fields::Multiselect
   @contentClass='z-10'
   @onChange={{this.onChange}}
-  @optionKey='label'
   @options={{this.options}}
   @selected={{this.selected}}
   placeholder='Colors'
@@ -165,7 +164,7 @@ A `:noResults` block is required and exposed to allow consumers to specify text 
 
   <:default as |multiselect|>
     <multiselect.Option>
-      {{multiselect.option.label}}
+      {{multiselect.option}}
     </multiselect.Option>
   </:default>
 </Form::Fields::Multiselect>
@@ -228,95 +227,22 @@ export default class extends Component {
 
 Required.
 
-`@options` forms the content of this component. To support a variety of data shapes, `@options` is typed as `string[] | Record<string, unknown>[]`. `@options` is simply iterated over then passed back to you as a block parameter (`multiselect.option`).
+`@options` forms the content of this component.
 
 ```hbs
 <Form::Fields::Multiselect @label='Label' @options={{this.options}}>
   <:default as |multiselect|>
     <!-- The content of each popover list item will be rendered here -->
     <multiselect.Option>
-      {{multiselect.option.label}}
+      {{multiselect.option}}
     </multiselect.Option>
   </:default>
 </Form::Fields::Multiselect>
-```
-
-## Option Key
-
-Optional.
-
-The `@optionKey` argument is used when your `@options` take the shape of an array of objects. The `@optionKey` is used to determine two things internally:
-
-1. The displayed value inside of each selected chip of the multiselect
-2. Used as the key in the default filtering scenario where we filter `@options`. To properly filter the `@options` based on the user input from the textbox, we need to know how to compare the entered value to each object. The `@optionKey` tells us which key of the object to use for this filtering.
-
-In the example below, we set `@optionKey='label'`. Our `@options` objects have a `label` key that we want displayed in each selected item chip. We also want our default filtering logic to use the `label` key.
-
-```hbs
-<Form::Fields::Multiselect
-  @label='Label'
-  @onChange={{this.handleChange}}
-  @optionKey='label'
-  @options={{this.options}}
-  @selected={{this.selected}}
->
-  <:default as |multiselect|>
-    <multiselect.Option @value={{multiselect.value}}>
-      {{multiselect.option.label}}
-    </multiselect.Option>
-  </:default>
-</Form::Fields::Multiselect>
-```
-
-```js
-import Component from '@glimmer/component';
-import { action } from '@ember/object';
-import { tracked } from '@glimmer/tracking';
-
-export default class extends Component {
-  @tracked selected;
-
-  options = [
-    {
-      label: 'Blue',
-      value: 'blue',
-    },
-    {
-      label: 'Green',
-      value: 'green',
-    },
-    {
-      label: 'Yellow',
-      value: 'yellow',
-    },
-    {
-      label: 'Orange',
-      value: 'orange',
-    },
-    {
-      label: 'Red',
-      value: 'red',
-    },
-    {
-      label: 'Purple',
-      value: 'purple',
-    },
-    {
-      label: 'Teal',
-      value: 'teal',
-    },
-  ];
-
-  @action
-  handleChange(option) {
-    this.selected = option;
-  }
-}
 ```
 
 ## Selected
 
-The currently selected options. Can be either an array of objects or strings. If `@options` is an array of strings, provide an array of strings. If `@options` is an array of objects, use an array of objects. Works in combination with `@onChange`.
+The currently selected option.
 
 ```hbs
 <Form::Fields::Multiselect
@@ -345,13 +271,13 @@ export default class extends Component {
 
 Optional.
 
-By default, when `@options` are an array of strings, the built-in filtering does simple `startsWith` filtering. When `@options` are an array of objects, the same filtering logic applies, but the key of each object is determined by the provided `@optionKey`. There may be cases where you need to write your own filtering logic completely that is more complex than the built-in `startsWith` filtering described. To do so, leverage `@onFilter` instead. This function should return an array of items that will then be used to populate the dropdown results.
+The built-in filtering does simple `String.prototype.startsWith` filtering. 
+Specify `onFilter` if you want to do something different.
 
 ```hbs
 <Form::Fields::Multiselect
   @onChange={{this.handleChange}}
   @onFilter={{this.handleFilter}}
-  @optionKey='label'
   @options={{this.options}}
   @selected={{this.selected}}
 >
@@ -409,7 +335,7 @@ export default class extends Component {
 
   @action
   handleFilter(value) {
-    return this.options.filter((option) => option.label === value);
+    return this.options.filter((option) => option === value);
   }
 }
 ```

--- a/docs/components/multiselect/demo/base-demo.md
+++ b/docs/components/multiselect/demo/base-demo.md
@@ -3,7 +3,6 @@
   <Form::Controls::Multiselect
     @contentClass='z-10'
     @onChange={{this.onChange}}
-    @optionKey='label'
     @options={{this.options}}
     @selected={{this.selected}}
     placeholder='Colors'
@@ -11,12 +10,12 @@
     <:noResults>No results</:noResults>
 
     <:remove as |remove|>
-      <remove.Remove @label={{(concat 'Remove' ' ' remove.option.label)}} />
+      <remove.Remove @label={{(concat 'Remove' ' ' remove.option)}} />
     </:remove>
 
     <:default as |multiselect|>
       <multiselect.Option>
-        {{multiselect.option.label}}
+        {{multiselect.option}}
       </multiselect.Option>
     </:default>
   </Form::Controls::Multiselect>
@@ -44,8 +43,7 @@
   <Form::Controls::Multiselect
     @contentClass='z-10'
     @onChange={{this.onChange3}}
-    @onFilter={{this.onFilterBy}}
-    @optionKey='label'
+    @onFilter={{this.onFilter}}
     @options={{this.options}}
     @selected={{this.selected3}}
     placeholder='Colors w/ Filtering'
@@ -53,12 +51,12 @@
     <:noResults>No results</:noResults>
 
     <:remove as |remove|>
-      <remove.Remove @label={{(concat 'Remove' ' ' remove.option.label)}} />
+      <remove.Remove @label={{(concat 'Remove' ' ' remove.option)}} />
     </:remove>
 
     <:default as |multiselect|>
       <multiselect.Option>
-        {{multiselect.option.label}}
+        {{multiselect.option}}
       </multiselect.Option>
     </:default>
   </Form::Controls::Multiselect>
@@ -111,7 +109,7 @@ export default class extends Component {
       name: 'teal',
       value: 'teal',
     },
-  ];
+  ].map(({ label }) => label);
 
   options2 = [
     'Billy',
@@ -145,16 +143,14 @@ export default class extends Component {
   }
 
   @action
-  onFilterBy(input) {
-    console.log(`filtering with the value "${input}"`);
+  onFilter(value) {
+    console.log(`filtering with the value "${value}"`);
 
-    if (input.length > 0) {
-      return this.options.filter((option) =>
-        option.label.toLowerCase().startsWith(input.toLowerCase())
+    return value === ''
+      ? this.options
+      : this.options.filter((option) =>
+        option.toLowerCase().includes(value.toLowerCase())
       );
-    } else {
-      return this.options;
-    }
   }
 }
 ```

--- a/docs/components/multiselect/index.md
+++ b/docs/components/multiselect/index.md
@@ -25,18 +25,17 @@ The `option` for that chip is yielded back to the consumer so that an appropriat
   @options={{this.options}}
   @contentClass='z-10'
   @selected={{this.selected}}
-  @optionKey='label'
   placeholder='Colors'
 >
   <:noResults>No results</:noResults>
 
   <:remove as |remove|>
-    <remove.Remove @label={{(concat 'Remove' ' ' remove.option.label)}} />
+    <remove.Remove @label={{(concat 'Remove' ' ' remove.option)}} />
   </:remove>
 
   <:default as |multiselect|>
     <multiselect.Option>
-      {{multiselect.option.label}}
+      {{multiselect.option}}
     </multiselect.Option>
   </:default>
 </Form::Controls::Multiselect>
@@ -50,18 +49,17 @@ An example with translations may be something like:
   @options={{this.options}}
   @contentClass='z-10'
   @selected={{this.selected}}
-  @optionKey='label'
   placeholder='Colors'
 >
   <:noResults>No results</:noResults>
 
   <:remove as |remove|>
-    <remove.Remove @label={{(t 'some-key' name=remove.option.label)}} />
+    <remove.Remove @label={{(t 'some-key' name=remove.option)}} />
   </:remove>
 
   <:default as |multiselect|>
     <multiselect.Option>
-      {{multiselect.option.label}}
+      {{multiselect.option}}
     </multiselect.Option>
   </:default>
 </Form::Controls::Multiselect>
@@ -75,7 +73,6 @@ A `:noResults` block is required and exposed to allow consumers to specify text 
 <Form::Controls::Multiselect
   @contentClass='z-10'
   @onChange={{this.onChange}}
-  @optionKey='label'
   @options={{this.options}}
   @selected={{this.selected}}
   placeholder='Colors'
@@ -84,12 +81,12 @@ A `:noResults` block is required and exposed to allow consumers to specify text 
   <:noResults>No results</:noResults>
 
   <:remove as |remove|>
-    <remove.Remove @label={{(concat 'Remove' ' ' remove.option.label)}} />
+    <remove.Remove @label={{(concat 'Remove' ' ' remove.option)}} />
   </:remove>
 
   <:default as |multiselect|>
     <multiselect.Option>
-      {{multiselect.option.label}}
+      {{multiselect.option}}
     </multiselect.Option>
   </:default>
 </Form::Controls::Multiselect>
@@ -97,14 +94,14 @@ A `:noResults` block is required and exposed to allow consumers to specify text 
 
 ## Options
 
-`@options` forms the content of this component. To support a variety of data shapes, `@options` is typed as `string[] | Record<string, unknown>[]`. `@options` is simply iterated over then passed back to you as a block parameter (`multiselect.option`).
+`@options` forms the content of this component. 
 
 ```hbs
 <Form::Controls::Multiselect @options={{this.options}}>
   <:default as |multiselect|>
     <!-- The content of each popover list item will be rendered here -->
     <multiselect.Option>
-      {{multiselect.option.label}}
+      {{multiselect.option}}
     </multiselect.Option>
   </:default>
 </Form::Controls::Multiselect>
@@ -112,7 +109,7 @@ A `:noResults` block is required and exposed to allow consumers to specify text 
 
 ## Selected
 
-The currently selected options. Can be either an array of objects or strings. If `@options` is an array of strings, provide an array of strings. If `@options` is an array of objects, use an array of objects. Works in combination with `@onChange`.
+The currently selected option.
 
 ```hbs
 <Form::Controls::Multiselect
@@ -170,90 +167,18 @@ export default class extends Component {
 }
 ```
 
-## Option Key
-
-Optional.
-
-The `@optionKey` argument is used when your `@options` take the shape of an array of objects. The `@optionKey` is used to determine two things internally:
-
-1. The displayed value inside of each selected chip of the multiselect
-2. Used as the key in the default filtering scenario where we filter `@options`. To properly filter the `@options` based on the user input from the textbox, we need to know how to compare the entered value to each object. The `@optionKey` tells us which key of the object to use for this filtering.
-
-In the example below, we set `@optionKey='label'`. Our `@options` objects have a `label` key that we want displayed in each selected item chip. We also want our default filtering logic to use the `label` key.
-
-```hbs
-<Form::Controls::Multiselect
-  @onChange={{this.handleChange}}
-  @options={{this.options}}
-  @optionKey='label'
-  @selected={{this.selected}}
->
-  <:default as |multiselect|>
-    <multiselect.Option @value={{multiselect.value}}>
-      {{multiselect.option.label}}
-    </multiselect.Option>
-  </:default>
-</Form::Controls::Multiselect>
-```
-
-```js
-import Component from '@glimmer/component';
-import { action } from '@ember/object';
-import { tracked } from '@glimmer/tracking';
-
-export default class extends Component {
-  @tracked selected;
-
-  options = [
-    {
-      label: 'Blue',
-      value: 'blue',
-    },
-    {
-      label: 'Green',
-      value: 'green',
-    },
-    {
-      label: 'Yellow',
-      value: 'yellow',
-    },
-    {
-      label: 'Orange',
-      value: 'orange',
-    },
-    {
-      label: 'Red',
-      value: 'red',
-    },
-    {
-      label: 'Purple',
-      value: 'purple',
-    },
-    {
-      label: 'Teal',
-      value: 'teal',
-    },
-  ];
-
-  @action
-  handleChange(option) {
-    this.selected = option;
-  }
-}
-```
-
 ## onFilter
 
 Optional.
 
-By default, when `@options` are an array of strings, the built-in filtering does simple `startsWith` filtering. When `@options` are an array of objects, the same filtering logic applies, but the key of each object is determined by the provided `@optionKey`. There may be cases where you need to write your own filtering logic completely that is more complex than the built-in `startsWith` filtering described. To do so, leverage `@onFilter` instead. This function should return an array of items that will then be used to populate the dropdown results.
+The built-in filtering does simple `String.prototype.startsWith` filtering. 
+Specify `onFilter` if you want to do something different.
 
 ```hbs
 <Form::Controls::Multiselect
   @onFilter={{this.handleFilter}}
   @onChange={{this.handleChange}}
   @options={{this.options}}
-  @optionKey='label'
   @selected={{this.selected}}
 >
   <:default as |multiselect|>
@@ -301,7 +226,7 @@ export default class extends Component {
       label: 'Teal',
       value: 'teal',
     },
-  ];
+  ].map(({ label }) => label);
 
   @action
   handleChange(option) {
@@ -310,7 +235,7 @@ export default class extends Component {
 
   @action
   handleFilter(value) {
-    return this.options.filter((option) => option.label === value);
+    return this.options.filter((option) => option === value);
   }
 }
 ```

--- a/docs/toucan-form/changeset-validation/demo/base-demo.md
+++ b/docs/toucan-form/changeset-validation/demo/base-demo.md
@@ -43,7 +43,6 @@
     @contentClass='z-10'
     @label='Multiselect'
     @name='multiselect'
-    @optionKey='label'
     @options={{this.options}}
   >
     <:noResults>No results</:noResults>

--- a/packages/ember-toucan-core/src/components/form/controls/multiselect.hbs
+++ b/packages/ember-toucan-core/src/components/form/controls/multiselect.hbs
@@ -12,7 +12,7 @@
     as |velcro|
   >
     {{! Disabling this rule as the user interacts with the input directly. The click on the div is simply for convenience. }}
-    {{!  template-lint-disable no-invalid-interactive }}
+    {{! template-lint-disable no-invalid-interactive }}
     <div
       class="bg-overlay-1 text-titles-and-attributes flex min-h-[2.5rem] items-center justify-between rounded-sm p-1 transition-shadow
         {{this.styles}}"
@@ -34,7 +34,7 @@
             data-multiselect-selected-option
           >
             <span class="block">
-              {{(this.getOptionLabel option)}}
+              {{option}}
             </span>
 
             {{#if this.isEnabled}}
@@ -53,7 +53,7 @@
           </div>
         {{/each}}
 
-        {{! template-lint-disable no-redundant-role  }}
+        {{! template-lint-disable no-redundant-role }}
         <input
           aria-activedescendant={{this.activeDescendant}}
           aria-autocomplete="list"
@@ -85,7 +85,7 @@
             (if
               this.isDisabledOrReadOnlyOrWithoutOptions
               this.noop
-              this.resetValue
+              this.resetInputValueAndFilteredOptions
             )
           }}
           {{on

--- a/packages/ember-toucan-core/src/components/form/fields/multiselect.hbs
+++ b/packages/ember-toucan-core/src/components/form/fields/multiselect.hbs
@@ -55,7 +55,6 @@
         @isReadOnly={{@isReadOnly}}
         @onChange={{@onChange}}
         @onFilter={{@onFilter}}
-        @optionKey={{@optionKey}}
         @options={{@options}}
         @selected={{@selected}}
         ...attributes

--- a/packages/ember-toucan-core/src/components/form/fields/multiselect.ts
+++ b/packages/ember-toucan-core/src/components/form/fields/multiselect.ts
@@ -6,15 +6,10 @@ import LockIcon from '../../../-private/icons/lock';
 import type { AssertBlockOrArg } from '../../../-private/assert-block-or-argument-exists';
 import type { ErrorMessage } from '../../../-private/types';
 import type {
-  Option as ControlOption,
   ToucanFormMultiselectControlComponentSignature,
 } from '../controls/multiselect';
 
-export type Option = ControlOption;
-
-export interface ToucanFormMultiselectFieldComponentSignature<
-  OPTION extends Option
-> {
+export interface ToucanFormMultiselectFieldComponentSignature {
   Element: HTMLInputElement;
   Args: {
     /**
@@ -52,27 +47,19 @@ export interface ToucanFormMultiselectFieldComponentSignature<
      * Called when the user makes a selection.
      * It is called with the selected options (derived from `@options`) as its only argument.
      */
-    onChange?: ToucanFormMultiselectControlComponentSignature<OPTION>['Args']['onChange'];
+    onChange?: ToucanFormMultiselectControlComponentSignature['Args']['onChange'];
 
     /**
      * The function called when a user types into the textbox, typically used to write custom filtering logic.
      */
-    onFilter?: ToucanFormMultiselectControlComponentSignature<OPTION>['Args']['onFilter'];
-
-    /**
-     * When `@options` is an array of objects, `@selected` is also an object.
-     * The `@optionKey` is used to determine which key of the object should
-     * be used for both filtering and displaying the selected values in the
-     * selected chips.
-     */
-    optionKey?: ToucanFormMultiselectControlComponentSignature<OPTION>['Args']['optionKey'];
+    onFilter?: ToucanFormMultiselectControlComponentSignature['Args']['onFilter'];
 
     /**
      * `@options` forms the content of this component.
      *
      * `@options` is simply iterated over then passed back to you as a block parameter (`multiselect.option`).
      */
-    options?: ToucanFormMultiselectControlComponentSignature<OPTION>['Args']['options'];
+    options?: ToucanFormMultiselectControlComponentSignature['Args']['options'];
 
     /**
      * A test selector for targeting the root element of the field.
@@ -81,22 +68,20 @@ export interface ToucanFormMultiselectFieldComponentSignature<
     rootTestSelector?: string;
 
     /**
-     * The currently selected options.  If `@options` is an array of strings, provide an array of strings.  If `@options` is an array of objects, pass an array of objects matching the format of `@options`.
+     * The currently selected option.
      */
-    selected?: ToucanFormMultiselectControlComponentSignature<OPTION>['Args']['selected'];
+    selected?: ToucanFormMultiselectControlComponentSignature['Args']['selected'];
   };
   Blocks: {
-    default: ToucanFormMultiselectControlComponentSignature<OPTION>['Blocks']['default'];
+    default: ToucanFormMultiselectControlComponentSignature['Blocks']['default'];
     hint: [];
     label: [];
-    noResults: ToucanFormMultiselectControlComponentSignature<OPTION>['Blocks']['noResults'];
-    remove: ToucanFormMultiselectControlComponentSignature<OPTION>['Blocks']['remove'];
+    noResults: ToucanFormMultiselectControlComponentSignature['Blocks']['noResults'];
+    remove: ToucanFormMultiselectControlComponentSignature['Blocks']['remove'];
   };
 }
 
-export default class ToucanFormMultiselectFieldComponent<
-  OPTION extends Option
-> extends Component<ToucanFormMultiselectFieldComponentSignature<OPTION>> {
+export default class ToucanFormMultiselectFieldComponent extends Component<ToucanFormMultiselectFieldComponentSignature> {
   LockIcon = LockIcon;
 
   assertBlockOrArgumentExists = ({

--- a/packages/ember-toucan-form/src/-private/autocomplete-field.ts
+++ b/packages/ember-toucan-form/src/-private/autocomplete-field.ts
@@ -51,7 +51,7 @@ export default class ToucanFormAutocompleteFieldComponent<
       `A string or \`undefined\` is expected for ${String(
         this.args.name
       )}, but you passed ${typeof value}`,
-     typeof value === 'string' || value === undefined
+      typeof value === 'string' || value === undefined
     );
 
     return value;

--- a/packages/ember-toucan-form/src/-private/multiselect-field.hbs
+++ b/packages/ember-toucan-form/src/-private/multiselect-field.hbs
@@ -29,7 +29,6 @@
       @onChange={{field.setValue}}
       @onFilter={{@onFilter}}
       @options={{@options}}
-      @optionKey={{@optionKey}}
       @rootTestSelector={{@rootTestSelector}}
       @selected={{this.assertSelected field.value}}
       name={{@name}}
@@ -71,7 +70,6 @@
       @onChange={{field.setValue}}
       @onFilter={{@onFilter}}
       @options={{@options}}
-      @optionKey={{@optionKey}}
       @rootTestSelector={{@rootTestSelector}}
       @selected={{this.assertSelected field.value}}
       name={{@name}}
@@ -113,7 +111,6 @@
       @onChange={{field.setValue}}
       @onFilter={{@onFilter}}
       @options={{@options}}
-      @optionKey={{@optionKey}}
       @rootTestSelector={{@rootTestSelector}}
       @selected={{this.assertSelected field.value}}
       name={{@name}}
@@ -155,7 +152,6 @@
       @onChange={{field.setValue}}
       @onFilter={{@onFilter}}
       @options={{@options}}
-      @optionKey={{@optionKey}}
       @rootTestSelector={{@rootTestSelector}}
       @selected={{this.assertSelected field.value}}
       name={{@name}}

--- a/packages/ember-toucan-form/src/-private/multiselect-field.ts
+++ b/packages/ember-toucan-form/src/-private/multiselect-field.ts
@@ -4,7 +4,6 @@ import { action } from '@ember/object';
 
 import type { HeadlessFormBlock, UserData } from './types';
 import type {
-  Option,
   ToucanFormMultiselectFieldComponentSignature as BaseMultiselectFieldSignature,
 } from '@crowdstrike/ember-toucan-core/components/form/fields/multiselect';
 import type { FormData, FormKey, ValidationError } from 'ember-headless-form';
@@ -15,7 +14,7 @@ export interface ToucanFormMultiselectFieldComponentSignature<
 > {
   Element: HTMLInputElement;
   Args: Omit<
-    BaseMultiselectFieldSignature<Option>['Args'],
+    BaseMultiselectFieldSignature['Args'],
     'error' | 'onChange'
   > & {
     /**
@@ -28,9 +27,7 @@ export interface ToucanFormMultiselectFieldComponentSignature<
      */
     form: HeadlessFormBlock<DATA>;
   };
-  // This will be updated to be typed properly with Clinton's work
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  Blocks: BaseMultiselectFieldSignature<any>['Blocks'];
+  Blocks: BaseMultiselectFieldSignature['Blocks'];
 }
 
 export default class ToucanFormMultiselectFieldComponent<
@@ -54,12 +51,12 @@ export default class ToucanFormMultiselectFieldComponent<
   };
 
   @action
-  assertSelected(value: unknown): Option[] | undefined {
+  assertSelected(value: unknown) {
     assert(
-      `Only array values are expected for ${String(
+      `\`string[]\` or \`undefined\` is expected for ${String(
         this.args.name
       )}, but you passed ${typeof value}`,
-      typeof value === 'undefined' || Array.isArray(value)
+      Array.isArray(value) || value === undefined
     );
 
     return value;

--- a/test-app/tests/integration/components/multiselect-test.gts
+++ b/test-app/tests/integration/components/multiselect-test.gts
@@ -393,43 +393,7 @@ module('Integration | Component | Multiselect', function (hooks) {
     assert.dom(secondChip).hasText('red');
   });
 
-  test('it sets the label of each selected chip via `@selected` and `@optionKey` when `@options` are an array of objects', async function (assert) {
-    let options = [
-      {
-        label: 'Blue',
-        value: 'blue',
-      },
-    ];
-
-    let selected = [...options];
-
-    await render(<template>
-      <Multiselect
-        @selected={{selected}}
-        @options={{options}}
-        @optionKey="label"
-        data-multiselect
-      >
-        <:noResults>No results</:noResults>
-
-        <:remove as |remove|>
-          <remove.Remove @label="Remove" />
-        </:remove>
-
-        <:default as |multiselect|>
-          <multiselect.Option
-            data-option
-          >{{multiselect.option.label}}</multiselect.Option>
-        </:default>
-      </Multiselect>
-    </template>);
-
-    assert.dom('[data-multiselect-selected-option]').exists({ count: 1 });
-    // NOTE: Since using `label` as `@optionKey`, we expect the uppercase version
-    assert.dom('[data-multiselect-selected-option]').hasText('Blue');
-  });
-
-  test('it sets the label of each selected chip via the raw string when `@options` is an array of strings', async function (assert) {
+  test('it sets the label of each selected chip', async function (assert) {
     let options = ['a'];
 
     let selected = [...options];
@@ -516,7 +480,7 @@ module('Integration | Component | Multiselect', function (hooks) {
     assert.dom('[data-multiselect-option-checkbox]:last-child').isNotChecked();
   });
 
-  test('it provides default filtering when `@options` is an array of strings', async function (assert) {
+  test('it provides default filtering', async function (assert) {
     await render(<template>
       <Multiselect @options={{testColors}} data-multiselect>
         <:noResults>No results</:noResults>
@@ -546,51 +510,6 @@ module('Integration | Component | Multiselect', function (hooks) {
     await fillIn('[data-multiselect]', 'red');
     assert.dom('[role="option"]').exists({ count: 1 });
     assert.dom('[role="option"]').hasText('red');
-  });
-
-  test('it provides default filtering when `@options` is an array of objects and is provided with `@optionKey`', async function (assert) {
-    let options = [
-      {
-        label: 'Blue',
-        value: 'blue',
-      },
-      {
-        label: 'Red',
-        value: 'red',
-      },
-    ];
-
-    await render(<template>
-      <Multiselect @options={{options}} @optionKey="label" data-multiselect>
-        <:noResults>No results</:noResults>
-
-        <:remove as |remove|>
-          <remove.Remove @label="Remove" />
-        </:remove>
-
-        <:default as |multiselect|>
-          <multiselect.Option>{{multiselect.option.label}}</multiselect.Option>
-        </:default>
-      </Multiselect>
-    </template>);
-
-    await fillIn('[data-multiselect]', 'blue');
-
-    // Filtering works as we expect
-    assert.dom('[role="option"]').exists({ count: 1 });
-    // NOTE: We should be using option.label (capitalized "Blue" instead of "blue")
-    assert.dom('[role="option"]').hasText('Blue');
-
-    // Resetting the filter by clearing the input should
-    // display all available options
-    await fillIn('[data-multiselect]', '');
-    assert.dom('[role="option"]').exists({ count: 2 });
-
-    // Verify we can filter again after clearing
-    await fillIn('[data-multiselect]', 'red');
-    assert.dom('[role="option"]').exists({ count: 1 });
-    // NOTE: We should be using option.label (capitalized "Red" instead of "red")
-    assert.dom('[role="option"]').hasText('Red');
   });
 
   test('it renders the no results content into the `:noResults` block', async function (assert) {


### PR DESCRIPTION
## 🚀 Description

### Only accept an array of strings for `@options`

The consumer is currently allowed to pass either an array of strings _or_ an array of objects. @ynotdraw and I talked about it. We think removing support for arrays of objects makes for an overall better component. 

This change does move some work to the consumer. If the consumer's data structure is anything other than an array of strings, the consumer will now have to do a lookup after `@onChange(selected: string[])` is called to find the selected object in the `@options` array. Consumers will also have to map their data to our `string[]` structure, though this is easily done.

Despite this additional work for the consumer, we think that the **disadvantages** of supporting an array of objects make this change worthwhile:

#### The implementation is more complex

Various [conditionals](https://github.com/CrowdStrike/ember-toucan-core/pull/229/files#diff-18271f9cbb7b93358816e2d878f5652b79f186067405c74744e3556eb4beb8e6L371) and [casts](https://github.com/CrowdStrike/ember-toucan-core/pull/229/files#diff-18271f9cbb7b93358816e2d878f5652b79f186067405c74744e3556eb4beb8e6L379) [were added throughout](https://github.com/CrowdStrike/ember-toucan-core/pull/229/files#diff-18271f9cbb7b93358816e2d878f5652b79f186067405c74744e3556eb4beb8e6L581) to support the two data structures.

#### The API is more complex

 A generic (`OPTION`) was [added](https://github.com/CrowdStrike/ember-toucan-core/pull/226/files#diff-837203e404c8fe1aa1e4644e395e8232a778a58071bc041170df58b22e60eeebL105) to (I believe) support `Form`. @ynotdraw can give you details if you're curious.

The [`@optionKey`](https://github.com/CrowdStrike/ember-toucan-core/pull/226/files#diff-837203e404c8fe1aa1e4644e395e8232a778a58071bc041170df58b22e60eeebL75) argument was added and required to be passed by the consumer when `@options` is an object.

#### The slope is slippery

What about consumers who want to supply an array of objects where the desired data doesn't reside on the top level of each object in the array? Or maybe the consumer has an array of arrays or a mix of arrays and objects? 

The permutations are endless, and we're bound to encounter all of them given enough consumers. Thus supporting an array of objects isn't just that—it's supporting arbitrary data structures, which is not the business we want to be in.

### Various tweaks and nitpicks

🤷‍♂️

## 🔬 How to Test (Copied from the [original PR](https://github.com/CrowdStrike/ember-toucan-core/pull/227))

1. Green build
1. Visit https://725ae457.ember-toucan-core.pages.dev/docs/components/multiselect
1. Click submit
1. Verify an error is displayed for the multi select
1. Select an option and then blur the input
1. Verify the error is removed

## Related

[Autocomplete tweaks PR](https://github.com/CrowdStrike/ember-toucan-core/pull/226)
