### PR TITLE
Set all form elements to `w-full` and adjust docs

### DIFF
--- a/.changeset/hip-bulldogs-kick.md
+++ b/.changeset/hip-bulldogs-kick.md
@@ -1,0 +1,6 @@
+---
+'@crowdstrike/ember-toucan-core': minor
+'@crowdstrike/ember-toucan-form': minor
+---
+
+Updated all form elements to have the `w-full` class, making them full width by default. The width of the element is now determined by the container. To restrict the width of the element, use a wrapping tag with an appropriate class name applied.

--- a/docs/components/autocomplete-field/demo/base-demo.md
+++ b/docs/components/autocomplete-field/demo/base-demo.md
@@ -1,20 +1,22 @@
 ```hbs template
-<Form::Fields::Autocomplete
-  @contentClass='z-10'
-  @error={{this.errorMessage}}
-  @hint='Type "blue" into the field'
-  @label='Label'
-  @noResultsText='No results'
-  @onChange={{this.onChange}}
-  @options={{this.options}}
-  @selected={{this.selected}}
-  placeholder='Colors'
-  as |autocomplete|
->
-  <autocomplete.Option>
-    {{autocomplete.option}}
-  </autocomplete.Option>
-</Form::Fields::Autocomplete>
+<div class='w-96'>
+  <Form::Fields::Autocomplete
+    @contentClass='z-10'
+    @error={{this.errorMessage}}
+    @hint='Type "blue" into the field'
+    @label='Label'
+    @noResultsText='No results'
+    @onChange={{this.onChange}}
+    @options={{this.options}}
+    @selected={{this.selected}}
+    placeholder='Colors'
+    as |autocomplete|
+  >
+    <autocomplete.Option>
+      {{autocomplete.option}}
+    </autocomplete.Option>
+  </Form::Fields::Autocomplete>
+</div>
 ```
 
 ```js component

--- a/docs/components/checkbox-group-field/demo/base-demo.md
+++ b/docs/components/checkbox-group-field/demo/base-demo.md
@@ -1,25 +1,27 @@
 ```hbs template
-<Form::Fields::CheckboxGroup
-  @label='Label'
-  @hint='Extra information about the field'
-  @name='options'
-  @value={{this.groupValue}}
-  @onChange={{this.updateValue}}
-  as |group|
->
-  <group.CheckboxField @label='Option 1' @value='option-1' />
-  <group.CheckboxField
-    @label='Option 2'
-    @hint='Extra information about the radio'
-    @value='option-2'
-  />
-  <group.CheckboxField @label='Option 3' @value='option-3' />
-  <group.CheckboxField
-    @label='Option 4'
-    @hint='Extra information about the radio'
-    @value='option-4'
-  />
-</Form::Fields::CheckboxGroup>
+<div class='w-96'>
+  <Form::Fields::CheckboxGroup
+    @label='Label'
+    @hint='Extra information about the field'
+    @name='options'
+    @value={{this.groupValue}}
+    @onChange={{this.updateValue}}
+    as |group|
+  >
+    <group.CheckboxField @label='Option 1' @value='option-1' />
+    <group.CheckboxField
+      @label='Option 2'
+      @hint='Extra information about the radio'
+      @value='option-2'
+    />
+    <group.CheckboxField @label='Option 3' @value='option-3' />
+    <group.CheckboxField
+      @label='Option 4'
+      @hint='Extra information about the radio'
+      @value='option-4'
+    />
+  </Form::Fields::CheckboxGroup>
+</div>
 ```
 
 ```js component

--- a/docs/components/file-input-field/demo/base-demo.md
+++ b/docs/components/file-input-field/demo/base-demo.md
@@ -1,5 +1,5 @@
 ```hbs template
-<div class='max-w-md'>
+<div class='w-96'>
   <Form::Fields::FileInput
     @deleteLabel='Delete file'
     @label='Label'

--- a/docs/components/input-field/demo/base-demo.md
+++ b/docs/components/input-field/demo/base-demo.md
@@ -1,12 +1,14 @@
 ```hbs template
-<Form::Fields::Input
-  @label='Label'
-  @hint='Type "input" into the field'
-  @error={{this.errorMessage}}
-  @value={{this.value}}
-  @onChange={{this.handleChange}}
-  type='text'
-/>
+<div class='w-96'>
+  <Form::Fields::Input
+    @label='Label'
+    @hint='Type "input" into the field'
+    @error={{this.errorMessage}}
+    @value={{this.value}}
+    @onChange={{this.handleChange}}
+    type='text'
+  />
+</div>
 ```
 
 ```js component

