### PR TITLE
Remove the :remove named block and yield a :chip block instead

### DIFF
--- a/.changeset/bright-spies-share.md
+++ b/.changeset/bright-spies-share.md
@@ -17,10 +17,13 @@ It has a similar API to `Autocomplete`, but allows for selecting multiple option
 >
   <:noResults>No results</:noResults>
 
-  <!-- NOTE: The remove block is required and a Remove component's label is also required! -->
-  <:remove as |remove|>
-    <remove.Remove @label={{(concat 'Remove' ' ' remove.option.label)}} />
-  </:remove>
+  <!-- NOTE: The chip block is required and a Remove component's label is also required! -->
+  <:chip as |chip|>
+    <chip.Chip>
+      {{chip.option}}
+      <chip.Remove @label={{(concat 'Remove' ' ' chip.option)}} />
+    </chip.Chip>
+  </:chip>
 
   <:default as |multiselect|>
     <multiselect.Option>

--- a/.changeset/spicy-suits-pay.md
+++ b/.changeset/spicy-suits-pay.md
@@ -14,9 +14,12 @@ Added `form.Multiselect` support.
   >
     <:noResults>No results</:noResults>
 
-    <:remove as |remove|>
-      <remove.Remove @label={{(concat 'Remove' ' ' remove.option)}} />
-    </:remove>
+    <:chip as |chip|>
+      <chip.Chip>
+        {{chip.option}}
+        <chip.Remove @label={{(concat 'Remove' ' ' chip.option)}} />
+      </chip.Chip>
+    </:chip>
 
     <:default as |multiselect|>
       <multiselect.Option>{{multiselect.option}}</multiselect.Option>

--- a/.changeset/warm-planes-fix.md
+++ b/.changeset/warm-planes-fix.md
@@ -15,10 +15,13 @@ Added `MultiselectField` component - it's the Multiselect control wrapped around
 >
   <:noResults>No results</:noResults>
 
-  <!-- NOTE: The remove block is required and a Remove component's label is also required! -->
-  <:remove as |remove|>
-    <remove.Remove @label={{(concat 'Remove' ' ' remove.option)}} />
-  </:remove>
+  <!-- NOTE: The chip block is required and a Remove component's `@label`` is also required! -->
+  <:chip as |chip|>
+    <chip.Chip>
+      {{chip.option}}
+      <chip.Remove @label={{(concat 'Remove' ' ' chip.option)}} />
+    </chip.Chip>
+  </:chip>
 
   <:default as |multiselect|>
     <multiselect.Option>

--- a/docs/components/multiselect-field/demo/base-demo.md
+++ b/docs/components/multiselect-field/demo/base-demo.md
@@ -11,9 +11,12 @@
   >
     <:noResults>No results</:noResults>
 
-    <:remove as |remove|>
-      <remove.Remove @label={{(concat 'Remove' ' ' remove.option)}} />
-    </:remove>
+    <:chip as |chip|>
+      <chip.Chip>
+        {{chip.option}}
+        <chip.Remove @label={{(concat 'Remove' ' ' chip.option)}} />
+      </chip.Chip>
+    </:chip>
 
     <:default as |multiselect|>
       <multiselect.Option>

--- a/docs/components/multiselect-field/index.md
+++ b/docs/components/multiselect-field/index.md
@@ -97,7 +97,7 @@ Provide a string to the `@hint` component argument or content to `:hint` named b
 
 Required.
 
-A `:chip` block is required and is used for rendering each selected option. The block returns the following:
+A `:chip` block is required and is used for rendering each selected option. The block has the following block parameters:
 
 - `index`: The index of the current chip
 - `option`: The raw option value for the current chip

--- a/docs/components/multiselect-field/index.md
+++ b/docs/components/multiselect-field/index.md
@@ -93,11 +93,29 @@ Provide a string to the `@hint` component argument or content to `:hint` named b
 </Form::Controls::Multiselect>
 ```
 
-## Remove Block
+## Chip Block
 
 Required.
 
-A `:remove` block is required and is used for the removal `X` on each selected chip. Clicking the button will remove the item from the selected options array. When the multiselect is disabled or in the readonly state, the button will not be available.
+A `:chip` block is required and is used for rendering each selected option. The block returns the following:
+
+- `index`: The index of the current chip
+- `option`: The raw option value for the current chip
+- `Chip`: The Chip component
+- `Remove`: The Remove component
+
+The `Chip` component allows for slight customization to the underlying chip.
+
+```hbs
+<:chip as |chip|>
+  <chip.Chip class='max-w-[4rem]' data-chip>
+    <CustomTruncationComponent>{{chip.option}}</CustomTruncationComponent>
+    <chip.Remove @label={{(concat 'Remove' ' ' chip.option)}} />
+  </chip.Chip>
+</:chip>
+```
+
+The `Remove` component contains the removal `X` on each selected chip. Clicking the button will remove the item from the selected options array. When the multiselect is disabled or in the readonly state, the button will not be available.
 
 A `@label` argument is **required** for accessibility reasons for the Remove component.
 
@@ -111,9 +129,12 @@ The `option` for that chip is yielded back to the consumer so that an appropriat
   @options={{this.options}}
   @selected={{this.selected}}
 >
-  <:remove as |remove|>
-    <remove.Remove @label={{(concat 'Remove' ' ' remove.option)}} />
-  </:remove>
+  <:chip as |chip|>
+    <chip.Chip>
+      {{chip.option}}
+      <chip.Remove @label={{(concat 'Remove' ' ' chip.option)}} />
+    </chip.Chip>
+  </:chip>
 
   <:default as |multiselect|>
     <multiselect.Option>
@@ -133,9 +154,12 @@ An example with translations may be something like:
   @options={{this.options}}
   @selected={{this.selected}}
 >
-  <:remove as |remove|>
-    <remove.Remove @label={{(t 'some-key' name=remove.option)}} />
-  </:remove>
+  <:chip as |chip|>
+    <chip.Chip>
+      {{chip.option}}
+      <chip.Remove @label={{(t 'some-key' name=remove.option)}} />
+    </chip.Chip>
+  </:chip>
 
   <:default as |multiselect|>
     <multiselect.Option>
@@ -271,7 +295,7 @@ export default class extends Component {
 
 Optional.
 
-The built-in filtering does simple `String.prototype.startsWith` filtering. 
+The built-in filtering does simple `String.prototype.startsWith` filtering.
 Specify `onFilter` if you want to do something different.
 
 ```hbs
@@ -393,9 +417,12 @@ Target the error block via `data-error`.
     @label='Label'
   >
     <:noResults>No results</:noResults>
-    <:remove as |remove|>
-      <remove.Remove @label="Remove" />
-    </:remove>
+    <:chip as |chip|>
+      <chip.Chip>
+        {{chip.option}}
+        <chip.Remove @label="Remove" />
+      </chip.Chip>
+    </:chip>
     <:default as |multiselect|>
       <multiselect.Option>
         {{multiselect.option}}
@@ -413,9 +440,12 @@ Target the error block via `data-error`.
     @hint="Hint"
   >
     <:noResults>No results</:noResults>
-    <:remove as |remove|>
-      <remove.Remove @label="Remove" />
-    </:remove>
+    <:chip as |chip|>
+      <chip.Chip>
+        {{chip.option}}
+        <chip.Remove @label="Remove" />
+      </chip.Chip>
+    </:chip>
     <:default as |multiselect|>
       <multiselect.Option>
         {{multiselect.option}}
@@ -433,9 +463,12 @@ Target the error block via `data-error`.
     <:label>Label <svg class="inline w-4 h-4" xmlns="http://www.w3.org/2000/svg" width="24" height="24" stroke="currentColor" viewBox="0 0 24 24"><path d="M12 3a9 9 0 11-6.364 2.636A8.972 8.972 0 0112 3zm0 4.7v5.2m0 3.39v.01" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg></:label>
     <:hint>Hint text <a href="https://www.crowdstrike.com/">link</a></:hint>
     <:noResults>No results</:noResults>
-    <:remove as |remove|>
-      <remove.Remove @label="Remove" />
-    </:remove>
+    <:chip as |chip|>
+      <chip.Chip>
+        {{chip.option}}
+        <chip.Remove @label="Remove" />
+      </chip.Chip>
+    </:chip>
     <:default as |multiselect|>
       <multiselect.Option>
         {{multiselect.option}}
@@ -453,9 +486,12 @@ Target the error block via `data-error`.
     @error='With error text'
   >
     <:noResults>No results</:noResults>
-    <:remove as |remove|>
-      <remove.Remove @label="Remove" />
-    </:remove>
+    <:chip as |chip|>
+      <chip.Chip>
+        {{chip.option}}
+        <chip.Remove @label="Remove" />
+      </chip.Chip>
+    </:chip>
     <:default as |multiselect|>
       <multiselect.Option>
         {{multiselect.option}}