--- a/docs/components/multiselect-field/demo/base-demo.md
+++ b/docs/components/multiselect-field/demo/base-demo.md
@@ -1,5 +1,5 @@
 ```hbs template
-<div class='flex flex-col gap-4 w-96'>
+<div class='w-96'>
   <Form::Fields::Multiselect
     @label='Label'
     @hint='Select a color'

--- a/docs/components/radio-field/demo/base-demo.md
+++ b/docs/components/radio-field/demo/base-demo.md
@@ -1,5 +1,5 @@
 ```hbs template
-<div class='space-y-4'>
+<div class='space-y-4 w-96'>
   <Form::Fields::Radio
     @label='Option 1'
     @name='options'

--- a/docs/components/radio-group-field/demo/base-demo.md
+++ b/docs/components/radio-group-field/demo/base-demo.md
@@ -1,25 +1,27 @@
 ```hbs template
-<Form::Fields::RadioGroup
-  @label='Label'
-  @hint='Extra information about the field'
-  @name='options'
-  @value={{this.groupValue}}
-  @onChange={{this.updateValue}}
-  as |group|
->
-  <group.RadioField @label='Option 1' @value='option-1' />
-  <group.RadioField
-    @label='Option 2'
-    @value='option-2'
-    @hint='Extra information about the radio'
-  />
-  <group.RadioField @label='Option 3' @value='option-3' />
-  <group.RadioField
-    @label='Option 4'
-    @value='option-4'
-    @hint='Extra information about the radio'
-  />
-</Form::Fields::RadioGroup>
+<div class='w-96'>
+  <Form::Fields::RadioGroup
+    @label='Label'
+    @hint='Extra information about the field'
+    @name='options'
+    @value={{this.groupValue}}
+    @onChange={{this.updateValue}}
+    as |group|
+  >
+    <group.RadioField @label='Option 1' @value='option-1' />
+    <group.RadioField
+      @label='Option 2'
+      @value='option-2'
+      @hint='Extra information about the radio'
+    />
+    <group.RadioField @label='Option 3' @value='option-3' />
+    <group.RadioField
+      @label='Option 4'
+      @value='option-4'
+      @hint='Extra information about the radio'
+    />
+  </Form::Fields::RadioGroup>
+</div>
 ```
 
 ```js component

--- a/docs/components/textarea-field/demo/base-demo.md
+++ b/docs/components/textarea-field/demo/base-demo.md
@@ -1,11 +1,13 @@
 ```hbs template
-<Form::Fields::Textarea
-  @label='Label'
-  @hint='Type "textarea" into the field'
-  @error={{this.errorMessage}}
-  @value={{this.value}}
-  @onChange={{this.updateValue}}
-/>
+<div class='w-96'>
+  <Form::Fields::Textarea
+    @label='Label'
+    @hint='Type "textarea" into the field'
+    @error={{this.errorMessage}}
+    @value={{this.value}}
+    @onChange={{this.updateValue}}
+  />
+</div>
 ```
 
 ```js component