@@ -474,9 +510,12 @@ Target the error block via `data-error`.
     @error='With error text'
   >
     <:noResults>No results</:noResults>
-    <:remove as |remove|>
-      <remove.Remove @label="Remove" />
-    </:remove>
+    <:chip as |chip|>
+      <chip.Chip>
+        {{chip.option}}
+        <chip.Remove @label="Remove" />
+      </chip.Chip>
+    </:chip>
     <:default as |multiselect|>
       <multiselect.Option>
         {{multiselect.option}}
@@ -494,9 +533,12 @@ Target the error block via `data-error`.
     @isDisabled={{true}}
   >
     <:noResults>No results</:noResults>
-    <:remove as |remove|>
-      <remove.Remove @label="Remove" />
-    </:remove>
+    <:chip as |chip|>
+      <chip.Chip>
+        {{chip.option}}
+        <chip.Remove @label="Remove" />
+      </chip.Chip>
+    </:chip>
     <:default as |multiselect|>
       <multiselect.Option>
         {{multiselect.option}}
@@ -516,9 +558,12 @@ Target the error block via `data-error`.
     @options={{(array 'blue' 'red')}}
   >
     <:noResults>No results</:noResults>
-    <:remove as |remove|>
-      <remove.Remove @label="Remove" />
-    </:remove>
+    <:chip as |chip|>
+      <chip.Chip>
+        {{chip.option}}
+        <chip.Remove @label="Remove" />
+      </chip.Chip>
+    </:chip>
     <:default as |multiselect|>
       <multiselect.Option>
         {{multiselect.option}}
@@ -536,9 +581,12 @@ Target the error block via `data-error`.
     @error={{(array 'With error 1' 'With error 2' 'With error 3')}}
   >
     <:noResults>No results</:noResults>
-    <:remove as |remove|>
-      <remove.Remove @label="Remove" />
-    </:remove>
+    <:chip as |chip|>
+      <chip.Chip>
+        {{chip.option}}
+        <chip.Remove @label="Remove" />
+      </chip.Chip>
+    </:chip>
     <:default as |multiselect|>
       <multiselect.Option>
         {{multiselect.option}}
@@ -556,9 +604,12 @@ Target the error block via `data-error`.
     @isReadOnly={{true}}
   >
     <:noResults>No results</:noResults>
-    <:remove as |remove|>
-      <remove.Remove @label="Remove" />
-    </:remove>
+    <:chip as |chip|>
+      <chip.Chip>
+        {{chip.option}}
+        <chip.Remove @label="Remove" />
+      </chip.Chip>
+    </:chip>
     <:default as |multiselect|>
       <multiselect.Option>
         {{multiselect.option}}
@@ -578,9 +629,12 @@ Target the error block via `data-error`.
     @options={{(array 'blue' 'red')}}
   >
     <:noResults>No results</:noResults>
-    <:remove as |remove|>
-      <remove.Remove @label="Remove" />
-    </:remove>
+    <:chip as |chip|>
+      <chip.Chip>
+        {{chip.option}}
+        <chip.Remove @label="Remove" />
+      </chip.Chip>
+    </:chip>
     <:default as |multiselect|>
       <multiselect.Option>
         {{multiselect.option}}

--- a/docs/components/multiselect/demo/base-demo.md
+++ b/docs/components/multiselect/demo/base-demo.md
@@ -9,9 +9,12 @@
   >
     <:noResults>No results</:noResults>
 
-    <:remove as |remove|>
-      <remove.Remove @label={{(concat 'Remove' ' ' remove.option)}} />
-    </:remove>
+    <:chip as |chip|>
+      <chip.Chip>
+        {{chip.option}}
+        <chip.Remove @label={{(concat 'Remove' ' ' chip.option)}} />
+      </chip.Chip>
+    </:chip>
 
     <:default as |multiselect|>
       <multiselect.Option>
@@ -29,9 +32,12 @@
   >
     <:noResults>No results</:noResults>
 
-    <:remove as |remove|>
-      <remove.Remove @label={{(concat 'Remove' ' ' remove.option)}} />
-    </:remove>
+    <:chip as |chip|>
+      <chip.Chip>
+        {{chip.option}}
+        <chip.Remove @label={{(concat 'Remove' ' ' chip.option)}} />
+      </chip.Chip>
+    </:chip>
 
     <:default as |multiselect|>
       <multiselect.Option>
@@ -50,9 +56,12 @@
   >
     <:noResults>No results</:noResults>
 
-    <:remove as |remove|>
-      <remove.Remove @label={{(concat 'Remove' ' ' remove.option)}} />
-    </:remove>
+    <:chip as |chip|>
+      <chip.Chip>
+        {{chip.option}}
+        <chip.Remove @label={{(concat 'Remove' ' ' chip.option)}} />
+      </chip.Chip>
+    </:chip>
 
     <:default as |multiselect|>
       <multiselect.Option>
@@ -149,8 +158,8 @@ export default class extends Component {
     return value === ''
       ? this.options
       : this.options.filter((option) =>
-        option.toLowerCase().includes(value.toLowerCase())
-      );
+          option.toLowerCase().includes(value.toLowerCase())
+        );
   }
 }
 ```

--- a/docs/components/multiselect/index.md
+++ b/docs/components/multiselect/index.md
@@ -11,9 +11,29 @@ A CSS class to add to this component's content container. Commonly used to speci
 <Form::Controls::Multiselect @contentClass='z-50' />
 ```
 
-## Remove Block
+## Chip Block
 
-A `:remove` block is required and is used for the removal `X` on each selected chip. Clicking the button will remove the item from the selected options array. When the multiselect is disabled or in the readonly state, the button will not be available.
+Required.
+
+A `:chip` block is required and is used for rendering each selected option. The block returns the following:
+
+- `index`: The index of the current chip
+- `option`: The raw option value for the current chip
+- `Chip`: The Chip component
+- `Remove`: The Remove component
+
+The `Chip` component allows for slight customization to the underlying chip.
+
+```hbs
+<:chip as |chip|>
+  <chip.Chip class='max-w-[4rem]' data-chip>
+    <CustomTruncationComponent>{{chip.option}}</CustomTruncationComponent>
+    <chip.Remove @label={{(concat 'Remove' ' ' chip.option)}} />
+  </chip.Chip>
+</:chip>
+```
+
+The `Remove` component contains the removal `X` on each selected chip. Clicking the button will remove the item from the selected options array. When the multiselect is disabled or in the readonly state, the button will not be available.
 
 A `@label` argument is **required** for accessibility reasons for the Remove component.
 
@@ -29,9 +49,12 @@ The `option` for that chip is yielded back to the consumer so that an appropriat
 >
   <:noResults>No results</:noResults>
 
-  <:remove as |remove|>
-    <remove.Remove @label={{(concat 'Remove' ' ' remove.option)}} />
-  </:remove>
+  <:chip as |chip|>
+    <chip.Chip>
+      {{chip.option}}
+      <chip.Remove @label={{(concat 'Remove' ' ' chip.option)}} />
+    </chip.Chip>
+  </:chip>
 
   <:default as |multiselect|>
     <multiselect.Option>
@@ -53,9 +76,12 @@ An example with translations may be something like:
 >
   <:noResults>No results</:noResults>
 
-  <:remove as |remove|>
-    <remove.Remove @label={{(t 'some-key' name=remove.option)}} />
-  </:remove>
+  <:chip as |chip|>
+    <chip.Chip>
+      {{chip.option}}
+      <chip.Remove @label={{(t 'some-key' name=remove.option)}} />
+    </chip.Chip>
+  </:chip>
 
   <:default as |multiselect|>
     <multiselect.Option>
@@ -80,9 +106,12 @@ A `:noResults` block is required and exposed to allow consumers to specify text 
   <!-- NOTE: Only text should go here. Please do not render content! -->
   <:noResults>No results</:noResults>
 
-  <:remove as |remove|>
-    <remove.Remove @label={{(concat 'Remove' ' ' remove.option)}} />
-  </:remove>
+  <:chip as |chip|>
+    <chip.Chip>
+      {{chip.option}}
+      <chip.Remove @label={{(concat 'Remove' ' ' chip.option)}} />
+    </chip.Chip>
+  </:chip>
 
   <:default as |multiselect|>
     <multiselect.Option>
@@ -94,7 +123,7 @@ A `:noResults` block is required and exposed to allow consumers to specify text 
 
 ## Options
 
-`@options` forms the content of this component. 
+`@options` forms the content of this component.
 
 ```hbs
 <Form::Controls::Multiselect @options={{this.options}}>
@@ -171,7 +200,7 @@ export default class extends Component {
 
 Optional.
 
-The built-in filtering does simple `String.prototype.startsWith` filtering. 
+The built-in filtering does simple `String.prototype.startsWith` filtering.
 Specify `onFilter` if you want to do something different.
 
 ```hbs

--- a/docs/toucan-form/changeset-validation/demo/base-demo.md
+++ b/docs/toucan-form/changeset-validation/demo/base-demo.md
@@ -43,45 +43,12 @@
       <group.RadioField @label='Broccoli' @value='broccoli' data-radio-2 />
     </form.RadioGroup>
 
-    <form.Autocomplete
-      @contentClass='z-10'
-      @label='Color'
-      @name='color'
-      @noResultsText='No results'
-      @options={{this.options}}
-      as |autocomplete|
-    >
-      <autocomplete.Option>
-        {{autocomplete.option}}
-      </autocomplete.Option>
-    </form.Autocomplete>
-
-    <form.Multiselect
-      @contentClass='z-10'
-      @label='Multiselect'
-      @name='multiselect'
-      @optionKey='label'
-      @options={{this.options}}
-    >
-      <:noResults>No results</:noResults>
-
-      <:remove as |remove|>
-        <remove.Remove @label={{(concat 'Remove' ' ' remove.option.label)}} />
-      </:remove>
-
-      <:default as |multiselect|>
-        <multiselect.Option>{{multiselect.option.label}}</multiselect.Option>
-      </:default>
-    </form.Multiselect>
-
     <form.FileInput
       @label='Files to attach'
       @trigger='Select files'
       @deleteLabel='Delete'
       @name='files'
     />
-
-    <form.Checkbox @label='Agree to the Terms' @name='terms' />
 
     <form.Autocomplete
       @contentClass='z-10'
@@ -104,21 +71,17 @@
     >
       <:noResults>No results</:noResults>
 
-      <:remove as |remove|>
-        <remove.Remove @label={{(concat 'Remove' ' ' remove.option.label)}} />
-      </:remove>
+      <:chip as |chip|>
+        <chip.Chip>
+          {{chip.option}}
+          <chip.Remove @label={{(concat 'Remove' ' ' chip.option)}} />
+        </chip.Chip>
+      </:chip>
 
       <:default as |multiselect|>
-        <multiselect.Option>{{multiselect.option.label}}</multiselect.Option>
+        <multiselect.Option>{{multiselect.option}}</multiselect.Option>
       </:default>
     </form.Multiselect>
-
-    <form.FileInput
-      @label='Files to attach'
-      @trigger='Select files'
-      @deleteLabel='Delete'
-      @name='files'
-    />
 
     <form.Checkbox @label='Agree to the Terms' @name='terms' />
 
@@ -181,7 +144,7 @@ export default class extends Component {
       label: 'Teal',
       value: 'teal',
     },