--- a/docs/toucan-form/changeset-validation/demo/base-demo.md
+++ b/docs/toucan-form/changeset-validation/demo/base-demo.md
@@ -1,72 +1,130 @@
 ```hbs template
-<ToucanForm
-  class='space-y-4 max-w-xs'
-  @data={{changeset this.data this.validations}}
-  @dataMode='mutable'
-  @onSubmit={{this.handleSubmit}}
-  @validate={{(validate-changeset)}}
-  as |form|
->
-  <form.Input @label='First name' @name='firstName' />
-  <form.Input @label='Last name' @name='lastName' />
-  <form.Textarea @label='Comment' @name='comment' />
+<div class='mx-auto max-w-md'>
+  <ToucanForm
+    class='space-y-4'
+    @data={{changeset this.data this.validations}}
+    @dataMode='mutable'
+    @onSubmit={{this.handleSubmit}}
+    @validate={{(validate-changeset)}}
+    as |form|
+  >
+    <form.Input @label='First name' @name='firstName' />
 
-  <form.CheckboxGroup @label='Fruit selection' @name='fruit' as |group|>
-    <group.CheckboxField
-      @label='Banana'
-      @value='banana'
-      data-checkbox-group-1
+    <form.Input @label='Last name' @name='lastName'>
+      <:secondary as |secondary|>
+        <secondary.CharacterCount @max={{255}} />
+      </:secondary>
+    </form.Input>
+
+    <form.Textarea @label='Comment' @name='comment' />
+
+    <form.Textarea @label='Description' @name='description'>
+      <:secondary as |secondary|>
+        <secondary.CharacterCount @max={{255}} />
+      </:secondary>
+    </form.Textarea>
+
+    <form.CheckboxGroup @label='Fruit selection' @name='fruit' as |group|>
+      <group.CheckboxField
+        @label='Banana'
+        @value='banana'
+        data-checkbox-group-1
+      />
+      <group.CheckboxField
+        @label='Apple'
+        @value='apple'
+        data-checkbox-group-2
+      />
+      <group.CheckboxField @label='Pear' @value='pear' data-checkbox-group-3 />
+    </form.CheckboxGroup>
+
+    <form.RadioGroup @label='Vegetable selection' @name='vegetable' as |group|>
+      <group.RadioField @label='Avocado' @value='avocado' data-radio-1 />
+      <group.RadioField @label='Broccoli' @value='broccoli' data-radio-2 />
+    </form.RadioGroup>
+
+    <form.Autocomplete
+      @contentClass='z-10'
+      @label='Color'
+      @name='color'
+      @noResultsText='No results'
+      @options={{this.options}}
+      as |autocomplete|
+    >
+      <autocomplete.Option>
+        {{autocomplete.option}}
+      </autocomplete.Option>
+    </form.Autocomplete>
+
+    <form.Multiselect
+      @contentClass='z-10'
+      @label='Multiselect'
+      @name='multiselect'
+      @optionKey='label'
+      @options={{this.options}}
+    >
+      <:noResults>No results</:noResults>
+
+      <:remove as |remove|>
+        <remove.Remove @label={{(concat 'Remove' ' ' remove.option.label)}} />
+      </:remove>
+
+      <:default as |multiselect|>
+        <multiselect.Option>{{multiselect.option.label}}</multiselect.Option>
+      </:default>
+    </form.Multiselect>
+
+    <form.FileInput
+      @label='Files to attach'
+      @trigger='Select files'
+      @deleteLabel='Delete'
+      @name='files'
     />
-    <group.CheckboxField @label='Apple' @value='apple' data-checkbox-group-2 />
-    <group.CheckboxField @label='Pear' @value='pear' data-checkbox-group-3 />
-  </form.CheckboxGroup>
 
-  <form.RadioGroup @label='Vegetable selection' @name='vegetable' as |group|>
-    <group.RadioField @label='Avocado' @value='avocado' data-radio-1 />
-    <group.RadioField @label='Broccoli' @value='broccoli' data-radio-2 />
-  </form.RadioGroup>
+    <form.Checkbox @label='Agree to the Terms' @name='terms' />
 
-  <form.Autocomplete
-    @contentClass='z-10'
-    @label='Color'
-    @name='color'
-    @noResultsText='No results'
-    @options={{this.options}}
-    as |autocomplete|
-  >
-    <autocomplete.Option>
-      {{autocomplete.option}}
-    </autocomplete.Option>
-  </form.Autocomplete>
+    <form.Autocomplete
+      @contentClass='z-10'
+      @label='Color'
+      @name='color'
+      @noResultsText='No results'
+      @options={{this.options}}
+      as |autocomplete|
+    >
+      <autocomplete.Option>
+        {{autocomplete.option}}
+      </autocomplete.Option>
+    </form.Autocomplete>
 
-  <form.Multiselect
-    @contentClass='z-10'
-    @label='Multiselect'
-    @name='multiselect'
-    @options={{this.options}}
-  >
-    <:noResults>No results</:noResults>
+    <form.Multiselect
+      @contentClass='z-10'
+      @label='Multiselect'
+      @name='multiselect'
+      @options={{this.options}}
+    >
+      <:noResults>No results</:noResults>
 
-    <:remove as |remove|>
-      <remove.Remove @label={{(concat 'Remove' ' ' remove.option.label)}} />
-    </:remove>
+      <:remove as |remove|>
+        <remove.Remove @label={{(concat 'Remove' ' ' remove.option.label)}} />
+      </:remove>
 
-    <:default as |multiselect|>
-      <multiselect.Option>{{multiselect.option.label}}</multiselect.Option>
-    </:default>
-  </form.Multiselect>
+      <:default as |multiselect|>
+        <multiselect.Option>{{multiselect.option.label}}</multiselect.Option>
+      </:default>
+    </form.Multiselect>
 
-  <form.FileInput
-    @label='Files to attach'
-    @trigger='Select files'
-    @deleteLabel='Delete'
-    @name='files'
-  />
+    <form.FileInput
+      @label='Files to attach'
+      @trigger='Select files'
+      @deleteLabel='Delete'
+      @name='files'
+    />
 
-  <form.Checkbox @label='Agree to the Terms' @name='terms' />
+    <form.Checkbox @label='Agree to the Terms' @name='terms' />
 
-  <Button type='submit'>Submit</Button>
-</ToucanForm>
+    <Button class='w-full' type='submit'>Submit</Button>
+  </ToucanForm>
+</div>
 ```
 
 ```js component
@@ -75,6 +133,7 @@ import { action } from '@ember/object';
 import {
   validatePresence,
   validateFormat,
+  validateLength,
 } from 'ember-changeset-validations/validators';
 
 export default class extends Component {
@@ -83,10 +142,11 @@ export default class extends Component {
   validations = {
     color: validatePresence(true),
     comment: validatePresence(true),
+    description: [validatePresence(true), validateLength({ max: 255 })],
     files: validatePresence(true),
     firstName: validatePresence(true),
     fruit: validatePresence(true),
-    lastName: validatePresence(true),
+    lastName: [validatePresence(true), validateLength({ max: 255 })],
     multiselect: validatePresence(true),
     terms: validatePresence(true),
     vegetable: validatePresence(true),

--- a/packages/ember-toucan-core/src/components/form/controls/autocomplete.hbs
+++ b/packages/ember-toucan-core/src/components/form/controls/autocomplete.hbs
@@ -3,7 +3,7 @@
   @placement="bottom-start"
   as |velcro|
 >
-  <div class="relative flex items-center">
+  <div class="relative flex w-full items-center">
     {{! template-lint-disable no-redundant-role  }}
     <input
       aria-activedescendant={{this.activeDescendant}}

--- a/packages/ember-toucan-core/src/components/form/controls/multiselect.hbs
+++ b/packages/ember-toucan-core/src/components/form/controls/multiselect.hbs
@@ -14,7 +14,7 @@
     {{! Disabling this rule as the user interacts with the input directly. The click on the div is simply for convenience. }}
     {{! template-lint-disable no-invalid-interactive }}
     <div
-      class="bg-overlay-1 text-titles-and-attributes flex min-h-[2.5rem] items-center justify-between rounded-sm p-1 transition-shadow
+      class="bg-overlay-1 text-titles-and-attributes flex min-h-[2.5rem] w-full items-center justify-between rounded-sm p-1 transition-shadow
         {{this.styles}}"
       {{on
         "click"

--- a/packages/ember-toucan-core/src/components/form/fields/input.hbs
+++ b/packages/ember-toucan-core/src/components/form/fields/input.hbs
@@ -50,6 +50,7 @@
         id={{field.id}}
         aria-describedby="{{if @hint field.hintId}} {{if @error field.errorId}}"
         aria-invalid={{if @error "true"}}
+        class="w-full"
         @isDisabled={{@isDisabled}}
         @isReadOnly={{@isReadOnly}}
         @value={{@value}}

--- a/packages/ember-toucan-core/src/components/form/fields/textarea.hbs
+++ b/packages/ember-toucan-core/src/components/form/fields/textarea.hbs
@@ -49,6 +49,7 @@
       <Form::Controls::Textarea
         aria-invalid={{if @error "true"}}
         aria-describedby="{{if @error field.errorId}} {{if @hint field.hintId}}"
+        class="w-full"
         id={{field.id}}
         @isDisabled={{@isDisabled}}
         @isReadOnly={{@isReadOnly}}


### PR DESCRIPTION
## 🚀 Description

- Adds `w-full` to all form elements
  - Went ahead and made this a breaking change (aka pre-1.0 `minor` update) to play it safe
- Adjusts the changeset demo to include character counter examples with maximum lengths
- Adjusts the changeset demo to be visually centered

---

## 🔬 How to Test

- View doc pages and verify everything looks good, or view the images below

---

## 📸 Images/Videos of Functionality

### New form layout


https://github.com/CrowdStrike/ember-toucan-core/assets/8069555/3c66eb59-1e97-4037-975b-debb1f975436



### Maximum length input example

<img width="531" alt="Screenshot 2023-07-25 at 8 31 42 AM" src="https://github.com/CrowdStrike/ember-toucan-core/assets/8069555/582231d1-2a10-4141-9712-5e452becff3e">

### Maximum length textarea example

<img width="480" alt="Screenshot 2023-07-25 at 8 37 10 AM" src="https://github.com/CrowdStrike/ember-toucan-core/assets/8069555/68aa9082-b0b0-4771-b35b-2d7446b41796">