-  ];
+  ].map(({ label }) => label);
 
   handleSubmit(data) {
     console.log({ data: data.get('pendingData') });

--- a/packages/ember-toucan-core/src/-private/components/form/controls/multiselect/chip.hbs
+++ b/packages/ember-toucan-core/src/-private/components/form/controls/multiselect/chip.hbs
@@ -1,0 +1,8 @@
+<div
+  class="min-h-6 bg-normal-idle flex items-center gap-x-2.5 rounded-sm px-2 py-1"
+  data-index={{@index}}
+  data-multiselect-selected-option
+  ...attributes
+>
+  {{yield}}
+</div>

--- a/packages/ember-toucan-core/src/-private/components/form/controls/multiselect/chip.ts
+++ b/packages/ember-toucan-core/src/-private/components/form/controls/multiselect/chip.ts
@@ -1,0 +1,16 @@
+import templateOnlyComponent from '@ember/component/template-only';
+
+export interface ToucanFormMultiselectChipComponent {
+  Args: {
+    /**
+     * The index of the chip based on the selected options.
+     */
+    index?: number;
+  };
+  Blocks: {
+    default: [];
+  };
+  Element: HTMLDivElement;
+}
+
+export default templateOnlyComponent<ToucanFormMultiselectChipComponent>();

--- a/packages/ember-toucan-core/src/-private/components/form/controls/multiselect/remove.hbs
+++ b/packages/ember-toucan-core/src/-private/components/form/controls/multiselect/remove.hbs
@@ -1,14 +1,16 @@
-{{! We have to use mousedown here to prevent default. Up does not work the same. }}
-{{!  template-lint-disable no-pointer-down-event-binding }}
-<button
-  aria-label={{@label}}
-  {{! TODO: remove reset-styles https://github.com/CrowdStrike/ember-oss-docs/issues/17 }}
-  class="focusable reset-styles p-1"
-  data-multiselect-remove-option
-  type="button"
-  {{on "click" @onClick}}
-  {{on "mousedown" @onMouseDown}}
-  ...attributes
->
-  <this.Cross />
-</button>
+{{#if @isVisible}}
+  {{! We have to use mousedown here to prevent default. Up does not work the same. }}
+  {{!  template-lint-disable no-pointer-down-event-binding }}
+  <button
+    aria-label={{@label}}
+    {{! TODO: remove reset-styles https://github.com/CrowdStrike/ember-oss-docs/issues/17 }}
+    class="focusable reset-styles p-1"
+    data-multiselect-remove-option
+    type="button"
+    {{on "click" @onClick}}
+    {{on "mousedown" @onMouseDown}}
+    ...attributes
+  >
+    <this.Cross />
+  </button>
+{{/if}}

--- a/packages/ember-toucan-core/src/-private/components/form/controls/multiselect/remove.ts
+++ b/packages/ember-toucan-core/src/-private/components/form/controls/multiselect/remove.ts
@@ -6,6 +6,12 @@ import Cross from '../../../../../-private/icons/cross';
 interface ToucanFormMultiselectRemoveComponentSignature {
   Args: {
     /**
+     * Determines if the component should be displayed or not.  When the multiselect
+     * is disabled or readonly, the remove button is not displayed.
+     */
+    isVisible?: boolean;
+
+    /**
      * Maps to the `aria-label` attribute of the button. Used for screenreaders.
      */
     label?: string;

--- a/packages/ember-toucan-core/src/components/form/controls/multiselect.hbs
+++ b/packages/ember-toucan-core/src/components/form/controls/multiselect.hbs
@@ -1,7 +1,7 @@
 {{#if
   (this.assertRequiredBlocksExist
     (hash
-      removeBlockExists=(has-block "remove")
+      chipBlockExists=(has-block "chip")
       noResultsBlockExists=(has-block "noResults")
     )
   )
@@ -29,28 +29,22 @@
     >
       <div class="flex w-full flex-wrap gap-1">
         {{#each this.selected as |option index|}}
-          <div
-            class="min-h-6 bg-normal-idle flex items-center gap-x-2.5 rounded-sm px-2 py-1"
-            data-multiselect-selected-option
-          >
-            <span class="block">
-              {{option}}
-            </span>
-
-            {{#if this.isEnabled}}
-              {{yield
-                (hash
-                  option=option
-                  Remove=(component
-                    (ensure-safe-component this.RemoveComponent)
-                    onClick=(fn this.removeSelection index)
-                    onMouseDown=this.handleRemoveMouseDown
-                  )
-                )
-                to="remove"
-              }}
-            {{/if}}
-          </div>
+          {{yield
+            (hash
+              index=index
+              option=option
+              Chip=(component
+                (ensure-safe-component this.ChipComponent) index=index
+              )
+              Remove=(component
+                (ensure-safe-component this.RemoveComponent)
+                onClick=(fn this.removeSelection index)
+                onMouseDown=this.handleRemoveMouseDown
+                isVisible=this.isEnabled
+              )
+            )
+            to="chip"
+          }}
         {{/each}}
 
         {{! template-lint-disable no-redundant-role }}

--- a/packages/ember-toucan-core/src/components/form/controls/multiselect.ts
+++ b/packages/ember-toucan-core/src/components/form/controls/multiselect.ts
@@ -8,6 +8,7 @@ import { isEqual as emberIsEqual } from '@ember/utils';
 
 import { offset, size } from '@floating-ui/dom';
 
+import ChipComponent from '../../../-private/components/form/controls/multiselect/chip';
 import OptionComponent, {
   selector as optionComponentSelector,
 } from '../../../-private/components/form/controls/multiselect/option';
@@ -65,9 +66,43 @@ export interface ToucanFormMultiselectControlComponentSignature {
     selected?: string[];
   };
   Blocks: {
+    chip: [
+      {
+        /**
+         * The selected option index.
+         */
+        index: number;
+
+        /**
+         * The selected option value.
+         */
+        option: string;
+
+        /**
+         * The Chip component used to render an option.
+         */
+        Chip: WithBoundArgs<typeof ChipComponent, 'index'>;
+
+        /**
+         * The Chip component's remove button component.  It is only displayed
+         * if the multiselect is not in a readonly or disabled state.
+         */
+        Remove: WithBoundArgs<
+          typeof RemoveComponent,
+          'isVisible' | 'onClick' | 'onMouseDown'
+        >;
+      }
+    ];
     default: [
       {
+        /**
+         * The selected option value.
+         */
         option: string;
+
+        /**
+         * The Option component rendered inside of the popover list.
+         */
         Option: WithBoundArgs<
           typeof OptionComponent,
           | 'index'
@@ -81,15 +116,6 @@ export interface ToucanFormMultiselectControlComponentSignature {
       }
     ];
     noResults: [];
-    remove: [
-      {
-        option: string;
-        Remove: WithBoundArgs<
-          typeof RemoveComponent,
-          'onClick' | 'onMouseDown'
-        >;
-      }
-    ];
   };
   Element: HTMLInputElement;
 }
@@ -103,23 +129,25 @@ export default class ToucanFormMultiselectControlComponent extends Component<Tou
   Chevron = Chevron;
   Cross = Cross;
   Option = OptionComponent;
+  ChipComponent = ChipComponent;
   RemoveComponent = RemoveComponent;
   popoverId = `popover--${guidFor(this)}`;
 
   /**
-   * The component requires the `:remove` block for accessibility reasons.
+   * The component requires these blocks to properly construct the
+   * multiselect.
    */
   assertRequiredBlocksExist = ({
-    removeBlockExists,
+    chipBlockExists,
     noResultsBlockExists,
   }: {
-    removeBlockExists: boolean;
+    chipBlockExists: boolean;
     noResultsBlockExists: boolean;
   }) => {
-    assert('The `:remove` block is required.', removeBlockExists);
+    assert('The `:chip` block is required.', chipBlockExists);
     assert('The `:noResults` block is required.', noResultsBlockExists);
 
-    return removeBlockExists && noResultsBlockExists;
+    return chipBlockExists && noResultsBlockExists;
   };
 
   velcroMiddleware: VelcroMiddleware[] = [

--- a/packages/ember-toucan-core/src/components/form/fields/multiselect.hbs
+++ b/packages/ember-toucan-core/src/components/form/fields/multiselect.hbs
@@ -61,15 +61,17 @@
       >
         <:noResults>{{yield to="noResults"}}</:noResults>
 
-        <:remove as |remove|>
+        <:chip as |chip|>
           {{yield
             (hash
-              Remove=(component (ensure-safe-component remove.Remove))
-              option=remove.option
+              index=chip.index
+              option=chip.option
+              Chip=(component (ensure-safe-component chip.Chip))
+              Remove=(component (ensure-safe-component chip.Remove))
             )
-            to="remove"
+            to="chip"
           }}
-        </:remove>
+        </:chip>
 
         <:default as |multiselect|>
           {{yield

--- a/packages/ember-toucan-core/src/components/form/fields/multiselect.ts
+++ b/packages/ember-toucan-core/src/components/form/fields/multiselect.ts
@@ -5,9 +5,7 @@ import LockIcon from '../../../-private/icons/lock';
 
 import type { AssertBlockOrArg } from '../../../-private/assert-block-or-argument-exists';
 import type { ErrorMessage } from '../../../-private/types';
-import type {
-  ToucanFormMultiselectControlComponentSignature,
-} from '../controls/multiselect';
+import type { ToucanFormMultiselectControlComponentSignature } from '../controls/multiselect';
 
 export interface ToucanFormMultiselectFieldComponentSignature {
   Element: HTMLInputElement;
@@ -73,11 +71,11 @@ export interface ToucanFormMultiselectFieldComponentSignature {
     selected?: ToucanFormMultiselectControlComponentSignature['Args']['selected'];
   };
   Blocks: {
+    chip: ToucanFormMultiselectControlComponentSignature['Blocks']['chip'];
     default: ToucanFormMultiselectControlComponentSignature['Blocks']['default'];
     hint: [];
     label: [];
     noResults: ToucanFormMultiselectControlComponentSignature['Blocks']['noResults'];
-    remove: ToucanFormMultiselectControlComponentSignature['Blocks']['remove'];
   };
 }
 

--- a/packages/ember-toucan-form/src/-private/multiselect-field.hbs
+++ b/packages/ember-toucan-form/src/-private/multiselect-field.hbs
@@ -38,15 +38,17 @@
 
       <:noResults>{{yield to='noResults'}}</:noResults>
 
-      <:remove as |remove|>
+      <:chip as |chip|>
         {{yield
           (hash
-            Remove=(component (ensure-safe-component remove.Remove))
-            option=remove.option
+            index=chip.index
+            option=chip.option
+            Chip=(component (ensure-safe-component chip.Chip))
+            Remove=(component (ensure-safe-component chip.Remove))
           )
-          to='remove'
+          to='chip'
         }}
-      </:remove>
+      </:chip>
 
       <:default as |multiselect|>
         {{yield
@@ -80,15 +82,17 @@
 
       <:noResults>{{yield to='noResults'}}</:noResults>
 
-      <:remove as |remove|>
+      <:chip as |chip|>
         {{yield
           (hash
-            Remove=(component (ensure-safe-component remove.Remove))
-            option=remove.option
+            index=chip.index
+            option=chip.option
+            Chip=(component (ensure-safe-component chip.Chip))
+            Remove=(component (ensure-safe-component chip.Remove))
           )
-          to='remove'
+          to='chip'
         }}
-      </:remove>
+      </:chip>
 
       <:default as |multiselect|>
         {{yield
@@ -120,15 +124,17 @@
 
       <:noResults>{{yield to='noResults'}}</:noResults>
 
-      <:remove as |remove|>
+      <:chip as |chip|>
         {{yield
           (hash
-            Remove=(component (ensure-safe-component remove.Remove))
-            option=remove.option
+            index=chip.index
+            option=chip.option
+            Chip=(component (ensure-safe-component chip.Chip))
+            Remove=(component (ensure-safe-component chip.Remove))
           )
-          to='remove'
+          to='chip'
         }}
-      </:remove>
+      </:chip>
 
       <:default as |multiselect|>
         {{yield
@@ -159,15 +165,17 @@
     >
       <:noResults>{{yield to='noResults'}}</:noResults>
 
-      <:remove as |remove|>
+      <:chip as |chip|>
         {{yield
           (hash
-            Remove=(component (ensure-safe-component remove.Remove))
-            option=remove.option
+            index=chip.index
+            option=chip.option
+            Chip=(component (ensure-safe-component chip.Chip))
+            Remove=(component (ensure-safe-component chip.Remove))
           )
-          to='remove'
+          to='chip'
         }}
-      </:remove>
+      </:chip>
 
       <:default as |multiselect|>
         {{yield

--- a/test-app/tests/integration/components/multiselect-field-test.gts
+++ b/test-app/tests/integration/components/multiselect-field-test.gts
@@ -14,9 +14,12 @@ module('Integration | Component | Fields | Multiselect', function (hooks) {
       <Multiselect @label="Label" @options={{testColors}} data-multiselect>
         <:noResults>No results</:noResults>
 
-        <:remove as |remove|>
-          <remove.Remove @label="Remove" />
-        </:remove>
+        <:chip as |chip|>
+          <chip.Chip>
+            {{chip.option}}
+            <chip.Remove @label="Remove" />
+          </chip.Chip>
+        </:chip>
 
         <:default as |multiselect|>
           <multiselect.Option>{{multiselect.option}}</multiselect.Option>
@@ -54,9 +57,12 @@ module('Integration | Component | Fields | Multiselect', function (hooks) {
       >
         <:noResults>No results</:noResults>
 
-        <:remove as |remove|>
-          <remove.Remove @label="Remove" />
-        </:remove>
+        <:chip as |chip|>
+          <chip.Chip>
+            {{chip.option}}
+            <chip.Remove @label="Remove" />
+          </chip.Chip>
+        </:chip>
 
         <:default as |multiselect|>
           <multiselect.Option>{{multiselect.option}}</multiselect.Option>
@@ -90,9 +96,12 @@ module('Integration | Component | Fields | Multiselect', function (hooks) {
 
         <:noResults>No results</:noResults>
 
-        <:remove as |remove|>
-          <remove.Remove @label="Remove" />
-        </:remove>
+        <:chip as |chip|>
+          <chip.Chip>
+            {{chip.option}}
+            <chip.Remove @label="Remove" />
+          </chip.Chip>
+        </:chip>
 
         <:default as |multiselect|>
           <multiselect.Option>{{multiselect.option}}</multiselect.Option>
@@ -114,9 +123,12 @@ module('Integration | Component | Fields | Multiselect', function (hooks) {
       >
         <:noResults>No results</:noResults>
 
-        <:remove as |remove|>
-          <remove.Remove @label="Remove" />
-        </:remove>
+        <:chip as |chip|>
+          <chip.Chip>
+            {{chip.option}}
+            <chip.Remove @label="Remove" />
+          </chip.Chip>
+        </:chip>
 
         <:default as |multiselect|>
           <multiselect.Option>{{multiselect.option}}</multiselect.Option>
@@ -163,9 +175,12 @@ module('Integration | Component | Fields | Multiselect', function (hooks) {
       >
         <:noResults>No results</:noResults>
 
-        <:remove as |remove|>
-          <remove.Remove @label="Remove" />
-        </:remove>
+        <:chip as |chip|>
+          <chip.Chip>
+            {{chip.option}}
+            <chip.Remove @label="Remove" />
+          </chip.Chip>
+        </:chip>
 
         <:default as |multiselect|>
           <multiselect.Option>{{multiselect.option}}</multiselect.Option>
@@ -196,9 +211,12 @@ module('Integration | Component | Fields | Multiselect', function (hooks) {
       >
         <:noResults>No results</:noResults>
 
-        <:remove as |remove|>
-          <remove.Remove @label="Remove" />
-        </:remove>
+        <:chip as |chip|>
+          <chip.Chip>
+            {{chip.option}}
+            <chip.Remove @label="Remove" />
+          </chip.Chip>
+        </:chip>
 
         <:default as |multiselect|>
           <multiselect.Option>{{multiselect.option}}</multiselect.Option>
@@ -222,9 +240,12 @@ module('Integration | Component | Fields | Multiselect', function (hooks) {
       >
         <:noResults>No results</:noResults>
 
-        <:remove as |remove|>
-          <remove.Remove @label="Remove" />
-        </:remove>
+        <:chip as |chip|>
+          <chip.Chip>
+            {{chip.option}}
+            <chip.Remove @label="Remove" />
+          </chip.Chip>
+        </:chip>
 
         <:default as |multiselect|>
           <multiselect.Option>{{multiselect.option}}</multiselect.Option>
@@ -247,9 +268,12 @@ module('Integration | Component | Fields | Multiselect', function (hooks) {
       >
         <:noResults>No results</:noResults>
 
-        <:remove as |remove|>
-          <remove.Remove @label="Remove" />
-        </:remove>
+        <:chip as |chip|>
+          <chip.Chip>
+            {{chip.option}}
+            <chip.Remove @label="Remove" />
+          </chip.Chip>
+        </:chip>
 
         <:default as |multiselect|>
           <multiselect.Option>{{multiselect.option}}</multiselect.Option>
@@ -272,9 +296,12 @@ module('Integration | Component | Fields | Multiselect', function (hooks) {
       >
         <:noResults>No results</:noResults>
 
-        <:remove as |remove|>
-          <remove.Remove @label="Remove" />
-        </:remove>
+        <:chip as |chip|>
+          <chip.Chip>
+            {{chip.option}}
+            <chip.Remove @label="Remove" />
+          </chip.Chip>
+        </:chip>
 
         <:default as |multiselect|>
           <multiselect.Option>{{multiselect.option}}</multiselect.Option>
@@ -296,9 +323,12 @@ module('Integration | Component | Fields | Multiselect', function (hooks) {
       >
         <:noResults>No results</:noResults>
 
-        <:remove as |remove|>
-          <remove.Remove @label="Remove" />
-        </:remove>
+        <:chip as |chip|>
+          <chip.Chip>
+            {{chip.option}}
+            <chip.Remove @label="Remove" />
+          </chip.Chip>
+        </:chip>
 
         <:default as |multiselect|>
           <multiselect.Option>{{multiselect.option}}</multiselect.Option>
@@ -368,9 +398,12 @@ module('Integration | Component | Fields | Multiselect', function (hooks) {
       <Multiselect @options={{testColors}} data-multiselect>
         <:noResults>No results</:noResults>
 
-        <:remove as |remove|>
-          <remove.Remove @label="Remove" />
-        </:remove>
+        <:chip as |chip|>
+          <chip.Chip>
+            {{chip.option}}
+            <chip.Remove @label="Remove" />
+          </chip.Chip>
+        </:chip>
 
         <:default as |multiselect|>
           <multiselect.Option>{{multiselect.option}}</multiselect.Option>
@@ -396,9 +429,12 @@ module('Integration | Component | Fields | Multiselect', function (hooks) {
         <:label>Label</:label>
         <:noResults>No results</:noResults>
 
-        <:remove as |remove|>
-          <remove.Remove @label="Remove" />
-        </:remove>
+        <:chip as |chip|>
+          <chip.Chip>
+            {{chip.option}}
+            <chip.Remove @label="Remove" />
+          </chip.Chip>
+        </:chip>
 
         <:default as |multiselect|>
           <multiselect.Option>{{multiselect.option}}</multiselect.Option>

--- a/test-app/tests/integration/components/multiselect-test.gts
+++ b/test-app/tests/integration/components/multiselect-test.gts
@@ -20,9 +20,12 @@ module('Integration | Component | Multiselect', function (hooks) {
       <Multiselect @options={{testColors}} data-multiselect>
         <:noResults>No results</:noResults>
 
-        <:remove as |remove|>
-          <remove.Remove @label="Remove" />
-        </:remove>
+        <:chip as |chip|>
+          <chip.Chip>
+            {{chip.option}}
+            <chip.Remove @label="Remove" />
+          </chip.Chip>
+        </:chip>
 
         <:default as |multiselect|>
           <multiselect.Option>{{multiselect.option}}</multiselect.Option>
@@ -66,9 +69,12 @@ module('Integration | Component | Multiselect', function (hooks) {
       >
         <:noResults>No results</:noResults>
 
-        <:remove as |remove|>
-          <remove.Remove @label="Remove" />
-        </:remove>
+        <:chip as |chip|>
+          <chip.Chip>
+            {{chip.option}}
+            <chip.Remove @label="Remove" />
+          </chip.Chip>
+        </:chip>
 
         <:default as |multiselect|>
           <multiselect.Option>{{multiselect.option}}</multiselect.Option>
@@ -92,9 +98,12 @@ module('Integration | Component | Multiselect', function (hooks) {
       >
         <:noResults>No results</:noResults>
 
-        <:remove as |remove|>
-          <remove.Remove @label="Remove" />
-        </:remove>
+        <:chip as |chip|>
+          <chip.Chip>
+            {{chip.option}}
+            <chip.Remove @label="Remove" />
+          </chip.Chip>
+        </:chip>
 
         <:default as |multiselect|>
           <multiselect.Option>{{multiselect.option}}</multiselect.Option>
@@ -123,9 +132,12 @@ module('Integration | Component | Multiselect', function (hooks) {
       >
         <:noResults>No results</:noResults>
 
-        <:remove as |remove|>
-          <remove.Remove @label="Remove" />
-        </:remove>
+        <:chip as |chip|>
+          <chip.Chip>
+            {{chip.option}}
+            <chip.Remove @label="Remove" />
+          </chip.Chip>
+        </:chip>
 
         <:default as |multiselect|>
           <multiselect.Option>{{multiselect.option}}</multiselect.Option>
@@ -143,9 +155,12 @@ module('Integration | Component | Multiselect', function (hooks) {
       <Multiselect @options={{testColors}} @hasError={{true}} data-multiselect>
         <:noResults>No results</:noResults>
 
-        <:remove as |remove|>
-          <remove.Remove @label="Remove" />
-        </:remove>
+        <:chip as |chip|>
+          <chip.Chip>
+            {{chip.option}}
+            <chip.Remove @label="Remove" />
+          </chip.Chip>
+        </:chip>
 
         <:default as |multiselect|>
           <multiselect.Option>{{multiselect.option}}</multiselect.Option>
@@ -167,9 +182,12 @@ module('Integration | Component | Multiselect', function (hooks) {
       <Multiselect @options={{testColors}} data-multiselect>
         <:noResults>No results</:noResults>
 
-        <:remove as |remove|>
-          <remove.Remove @label="Remove" />
-        </:remove>
+        <:chip as |chip|>
+          <chip.Chip>
+            {{chip.option}}
+            <chip.Remove @label="Remove" />
+          </chip.Chip>
+        </:chip>
 
         <:default as |multiselect|>
           <multiselect.Option>{{multiselect.option}}</multiselect.Option>
@@ -189,9 +207,12 @@ module('Integration | Component | Multiselect', function (hooks) {
       <Multiselect @options={{testColors}} data-multiselect>
         <:noResults>No results</:noResults>
 
-        <:remove as |remove|>
-          <remove.Remove @label="Remove" />
-        </:remove>
+        <:chip as |chip|>
+          <chip.Chip>
+            {{chip.option}}
+            <chip.Remove @label="Remove" />
+          </chip.Chip>
+        </:chip>
 
         <:default as |multiselect|>
           <multiselect.Option>{{multiselect.option}}</multiselect.Option>
@@ -213,9 +234,12 @@ module('Integration | Component | Multiselect', function (hooks) {
       <Multiselect @options={{testColors}} data-multiselect>
         <:noResults>No results</:noResults>
 
-        <:remove as |remove|>
-          <remove.Remove @label="Remove" />
-        </:remove>
+        <:chip as |chip|>
+          <chip.Chip>
+            {{chip.option}}
+            <chip.Remove @label="Remove" />
+          </chip.Chip>
+        </:chip>
 
         <:default as |multiselect|>
           <multiselect.Option>{{multiselect.option}}</multiselect.Option>
@@ -232,7 +256,7 @@ module('Integration | Component | Multiselect', function (hooks) {
     assert.dom('[role="listbox"]').exists();
   });
 
-  test('it yields the `:remove` block option and Remove component and sets the `@label` on the remove component', async function (assert) {
+  test('it yields the `option`, `index`, `Chip`, and `Remove` to the `:chip` block and sets the `@label` on the Remove component', async function (assert) {
     let selected = ['blue'];
 
     await render(<template>
@@ -243,9 +267,12 @@ module('Integration | Component | Multiselect', function (hooks) {
       >
         <:noResults>No results</:noResults>
 
-        <:remove as |remove|>
-          <remove.Remove @label="Remove" data-remove="{{remove.option}}" />
-        </:remove>
+        <:chip as |chip|>
+          <chip.Chip data-test-index="{{chip.index}}">
+            {{chip.option}}
+            <chip.Remove data-remove="{{chip.option}}" @label="Remove" />
+          </chip.Chip>
+        </:chip>
 
         <:default as |multiselect|>
           <multiselect.Option data-option>
@@ -255,15 +282,18 @@ module('Integration | Component | Multiselect', function (hooks) {
       </Multiselect>
     </template>);
 
-    // Verify the `remove.Remove` `@label` argument gets set to the aria-label properly
+    // Verify the `chip.Remove` `@label` argument gets set to the aria-label properly
     // for screenreaders.  Without an aria-label attribute, screenreader users
     // will have 0 context on what the button does.
     assert
       .dom('[data-multiselect-remove-option]')
       .hasAttribute('aria-label', 'Remove');
 
-    // Verify the `remove.option` gets yielded back properly via the `remove` block.
+    // Verify the `chip.option` gets yielded back properly via the `chip` block.
     assert.dom('[data-remove="blue"]').exists();
+
+    // Verify the chip index gets yielded back
+    assert.dom('[data-test-index="0"]').exists();
   });
 
   test('it sets `aria-expanded` based on the popover state', async function (assert) {
@@ -271,9 +301,12 @@ module('Integration | Component | Multiselect', function (hooks) {
       <Multiselect @options={{testColors}} data-multiselect>
         <:noResults>No results</:noResults>
 
-        <:remove as |remove|>
-          <remove.Remove @label="Remove" />
-        </:remove>
+        <:chip as |chip|>
+          <chip.Chip>
+            {{chip.option}}
+            <chip.Remove @label="Remove" />
+          </chip.Chip>
+        </:chip>
 
         <:default as |multiselect|>
           <multiselect.Option>{{multiselect.option}}</multiselect.Option>
@@ -295,9 +328,12 @@ module('Integration | Component | Multiselect', function (hooks) {
       <Multiselect @options={{testColors}} data-multiselect>
         <:noResults>No results</:noResults>
 
-        <:remove as |remove|>
-          <remove.Remove @label="Remove" />
-        </:remove>
+        <:chip as |chip|>
+          <chip.Chip>
+            {{chip.option}}
+            <chip.Remove @label="Remove" />
+          </chip.Chip>
+        </:chip>
 
         <:default as |multiselect|>
           <multiselect.Option>{{multiselect.option}}</multiselect.Option>
@@ -317,9 +353,12 @@ module('Integration | Component | Multiselect', function (hooks) {
       >
         <:noResults>No results</:noResults>
 
-        <:remove as |remove|>
-          <remove.Remove @label="Remove" />
-        </:remove>
+        <:chip as |chip|>
+          <chip.Chip>
+            {{chip.option}}
+            <chip.Remove @label="Remove" />
+          </chip.Chip>
+        </:chip>
 
         <:default as |multiselect|>
           <multiselect.Option>{{multiselect.option}}</multiselect.Option>
@@ -342,9 +381,12 @@ module('Integration | Component | Multiselect', function (hooks) {
       >
         <:noResults>No results</:noResults>
 
-        <:remove as |remove|>
-          <remove.Remove @label="Remove" />
-        </:remove>
+        <:chip as |chip|>
+          <chip.Chip>
+            {{chip.option}}
+            <chip.Remove @label="Remove" />
+          </chip.Chip>
+        </:chip>
 
         <:default as |multiselect|>
           <multiselect.Option
@@ -373,9 +415,12 @@ module('Integration | Component | Multiselect', function (hooks) {
       >
         <:noResults>No results</:noResults>
 
-        <:remove as |remove|>
-          <remove.Remove @label="Remove" />
-        </:remove>
+        <:chip as |chip|>
+          <chip.Chip>
+            {{chip.option}}
+            <chip.Remove @label="Remove" />
+          </chip.Chip>
+        </:chip>
 
         <:default as |multiselect|>
           <multiselect.Option>{{multiselect.option}}</multiselect.Option>
@@ -402,9 +447,12 @@ module('Integration | Component | Multiselect', function (hooks) {
       <Multiselect @selected={{selected}} @options={{options}} data-multiselect>
         <:noResults>No results</:noResults>
 
-        <:remove as |remove|>
-          <remove.Remove @label="Remove" />
-        </:remove>
+        <:chip as |chip|>
+          <chip.Chip>
+            {{chip.option}}
+            <chip.Remove @label="Remove" />
+          </chip.Chip>
+        </:chip>
 
         <:default as |multiselect|>
           <multiselect.Option>{{multiselect.option}}</multiselect.Option>
@@ -427,9 +475,12 @@ module('Integration | Component | Multiselect', function (hooks) {
       >
         <:noResults>No results</:noResults>
 
-        <:remove as |remove|>
-          <remove.Remove @label="Remove" />
-        </:remove>
+        <:chip as |chip|>
+          <chip.Chip>
+            {{chip.option}}
+            <chip.Remove @label="Remove" />
+          </chip.Chip>
+        </:chip>
 
         <:default as |multiselect|>
           <multiselect.Option>{{multiselect.option}}</multiselect.Option>
@@ -461,9 +512,12 @@ module('Integration | Component | Multiselect', function (hooks) {
       >
         <:noResults>No results</:noResults>
 
-        <:remove as |remove|>
-          <remove.Remove @label="Remove" />
-        </:remove>
+        <:chip as |chip|>
+          <chip.Chip>
+            {{chip.option}}
+            <chip.Remove @label="Remove" />
+          </chip.Chip>
+        </:chip>
 
         <:default as |multiselect|>
           <multiselect.Option>{{multiselect.option}}</multiselect.Option>
@@ -485,9 +539,12 @@ module('Integration | Component | Multiselect', function (hooks) {
       <Multiselect @options={{testColors}} data-multiselect>
         <:noResults>No results</:noResults>
 
-        <:remove as |remove|>
-          <remove.Remove @label="Remove" />
-        </:remove>
+        <:chip as |chip|>
+          <chip.Chip>
+            {{chip.option}}
+            <chip.Remove @label="Remove" />
+          </chip.Chip>
+        </:chip>
 
         <:default as |multiselect|>
           <multiselect.Option>{{multiselect.option}}</multiselect.Option>
@@ -517,9 +574,12 @@ module('Integration | Component | Multiselect', function (hooks) {
       <Multiselect @options={{testColors}} data-multiselect>
         <:noResults>No items</:noResults>
 
-        <:remove as |remove|>
-          <remove.Remove @label="Remove" />
-        </:remove>
+        <:chip as |chip|>
+          <chip.Chip>
+            {{chip.option}}
+            <chip.Remove @label="Remove" />
+          </chip.Chip>
+        </:chip>
 
         <:default as |multiselect|>
           <multiselect.Option>{{multiselect.option}}</multiselect.Option>
@@ -561,9 +621,12 @@ module('Integration | Component | Multiselect', function (hooks) {
       >
         <:noResults>No results</:noResults>
 
-        <:remove as |remove|>
-          <remove.Remove @label="Remove" />
-        </:remove>
+        <:chip as |chip|>
+          <chip.Chip>
+            {{chip.option}}
+            <chip.Remove @label="Remove" />
+          </chip.Chip>
+        </:chip>
 
         <:default as |multiselect|>
           <multiselect.Option>{{multiselect.option}}</multiselect.Option>
@@ -601,9 +664,12 @@ module('Integration | Component | Multiselect', function (hooks) {
       >
         <:noResults>No results</:noResults>
 
-        <:remove as |remove|>
-          <remove.Remove @label="Remove" />
-        </:remove>
+        <:chip as |chip|>
+          <chip.Chip>
+            {{chip.option}}
+            <chip.Remove @label="Remove" />
+          </chip.Chip>
+        </:chip>
 
         <:default as |multiselect|>
           <multiselect.Option>{{multiselect.option}}</multiselect.Option>
@@ -650,9 +716,12 @@ module('Integration | Component | Multiselect', function (hooks) {
       >
         <:noResults>No results</:noResults>
 
-        <:remove as |remove|>
-          <remove.Remove @label="Remove" />
-        </:remove>
+        <:chip as |chip|>
+          <chip.Chip>
+            {{chip.option}}
+            <chip.Remove @label="Remove" />
+          </chip.Chip>
+        </:chip>
 
         <:default as |multiselect|>
           <multiselect.Option>{{multiselect.option}}</multiselect.Option>
@@ -692,9 +761,12 @@ module('Integration | Component | Multiselect', function (hooks) {
       >
         <:noResults>No results</:noResults>
 
-        <:remove as |remove|>
-          <remove.Remove @label="Remove" />
-        </:remove>
+        <:chip as |chip|>
+          <chip.Chip>
+            {{chip.option}}
+            <chip.Remove @label="Remove" />
+          </chip.Chip>
+        </:chip>
 
         <:default as |multiselect|>
           <multiselect.Option>{{multiselect.option}}</multiselect.Option>
@@ -745,9 +817,12 @@ module('Integration | Component | Multiselect', function (hooks) {
       >
         <:noResults>No results</:noResults>
 
-        <:remove as |remove|>
-          <remove.Remove @label="Remove" />
-        </:remove>
+        <:chip as |chip|>
+          <chip.Chip>
+            {{chip.option}}
+            <chip.Remove @label="Remove" />
+          </chip.Chip>
+        </:chip>
 
         <:default as |multiselect|>
           <multiselect.Option>{{multiselect.option}}</multiselect.Option>
@@ -786,9 +861,12 @@ module('Integration | Component | Multiselect', function (hooks) {
       >
         <:noResults>No results</:noResults>
 
-        <:remove as |remove|>
-          <remove.Remove @label="Remove" />
-        </:remove>
+        <:chip as |chip|>
+          <chip.Chip>
+            {{chip.option}}
+            <chip.Remove @label="Remove" />
+          </chip.Chip>
+        </:chip>
 
         <:default as |multiselect|>
           <multiselect.Option>{{multiselect.option}}</multiselect.Option>
@@ -828,9 +906,12 @@ module('Integration | Component | Multiselect', function (hooks) {
       >
         <:noResults>No results</:noResults>
 
-        <:remove as |remove|>
-          <remove.Remove @label="Remove" />
-        </:remove>
+        <:chip as |chip|>
+          <chip.Chip>
+            {{chip.option}}
+            <chip.Remove @label="Remove" />
+          </chip.Chip>
+        </:chip>
 
         <:default as |multiselect|>
           <multiselect.Option>{{multiselect.option}}</multiselect.Option>
@@ -858,9 +939,12 @@ module('Integration | Component | Multiselect', function (hooks) {
       >
         <:noResults>No results</:noResults>
 
-        <:remove as |remove|>
-          <remove.Remove @label="Remove" />
-        </:remove>
+        <:chip as |chip|>
+          <chip.Chip>
+            {{chip.option}}
+            <chip.Remove @label="Remove" />
+          </chip.Chip>
+        </:chip>
 
         <:default as |multiselect|>
           <multiselect.Option>{{multiselect.option}}</multiselect.Option>
@@ -885,9 +969,12 @@ module('Integration | Component | Multiselect', function (hooks) {
       >
         <:noResults>No results</:noResults>
 
-        <:remove as |remove|>
-          <remove.Remove @label="Remove" />
-        </:remove>
+        <:chip as |chip|>
+          <chip.Chip>
+            {{chip.option}}
+            <chip.Remove @label="Remove" />
+          </chip.Chip>
+        </:chip>
 
         <:default as |multiselect|>
           <multiselect.Option>{{multiselect.option}}</multiselect.Option>
@@ -923,9 +1010,12 @@ module('Integration | Component | Multiselect', function (hooks) {
       >
         <:noResults>No results</:noResults>
 
-        <:remove as |remove|>
-          <remove.Remove @label="Remove" />
-        </:remove>
+        <:chip as |chip|>
+          <chip.Chip>
+            {{chip.option}}
+            <chip.Remove @label="Remove" />
+          </chip.Chip>
+        </:chip>
 
         <:default as |multiselect|>
           <multiselect.Option>{{multiselect.option}}</multiselect.Option>
@@ -952,9 +1042,12 @@ module('Integration | Component | Multiselect', function (hooks) {
       >
         <:noResults>No results</:noResults>
 
-        <:remove as |remove|>
-          <remove.Remove @label="Remove" />
-        </:remove>
+        <:chip as |chip|>
+          <chip.Chip>
+            {{chip.option}}
+            <chip.Remove @label="Remove" />
+          </chip.Chip>
+        </:chip>
 
         <:default as |multiselect|>
           <multiselect.Option>{{multiselect.option}}</multiselect.Option>
@@ -985,9 +1078,12 @@ module('Integration | Component | Multiselect', function (hooks) {
       >
         <:noResults>No results</:noResults>
 
-        <:remove as |remove|>
-          <remove.Remove @label="Remove" />
-        </:remove>
+        <:chip as |chip|>
+          <chip.Chip>
+            {{chip.option}}
+            <chip.Remove @label="Remove" />
+          </chip.Chip>
+        </:chip>
 
         <:default as |multiselect|>
           <multiselect.Option>{{multiselect.option}}</multiselect.Option>
@@ -1023,9 +1119,12 @@ module('Integration | Component | Multiselect', function (hooks) {
       >
         <:noResults>No results</:noResults>
 
-        <:remove as |remove|>
-          <remove.Remove @label="Remove" />
-        </:remove>
+        <:chip as |chip|>
+          <chip.Chip>
+            {{chip.option}}
+            <chip.Remove @label="Remove" />
+          </chip.Chip>
+        </:chip>
 
         <:default as |multiselect|>
           <multiselect.Option>{{multiselect.option}}</multiselect.Option>
@@ -1052,9 +1151,12 @@ module('Integration | Component | Multiselect', function (hooks) {
       <Multiselect @options={{testColors}} data-multiselect>
         <:noResults>No results</:noResults>
 
-        <:remove as |remove|>
-          <remove.Remove @label="Remove" />
-        </:remove>
+        <:chip as |chip|>
+          <chip.Chip>
+            {{chip.option}}
+            <chip.Remove @label="Remove" />
+          </chip.Chip>
+        </:chip>
 
         <:default as |multiselect|>
           <multiselect.Option>{{multiselect.option}}</multiselect.Option>
@@ -1080,9 +1182,12 @@ module('Integration | Component | Multiselect', function (hooks) {
       <Multiselect @options={{testColors}} data-multiselect>
         <:noResults>No results</:noResults>
 
-        <:remove as |remove|>
-          <remove.Remove @label="Remove" />
-        </:remove>
+        <:chip as |chip|>
+          <chip.Chip>
+            {{chip.option}}
+            <chip.Remove @label="Remove" />
+          </chip.Chip>
+        </:chip>
 
         <:default as |multiselect|>
           <multiselect.Option>{{multiselect.option}}</multiselect.Option>
@@ -1106,9 +1211,12 @@ module('Integration | Component | Multiselect', function (hooks) {
       <Multiselect @options={{testColors}} data-multiselect>
         <:noResults>No results</:noResults>
 
-        <:remove as |remove|>
-          <remove.Remove @label="Remove" />
-        </:remove>
+        <:chip as |chip|>
+          <chip.Chip>
+            {{chip.option}}
+            <chip.Remove @label="Remove" />
+          </chip.Chip>
+        </:chip>
 
         <:default as |multiselect|>
           <multiselect.Option>{{multiselect.option}}</multiselect.Option>
@@ -1136,9 +1244,12 @@ module('Integration | Component | Multiselect', function (hooks) {
       <Multiselect @selected={{selected}} @options={{options}} data-multiselect>
         <:noResults>No results</:noResults>
 
-        <:remove as |remove|>
-          <remove.Remove @label="Remove" />
-        </:remove>
+        <:chip as |chip|>
+          <chip.Chip>
+            {{chip.option}}
+            <chip.Remove @label="Remove" />
+          </chip.Chip>
+        </:chip>
 
         <:default as |multiselect|>
           <multiselect.Option>{{multiselect.option}}</multiselect.Option>
@@ -1171,9 +1282,12 @@ module('Integration | Component | Multiselect', function (hooks) {
       <Multiselect @selected={{selected}} @options={{options}} data-multiselect>
         <:noResults>No results</:noResults>
 
-        <:remove as |remove|>
-          <remove.Remove @label="Remove" />
-        </:remove>
+        <:chip as |chip|>
+          <chip.Chip>
+            {{chip.option}}
+            <chip.Remove @label="Remove" />
+          </chip.Chip>
+        </:chip>
 
         <:default as |multiselect|>
           <multiselect.Option>{{multiselect.option}}</multiselect.Option>
@@ -1207,9 +1321,12 @@ module('Integration | Component | Multiselect', function (hooks) {
       <Multiselect @selected={{selected}} @options={{options}} data-multiselect>
         <:noResults>No results</:noResults>
 
-        <:remove as |remove|>
-          <remove.Remove @label="Remove" />
-        </:remove>
+        <:chip as |chip|>
+          <chip.Chip>
+            {{chip.option}}
+            <chip.Remove @label="Remove" />
+          </chip.Chip>
+        </:chip>
 
         <:default as |multiselect|>
           <multiselect.Option>{{multiselect.option}}</multiselect.Option>
@@ -1241,9 +1358,12 @@ module('Integration | Component | Multiselect', function (hooks) {
       <Multiselect @selected={{selected}} @options={{options}} data-multiselect>
         <:noResults>No results</:noResults>
 
-        <:remove as |remove|>
-          <remove.Remove @label="Remove" />
-        </:remove>
+        <:chip as |chip|>
+          <chip.Chip>
+            {{chip.option}}
+            <chip.Remove @label="Remove" />
+          </chip.Chip>
+        </:chip>
 
         <:default as |multiselect|>
           <multiselect.Option>{{multiselect.option}}</multiselect.Option>
@@ -1274,9 +1394,12 @@ module('Integration | Component | Multiselect', function (hooks) {
       <Multiselect @selected={{selected}} @options={{options}} data-multiselect>
         <:noResults>No results</:noResults>
 
-        <:remove as |remove|>
-          <remove.Remove @label="Remove" />
-        </:remove>
+        <:chip as |chip|>
+          <chip.Chip>
+            {{chip.option}}
+            <chip.Remove @label="Remove" />
+          </chip.Chip>
+        </:chip>
 
         <:default as |multiselect|>
           <multiselect.Option>{{multiselect.option}}</multiselect.Option>
@@ -1319,9 +1442,12 @@ module('Integration | Component | Multiselect', function (hooks) {
       >
         <:noResults>No results</:noResults>
 
-        <:remove as |remove|>
-          <remove.Remove @label="Remove" />
-        </:remove>
+        <:chip as |chip|>
+          <chip.Chip>
+            {{chip.option}}
+            <chip.Remove @label="Remove" />
+          </chip.Chip>
+        </:chip>
 
         <:default as |multiselect|>
           <multiselect.Option>{{multiselect.option}}</multiselect.Option>
@@ -1355,12 +1481,12 @@ module('Integration | Component | Multiselect', function (hooks) {
     assert.dom('[role="option"]').exists({ count: 2 });
   });
 
-  test('it throws an assertion error if no `:remove` block is provided', async function (assert) {
+  test('it throws an assertion error if no `:chip` block is provided', async function (assert) {
     assert.expect(1);
 
     setupOnerror((e: Error) => {
       assert.ok(
-        e.message.includes('The `:remove` block is required'),
+        e.message.includes('The `:chip` block is required'),
         'Expected assertion error message'
       );
     });
@@ -1396,9 +1522,12 @@ module('Integration | Component | Multiselect', function (hooks) {
       >
         <:noResults>No results</:noResults>
 
-        <:remove as |remove|>
-          <remove.Remove />
-        </:remove>
+        <:chip as |chip|>
+          <chip.Chip>
+            {{chip.option}}
+            <chip.Remove />
+          </chip.Chip>
+        </:chip>
 
         <:default as |multiselect|>
           <multiselect.Option>{{multiselect.option}}</multiselect.Option>
@@ -1419,9 +1548,12 @@ module('Integration | Component | Multiselect', function (hooks) {
 
     await render(<template>
       <Multiselect @options={{testColors}} data-multiselect>
-        <:remove as |remove|>
-          <remove.Remove @label="Remove" />
-        </:remove>
+        <:chip as |chip|>
+          <chip.Chip>
+            {{chip.option}}
+            <chip.Remove @label="Remove" />
+          </chip.Chip>
+        </:chip>
 
         <:default as |multiselect|>
           <multiselect.Option>{{multiselect.option}}</multiselect.Option>

--- a/test-app/tests/integration/components/toucan-form/form-multiselect-test.gts
+++ b/test-app/tests/integration/components/toucan-form/form-multiselect-test.gts
@@ -29,9 +29,12 @@ module('Integration | Component | ToucanForm | Multiselect', function (hooks) {
         >
           <:noResults>No results</:noResults>
 
-          <:remove as |remove|>
-            <remove.Remove @label="Remove" />
-          </:remove>
+          <:chip as |chip|>
+            <chip.Chip>
+              {{chip.option}}
+              <chip.Remove @label="Remove" />
+            </chip.Chip>
+          </:chip>
 
           <:default as |multiselect|>
             <multiselect.Option>{{multiselect.option}}</multiselect.Option>
@@ -61,10 +64,12 @@ module('Integration | Component | ToucanForm | Multiselect', function (hooks) {
 
           <:noResults>No results</:noResults>
 
-          <:remove as |remove|>
-            <remove.Remove @label="Remove" />
-          </:remove>
-
+          <:chip as |chip|>
+            <chip.Chip>
+              {{chip.option}}
+              <chip.Remove @label="Remove" />
+            </chip.Chip>
+          </:chip>
           <:default as |multiselect|>
             <multiselect.Option>{{multiselect.option}}</multiselect.Option>
           </:default>
@@ -96,9 +101,12 @@ module('Integration | Component | ToucanForm | Multiselect', function (hooks) {
 
           <:noResults>No results</:noResults>
 
-          <:remove as |remove|>
-            <remove.Remove @label="Remove" />
-          </:remove>
+          <:chip as |chip|>
+            <chip.Chip>
+              {{chip.option}}
+              <chip.Remove @label="Remove" />
+            </chip.Chip>
+          </:chip>
 
           <:default as |multiselect|>
             <multiselect.Option>{{multiselect.option}}</multiselect.Option>
@@ -131,9 +139,12 @@ module('Integration | Component | ToucanForm | Multiselect', function (hooks) {
 
           <:noResults>No results</:noResults>
 
-          <:remove as |remove|>
-            <remove.Remove @label="Remove" />
-          </:remove>
+          <:chip as |chip|>
+            <chip.Chip>
+              {{chip.option}}
+              <chip.Remove @label="Remove" />
+            </chip.Chip>
+          </:chip>
 
           <:default as |multiselect|>
             <multiselect.Option>{{multiselect.option}}</multiselect.Option>

--- a/test-app/tests/integration/components/toucan-form/toucan-form-test.gts
+++ b/test-app/tests/integration/components/toucan-form/toucan-form-test.gts
@@ -211,9 +211,12 @@ module('Integration | Component | ToucanForm', function (hooks) {
         >
           <:noResults>No results</:noResults>
 
-          <:remove as |remove|>
-            <remove.Remove @label="Remove" />
-          </:remove>
+          <:chip as |chip|>
+            <chip.Chip>
+              {{chip.option}}
+              <chip.Remove @label="Remove" />
+            </chip.Chip>
+          </:chip>
 
           <:default as |multiselect|>
             <multiselect.Option>{{multiselect.option}}</multiselect.Option>
@@ -489,9 +492,12 @@ module('Integration | Component | ToucanForm', function (hooks) {
         >
           <:noResults>No results</:noResults>
 
-          <:remove as |remove|>
-            <remove.Remove @label="Remove" />
-          </:remove>
+          <:chip as |chip|>
+            <chip.Chip>
+              {{chip.option}}
+              <chip.Remove @label="Remove" />
+            </chip.Chip>
+          </:chip>
 
           <:default as |multiselect|>
             <multiselect.Option>{{multiselect.option}}</multiselect.Option>


### PR DESCRIPTION
## 🚀 Description

This PR removes the `:remove` named block in favor of a `:chip` named block.  This new block gives us more flexibility for new use cases and allows for the following:

- Exposes the `Chip` component directly to consumers
- Attributes to be spread onto the underlying `Chip` component
- Allows consumers to wrap the chip contents in whatever component they need.  For example, if they want to truncate the text of a long select option, they can do `<TruncateText>{{chip.option}}</TruncateText>` and we don't need to support it internally

---

## 🔬 How to Test

- Green build

---

## 📸 Images/Videos of Functionality

- No visual changes, only component API changes