### PR TITLE
chore: add `@noResultsText` argument to Multiselect

### DIFF
--- a/.changeset/kind-ways-fold.md
+++ b/.changeset/kind-ways-fold.md
@@ -1,0 +1,6 @@
+---
+'@crowdstrike/ember-toucan-core': minor
+'@crowdstrike/ember-toucan-form': minor
+---
+
+Replace Multiselect's `:noResults` block with a `@noResultsText` argument.

--- a/docs/components/multiselect-field/demo/base-demo.md
+++ b/docs/components/multiselect-field/demo/base-demo.md
@@ -6,11 +6,10 @@
     @contentClass='z-10'
     @onChange={{this.onChange}}
     @options={{this.options}}
+    @noResultsText="No results"
     @selected={{this.selected}}
     placeholder='Colors'
   >
-    <:noResults>No results</:noResults>
-
     <:chip as |chip|>
       <chip.Chip>
         {{chip.option}}

--- a/docs/components/multiselect-field/index.md
+++ b/docs/components/multiselect-field/index.md
@@ -16,6 +16,7 @@ Provide a string to the `@label` component argument or content to the `:label` n
 <Form::Controls::Multiselect
   @contentClass='z-10'
   @label='Label'
+  @noResultsText='No results'
   @onChange={{this.onChange}}
   @options={{this.options}}
   @selected={{this.selected}}
@@ -33,6 +34,7 @@ Provide a string to the `@label` component argument or content to the `:label` n
 ```hbs
 <Form::Controls::Multiselect
   @contentClass='z-10'
+  @noResultsText='No results'
   @onChange={{this.onChange}}
   @options={{this.options}}
   @selected={{this.selected}}
@@ -60,6 +62,7 @@ Provide a string to the `@hint` component argument or content to `:hint` named b
 ```hbs
 <Form::Controls::Multiselect
   @contentClass='z-10'
+  @noResultsText='No results'
   @hint='Here is a hint'
   @onChange={{this.onChange}}
   @options={{this.options}}
@@ -79,6 +82,7 @@ Provide a string to the `@hint` component argument or content to `:hint` named b
 <Form::Controls::Multiselect
   @contentClass='z-10'
   @label='Label'
+  @noResultsText='No results'
   @onChange={{this.onChange}}
   @options={{this.options}}
   @selected={{this.selected}}
@@ -125,6 +129,7 @@ The `option` for that chip is yielded back to the consumer so that an appropriat
 <Form::Fields::Multiselect
   @contentClass='z-10'
   @label='Label'
+  @noResultsText='No results'
   @onChange={{this.onChange}}
   @options={{this.options}}
   @selected={{this.selected}}
@@ -150,6 +155,7 @@ An example with translations may be something like:
 <Form::Fields::Multiselect
   @contentClass='z-10'
   @label='Label'
+  @noResultsText='No results'
   @onChange={{this.onChange}}
   @options={{this.options}}
   @selected={{this.selected}}
@@ -169,23 +175,21 @@ An example with translations may be something like:
 </Form::Fields::Multiselect>
 ```
 
-## No Results Block
+## No results text
 
 Required.
 
-A `:noResults` block is required and exposed to allow consumers to specify text when there are no results after filtering the options. Since it is a named block, any content can be rendered inside; however, we recommend only putting text as the content.
+`@noResultsText` is shown when there are no results after filtering. 
 
 ```hbs
 <Form::Fields::Multiselect
   @contentClass='z-10'
+  @noResultsText='No results'
   @onChange={{this.onChange}}
   @options={{this.options}}
   @selected={{this.selected}}
   placeholder='Colors'
 >
-  <!-- NOTE: Only text should go here. Please do not render content! -->
-  <:noResults>No results</:noResults>
-
   <:default as |multiselect|>
     <multiselect.Option>
       {{multiselect.option}}
@@ -415,8 +419,8 @@ Target the error block via `data-error`.
   <Form::Fields::Multiselect
     @contentClass='z-10'
     @label='Label'
+    @noResultsText='No results'
   >
-    <:noResults>No results</:noResults>
     <:chip as |chip|>
       <chip.Chip>
         {{chip.option}}
@@ -438,8 +442,8 @@ Target the error block via `data-error`.
     @contentClass='z-10'
     @label='Label'
     @hint="Hint"
+    @noResultsText='No results'
   >
-    <:noResults>No results</:noResults>
     <:chip as |chip|>
       <chip.Chip>
         {{chip.option}}
@@ -459,10 +463,10 @@ Target the error block via `data-error`.
 <div class='mb-4 w-64'>
   <Form::Fields::Multiselect
     @contentClass='z-10'
+    @noResultsText='No results'
   >
     <:label>Label <svg class="inline w-4 h-4" xmlns="http://www.w3.org/2000/svg" width="24" height="24" stroke="currentColor" viewBox="0 0 24 24"><path d="M12 3a9 9 0 11-6.364 2.636A8.972 8.972 0 0112 3zm0 4.7v5.2m0 3.39v.01" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg></:label>
     <:hint>Hint text <a href="https://www.crowdstrike.com/">link</a></:hint>
-    <:noResults>No results</:noResults>
     <:chip as |chip|>
       <chip.Chip>
         {{chip.option}}
@@ -484,8 +488,8 @@ Target the error block via `data-error`.
     @contentClass='z-10'
     @label='Label'
     @error='With error text'
+    @noResultsText='No results'
   >
-    <:noResults>No results</:noResults>
     <:chip as |chip|>
       <chip.Chip>
         {{chip.option}}
@@ -508,8 +512,8 @@ Target the error block via `data-error`.
     @label='Label'
     @hint='With hint text'
     @error='With error text'
+    @noResultsText='No results'
   >
-    <:noResults>No results</:noResults>
     <:chip as |chip|>
       <chip.Chip>
         {{chip.option}}
@@ -531,8 +535,8 @@ Target the error block via `data-error`.
     @contentClass='z-10'
     @label='Label'
     @isDisabled={{true}}
+    @noResultsText='No results'
   >
-    <:noResults>No results</:noResults>
     <:chip as |chip|>
       <chip.Chip>
         {{chip.option}}
@@ -554,10 +558,10 @@ Target the error block via `data-error`.
     @contentClass='z-10'
     @label='Label'
     @isDisabled={{true}}
-    @selected={{(array 'blue')}}
+    @noResultsText='No results'
     @options={{(array 'blue' 'red')}}
+    @selected={{(array 'blue')}}
   >
-    <:noResults>No results</:noResults>
     <:chip as |chip|>
       <chip.Chip>
         {{chip.option}}
@@ -579,8 +583,8 @@ Target the error block via `data-error`.
     @contentClass='z-10'
     @label='Label'
     @error={{(array 'With error 1' 'With error 2' 'With error 3')}}
+    @noResultsText='No results'
   >
-    <:noResults>No results</:noResults>
     <:chip as |chip|>
       <chip.Chip>
         {{chip.option}}
@@ -602,8 +606,8 @@ Target the error block via `data-error`.
     @contentClass='z-10'
     @label='Label'
     @isReadOnly={{true}}
+    @noResultsText='No results'
   >
-    <:noResults>No results</:noResults>
     <:chip as |chip|>
       <chip.Chip>
         {{chip.option}}
@@ -625,10 +629,10 @@ Target the error block via `data-error`.
     @contentClass='z-10'
     @label='Label'
     @isReadOnly={{true}}
-    @selected={{(array 'blue')}}
+    @noResultsText='No results'
     @options={{(array 'blue' 'red')}}
+    @selected={{(array 'blue')}}
   >
-    <:noResults>No results</:noResults>
     <:chip as |chip|>
       <chip.Chip>
         {{chip.option}}

--- a/docs/components/multiselect/demo/base-demo.md
+++ b/docs/components/multiselect/demo/base-demo.md
@@ -2,13 +2,12 @@
 <div class='flex flex-col gap-4 w-96'>
   <Form::Controls::Multiselect
     @contentClass='z-10'
+    @noResultsText="No results"
     @onChange={{this.onChange}}
     @options={{this.options}}
     @selected={{this.selected}}
     placeholder='Colors'
   >
-    <:noResults>No results</:noResults>
-
     <:chip as |chip|>
       <chip.Chip>
         {{chip.option}}
@@ -25,13 +24,12 @@
 
   <Form::Controls::Multiselect
     @contentClass='z-10'
+    @noResultsText="No results"
     @onChange={{this.onChange2}}
     @options={{this.options2}}
     @selected={{this.selected2}}
     placeholder='Names'
   >
-    <:noResults>No results</:noResults>
-
     <:chip as |chip|>
       <chip.Chip>
         {{chip.option}}
@@ -48,14 +46,13 @@
 
   <Form::Controls::Multiselect
     @contentClass='z-10'
+    @noResultsText="No results"
     @onChange={{this.onChange3}}
     @onFilter={{this.onFilter}}
     @options={{this.options}}
     @selected={{this.selected3}}
     placeholder='Colors w/ Filtering'
   >
-    <:noResults>No results</:noResults>
-
     <:chip as |chip|>
       <chip.Chip>
         {{chip.option}}

--- a/docs/components/multiselect/index.md
+++ b/docs/components/multiselect/index.md
@@ -41,14 +41,13 @@ The `option` for that chip is yielded back to the consumer so that an appropriat
 
 ```hbs
 <Form::Controls::Multiselect
+  @noResultsText="No results"
   @onChange={{this.onChange}}
   @options={{this.options}}
   @contentClass='z-10'
   @selected={{this.selected}}
   placeholder='Colors'
 >
-  <:noResults>No results</:noResults>
-
   <:chip as |chip|>
     <chip.Chip>
       {{chip.option}}
@@ -68,14 +67,13 @@ An example with translations may be something like:
 
 ```hbs
 <Form::Controls::Multiselect
+  @noResultsText="No results"
   @onChange={{this.onChange}}
   @options={{this.options}}
   @contentClass='z-10'
   @selected={{this.selected}}
   placeholder='Colors'
 >
-  <:noResults>No results</:noResults>
-
   <:chip as |chip|>
     <chip.Chip>
       {{chip.option}}
@@ -91,21 +89,21 @@ An example with translations may be something like:
 </Form::Controls::Multiselect>
 ```
 
-## No Results Block
+## No results text
 
-A `:noResults` block is required and exposed to allow consumers to specify text when there are no results after filtering the options. Since it is a named block, any content can be rendered inside; however, we recommend only putting text as the content.
+Required.
+
+`@noResultsText` is shown when there are no results after filtering. 
 
 ```hbs
 <Form::Controls::Multiselect
   @contentClass='z-10'
+  @noResultsText="No results"
   @onChange={{this.onChange}}
   @options={{this.options}}
   @selected={{this.selected}}
   placeholder='Colors'
 >
-  <!-- NOTE: Only text should go here. Please do not render content! -->
-  <:noResults>No results</:noResults>
-
   <:chip as |chip|>
     <chip.Chip>
       {{chip.option}}
@@ -168,7 +166,7 @@ Called when the user makes a selection. It is called with the entire array of se
 
 ```hbs
 <Form::Controls::Multiselect
-  @onChange={{this.handleChange}}
+  @onChange={{this.onChange}}
   @options={{this.options}}
   @selected={{this.selected}}
   as |multiselect|
@@ -190,7 +188,7 @@ export default class extends Component {
   options = ['Blue', 'Red', 'Yellow'];
 
   @action
-  handleChange(option) {
+  onChange(option) {
     this.selected = option;
   }
 }
@@ -205,8 +203,9 @@ Specify `onFilter` if you want to do something different.
 
 ```hbs
 <Form::Controls::Multiselect
-  @onFilter={{this.handleFilter}}
-  @onChange={{this.handleChange}}
+  @noResultsText="No results"
+  @onFilter={{this.onFilter}}
+  @onChange={{this.onChange}}
   @options={{this.options}}
   @selected={{this.selected}}
 >
@@ -258,12 +257,12 @@ export default class extends Component {
   ].map(({ label }) => label);
 
   @action
-  handleChange(option) {
+  onChange(option) {
     this.selected = option;
   }
 
   @action
-  handleFilter(value) {
+  onFilter(value) {
     return this.options.filter((option) => option === value);
   }
 }

--- a/docs/toucan-form/changeset-validation/demo/base-demo.md
+++ b/docs/toucan-form/changeset-validation/demo/base-demo.md
@@ -67,10 +67,9 @@
       @contentClass='z-10'
       @label='Multiselect'
       @name='multiselect'
+      @noResultsText='No results'
       @options={{this.options}}
     >
-      <:noResults>No results</:noResults>
-
       <:chip as |chip|>
         <chip.Chip>
           {{chip.option}}

--- a/packages/ember-toucan-core/src/components/form/controls/autocomplete.ts
+++ b/packages/ember-toucan-core/src/components/form/controls/autocomplete.ts
@@ -40,7 +40,7 @@ export interface ToucanFormAutocompleteControlComponentSignature {
     isReadOnly?: boolean;
 
     /**
-     * A string to display when there are no results after the user's filter.
+     * A string to display when there are no results after filtering.
      */
     noResultsText?: string;
 

--- a/packages/ember-toucan-core/src/components/form/controls/multiselect.hbs
+++ b/packages/ember-toucan-core/src/components/form/controls/multiselect.hbs
@@ -2,7 +2,6 @@
   (this.assertRequiredBlocksExist
     (hash
       chipBlockExists=(has-block "chip")
-      noResultsBlockExists=(has-block "noResults")
     )
   )
 }}
@@ -144,7 +143,7 @@
             aria-live="assertive"
             class="text-titles-and-attributes my-0 flex cursor-default items-center px-3 py-2 leading-4"
             role="status"
-          >{{yield to="noResults"}}</li>
+          >{{@noResultsText}}</li>
         {{/if}}
       </ul>
     {{/if}}

--- a/packages/ember-toucan-core/src/components/form/controls/multiselect.ts
+++ b/packages/ember-toucan-core/src/components/form/controls/multiselect.ts
@@ -43,6 +43,11 @@ export interface ToucanFormMultiselectControlComponentSignature {
     isReadOnly?: boolean;
 
     /**
+     * A string to display when there are no results after filtering.
+     */
+    noResultsText: string;
+
+    /**
      * Called when the user makes a selection.
      * It is called with the selected options (derived from `@options`) as its only argument.
      */
@@ -115,7 +120,6 @@ export interface ToucanFormMultiselectControlComponentSignature {
         >;
       }
     ];
-    noResults: [];
   };
   Element: HTMLInputElement;
 }
@@ -139,15 +143,12 @@ export default class ToucanFormMultiselectControlComponent extends Component<Tou
    */
   assertRequiredBlocksExist = ({
     chipBlockExists,
-    noResultsBlockExists,
   }: {
     chipBlockExists: boolean;
-    noResultsBlockExists: boolean;
   }) => {
     assert('The `:chip` block is required.', chipBlockExists);
-    assert('The `:noResults` block is required.', noResultsBlockExists);
 
-    return chipBlockExists && noResultsBlockExists;
+    return chipBlockExists;
   };
 
   velcroMiddleware: VelcroMiddleware[] = [

--- a/packages/ember-toucan-core/src/components/form/fields/autocomplete.ts
+++ b/packages/ember-toucan-core/src/components/form/fields/autocomplete.ts
@@ -42,9 +42,9 @@ export interface ToucanFormAutocompleteFieldComponentSignature {
     label?: string;
 
     /**
-     * A string to display when there are no results after the user's filter.
+     * A string to display when there are no results after filtering.
      */
-    noResultsText?: string;
+  noResultsText?: string;
 
     /**
      * The function called when a new selection is made.

--- a/packages/ember-toucan-core/src/components/form/fields/multiselect.hbs
+++ b/packages/ember-toucan-core/src/components/form/fields/multiselect.hbs
@@ -53,14 +53,13 @@
         @hasError={{this.hasError}}
         @isDisabled={{@isDisabled}}
         @isReadOnly={{@isReadOnly}}
+        @noResultsText={{@noResultsText}}
         @onChange={{@onChange}}
         @onFilter={{@onFilter}}
         @options={{@options}}
         @selected={{@selected}}
         ...attributes
       >
-        <:noResults>{{yield to="noResults"}}</:noResults>
-
         <:chip as |chip|>
           {{yield
             (hash

--- a/packages/ember-toucan-core/src/components/form/fields/multiselect.ts
+++ b/packages/ember-toucan-core/src/components/form/fields/multiselect.ts
@@ -42,6 +42,11 @@ export interface ToucanFormMultiselectFieldComponentSignature {
     label?: string;
 
     /**
+     * A string to display when there are no results after filtering.
+     */
+    noResultsText: string;
+
+    /**
      * Called when the user makes a selection.
      * It is called with the selected options (derived from `@options`) as its only argument.
      */
@@ -75,7 +80,6 @@ export interface ToucanFormMultiselectFieldComponentSignature {
     default: ToucanFormMultiselectControlComponentSignature['Blocks']['default'];
     hint: [];
     label: [];
-    noResults: ToucanFormMultiselectControlComponentSignature['Blocks']['noResults'];
   };
 }
 

--- a/packages/ember-toucan-form/src/-private/multiselect-field.hbs
+++ b/packages/ember-toucan-form/src/-private/multiselect-field.hbs
@@ -25,6 +25,7 @@
       @isDisabled={{@isDisabled}}
       @isReadOnly={{@isReadOnly}}
       @label={{@label}}
+      @noResultsText={{@noResultsText}}
       {{! @glint-expect-error }}
       @onChange={{field.setValue}}
       @onFilter={{@onFilter}}
@@ -35,8 +36,6 @@
       ...attributes
     >
       <:label>{{yield to='label'}}</:label>
-
-      <:noResults>{{yield to='noResults'}}</:noResults>
 
       <:chip as |chip|>
         {{yield
@@ -68,6 +67,7 @@
       @isDisabled={{@isDisabled}}
       @isReadOnly={{@isReadOnly}}
       @label={{@label}}
+      @noResultsText={{@noResultsText}}
       {{! @glint-expect-error }}
       @onChange={{field.setValue}}
       @onFilter={{@onFilter}}
@@ -79,8 +79,6 @@
     >
       <:label>{{yield to='label'}}</:label>
       <:hint>{{yield to='hint'}}</:hint>
-
-      <:noResults>{{yield to='noResults'}}</:noResults>
 
       <:chip as |chip|>
         {{yield
@@ -111,6 +109,7 @@
       @isDisabled={{@isDisabled}}
       @isReadOnly={{@isReadOnly}}
       @label={{@label}}
+      @noResultsText={{@noResultsText}}
       {{! @glint-expect-error }}
       @onChange={{field.setValue}}
       @onFilter={{@onFilter}}
@@ -121,8 +120,6 @@
       ...attributes
     >
       <:hint>{{yield to='hint'}}</:hint>
-
-      <:noResults>{{yield to='noResults'}}</:noResults>
 
       <:chip as |chip|>
         {{yield
@@ -154,6 +151,7 @@
       @isDisabled={{@isDisabled}}
       @isReadOnly={{@isReadOnly}}
       @label={{@label}}
+      @noResultsText={{@noResultsText}}
       {{! @glint-expect-error }}
       @onChange={{field.setValue}}
       @onFilter={{@onFilter}}
@@ -163,8 +161,6 @@
       name={{@name}}
       ...attributes
     >
-      <:noResults>{{yield to='noResults'}}</:noResults>
-
       <:chip as |chip|>
         {{yield
           (hash

--- a/test-app/tests/integration/components/multiselect-field-test.gts
+++ b/test-app/tests/integration/components/multiselect-field-test.gts
@@ -11,9 +11,12 @@ module('Integration | Component | Fields | Multiselect', function (hooks) {
 
   test('it renders', async function (assert) {
     await render(<template>
-      <Multiselect @label="Label" @options={{testColors}} data-multiselect>
-        <:noResults>No results</:noResults>
-
+      <Multiselect
+        @label="Label"
+        @noResultsText='No results'
+        @options={{testColors}}
+        data-multiselect
+      >
         <:chip as |chip|>
           <chip.Chip>
             {{chip.option}}
@@ -53,10 +56,9 @@ module('Integration | Component | Fields | Multiselect', function (hooks) {
         @label="Label"
         @hint="Hint text"
         @options={{testColors}}
+        @noResultsText='No results'
         data-multiselect
       >
-        <:noResults>No results</:noResults>
-
         <:chip as |chip|>
           <chip.Chip>
             {{chip.option}}
@@ -90,11 +92,9 @@ module('Integration | Component | Fields | Multiselect', function (hooks) {
 
   test('it renders with a hint and label block', async function (assert) {
     await render(<template>
-      <Multiselect @options={{testColors}} data-multiselect>
+      <Multiselect @noResultsText='No results' @options={{testColors}} data-multiselect>
         <:label><span data-label>label block content</span></:label>
         <:hint><span data-hint>hint block content</span></:hint>
-
-        <:noResults>No results</:noResults>
 
         <:chip as |chip|>
           <chip.Chip>
@@ -118,11 +118,10 @@ module('Integration | Component | Fields | Multiselect', function (hooks) {
       <Multiselect
         @label="Label"
         @error="Error text"
+        @noResultsText='No results'
         @options={{testColors}}
         data-multiselect
       >
-        <:noResults>No results</:noResults>
-
         <:chip as |chip|>
           <chip.Chip>
             {{chip.option}}
@@ -170,11 +169,10 @@ module('Integration | Component | Fields | Multiselect', function (hooks) {
         @label="Label"
         @error="Error text"
         @hint="Hint text"
+        @noResultsText='No results'
         @options={{testColors}}
         data-multiselect
       >
-        <:noResults>No results</:noResults>
-
         <:chip as |chip|>
           <chip.Chip>
             {{chip.option}}
@@ -206,11 +204,10 @@ module('Integration | Component | Fields | Multiselect', function (hooks) {
       <Multiselect
         @label="Label"
         @isDisabled={{true}}
+        @noResultsText='No results'
         @options={{testColors}}
         data-multiselect
       >
-        <:noResults>No results</:noResults>
-
         <:chip as |chip|>
           <chip.Chip>
             {{chip.option}}
@@ -235,11 +232,10 @@ module('Integration | Component | Fields | Multiselect', function (hooks) {
       <Multiselect
         @label="Label"
         @isReadOnly={{true}}
+        @noResultsText='No results'
         @options={{testColors}}
         data-multiselect
       >
-        <:noResults>No results</:noResults>
-
         <:chip as |chip|>
           <chip.Chip>
             {{chip.option}}
@@ -262,12 +258,11 @@ module('Integration | Component | Fields | Multiselect', function (hooks) {
     await render(<template>
       <Multiselect
         @label="Label"
+        @noResultsText='No results'
         @options={{testColors}}
         placeholder="Placeholder text"
         data-multiselect
       >
-        <:noResults>No results</:noResults>
-
         <:chip as |chip|>
           <chip.Chip>
             {{chip.option}}
@@ -290,12 +285,11 @@ module('Integration | Component | Fields | Multiselect', function (hooks) {
     await render(<template>
       <Multiselect
         @label="Label"
+        @noResultsText='No results'
         @options={{testColors}}
         @rootTestSelector="selector"
         data-multiselect
       >
-        <:noResults>No results</:noResults>
-
         <:chip as |chip|>
           <chip.Chip>
             {{chip.option}}
@@ -316,13 +310,12 @@ module('Integration | Component | Fields | Multiselect', function (hooks) {
     await render(<template>
       <Multiselect
         @label="Label"
+        @noResultsText='No results'
         @options={{testColors}}
         @selected={{testColors}}
         placeholder="Placeholder text"
         data-multiselect
       >
-        <:noResults>No results</:noResults>
-
         <:chip as |chip|>
           <chip.Chip>
             {{chip.option}}
@@ -362,6 +355,7 @@ module('Integration | Component | Fields | Multiselect', function (hooks) {
     await render(<template>
       <Multiselect
         @label="Label"
+        @noResultsText="No results"
         @options={{options}}
         @onChange={{handleChange}}
         data-multiselect
@@ -395,9 +389,11 @@ module('Integration | Component | Fields | Multiselect', function (hooks) {
     });
 
     await render(<template>
-      <Multiselect @options={{testColors}} data-multiselect>
-        <:noResults>No results</:noResults>
-
+      <Multiselect
+        @noResultsText='No results'
+        @options={{testColors}}
+        data-multiselect
+      >
         <:chip as |chip|>
           <chip.Chip>
             {{chip.option}}
@@ -425,9 +421,13 @@ module('Integration | Component | Fields | Multiselect', function (hooks) {
     });
 
     await render(<template>
-      <Multiselect @label="Label" @options={{testColors}} data-multiselect>
+      <Multiselect
+        @label="Label"
+        @noResultsText='No results'
+        @options={{testColors}}
+        data-multiselect
+      >
         <:label>Label</:label>
-        <:noResults>No results</:noResults>
 
         <:chip as |chip|>
           <chip.Chip>

--- a/test-app/tests/integration/components/multiselect-test.gts
+++ b/test-app/tests/integration/components/multiselect-test.gts
@@ -17,9 +17,11 @@ module('Integration | Component | Multiselect', function (hooks) {
 
   test('it renders', async function (assert) {
     await render(<template>
-      <Multiselect @options={{testColors}} data-multiselect>
-        <:noResults>No results</:noResults>
-
+      <Multiselect
+        @noResultsText="No results"
+        @options={{testColors}}
+        data-multiselect
+      >
         <:chip as |chip|>
           <chip.Chip>
             {{chip.option}}
@@ -63,12 +65,11 @@ module('Integration | Component | Multiselect', function (hooks) {
   test('it disables the component using `@isDisabled`', async function (assert) {
     await render(<template>
       <Multiselect
+        @noResultsText="No results"
         @options={{testColors}}
         @isDisabled={{true}}
         data-multiselect
       >
-        <:noResults>No results</:noResults>
-
         <:chip as |chip|>
           <chip.Chip>
             {{chip.option}}
@@ -92,12 +93,11 @@ module('Integration | Component | Multiselect', function (hooks) {
   test('it sets readonly on the input using `@isReadOnly`', async function (assert) {
     await render(<template>
       <Multiselect
+        @noResultsText="No results"
         @options={{testColors}}
         @isReadOnly={{true}}
         data-multiselect
       >
-        <:noResults>No results</:noResults>
-
         <:chip as |chip|>
           <chip.Chip>
             {{chip.option}}
@@ -126,12 +126,11 @@ module('Integration | Component | Multiselect', function (hooks) {
   test('it spreads attributes to the underlying input', async function (assert) {
     await render(<template>
       <Multiselect
+        @noResultsText="No results"
         @options={{testColors}}
         placeholder="Placeholder text"
         data-multiselect
       >
-        <:noResults>No results</:noResults>
-
         <:chip as |chip|>
           <chip.Chip>
             {{chip.option}}
@@ -152,9 +151,12 @@ module('Integration | Component | Multiselect', function (hooks) {
 
   test('it applies the error shadow when `@hasError={{true}}`', async function (assert) {
     await render(<template>
-      <Multiselect @options={{testColors}} @hasError={{true}} data-multiselect>
-        <:noResults>No results</:noResults>
-
+      <Multiselect
+        @noResultsText="No results"
+        @options={{testColors}}
+        @hasError={{true}}
+        data-multiselect
+      >
         <:chip as |chip|>
           <chip.Chip>
             {{chip.option}}
@@ -179,9 +181,11 @@ module('Integration | Component | Multiselect', function (hooks) {
 
   test('it opens the popover on click', async function (assert) {
     await render(<template>
-      <Multiselect @options={{testColors}} data-multiselect>
-        <:noResults>No results</:noResults>
-
+      <Multiselect
+        @noResultsText="No results"
+        @options={{testColors}}
+        data-multiselect
+      >
         <:chip as |chip|>
           <chip.Chip>
             {{chip.option}}
@@ -204,9 +208,11 @@ module('Integration | Component | Multiselect', function (hooks) {
 
   test('it opens the popover when the input receives input', async function (assert) {
     await render(<template>
-      <Multiselect @options={{testColors}} data-multiselect>
-        <:noResults>No results</:noResults>
-
+      <Multiselect
+        @noResultsText="No results"
+        @options={{testColors}}
+        data-multiselect
+      >
         <:chip as |chip|>
           <chip.Chip>
             {{chip.option}}
@@ -231,9 +237,11 @@ module('Integration | Component | Multiselect', function (hooks) {
   //       that the input gets focused
   test('it focuses the input when the container element is clicked', async function (assert) {
     await render(<template>
-      <Multiselect @options={{testColors}} data-multiselect>
-        <:noResults>No results</:noResults>
-
+      <Multiselect
+        @noResultsText="No results"
+        @options={{testColors}}
+        data-multiselect
+      >
         <:chip as |chip|>
           <chip.Chip>
             {{chip.option}}
@@ -261,12 +269,11 @@ module('Integration | Component | Multiselect', function (hooks) {
 
     await render(<template>
       <Multiselect
+        @noResultsText="No results"
         @options={{selected}}
         @selected={{selected}}
         data-multiselect
       >
-        <:noResults>No results</:noResults>
-
         <:chip as |chip|>
           <chip.Chip data-test-index="{{chip.index}}">
             {{chip.option}}
@@ -298,9 +305,11 @@ module('Integration | Component | Multiselect', function (hooks) {
 
   test('it sets `aria-expanded` based on the popover state', async function (assert) {
     await render(<template>
-      <Multiselect @options={{testColors}} data-multiselect>
-        <:noResults>No results</:noResults>
-
+      <Multiselect
+        @noResultsText="No results"
+        @options={{testColors}}
+        data-multiselect
+      >
         <:chip as |chip|>
           <chip.Chip>
             {{chip.option}}
@@ -325,9 +334,11 @@ module('Integration | Component | Multiselect', function (hooks) {
 
   test('it sets `aria-controls`', async function (assert) {
     await render(<template>
-      <Multiselect @options={{testColors}} data-multiselect>
-        <:noResults>No results</:noResults>
-
+      <Multiselect
+        @noResultsText="No results"
+        @options={{testColors}}
+        data-multiselect
+      >
         <:chip as |chip|>
           <chip.Chip>
             {{chip.option}}
@@ -349,10 +360,9 @@ module('Integration | Component | Multiselect', function (hooks) {
       <Multiselect
         @options={{testColors}}
         @contentClass="test-class"
+        @noResultsText="No results"
         data-multiselect
       >
-        <:noResults>No results</:noResults>
-
         <:chip as |chip|>
           <chip.Chip>
             {{chip.option}}
@@ -377,10 +387,9 @@ module('Integration | Component | Multiselect', function (hooks) {
       <Multiselect
         @options={{testColors}}
         @contentClass="test-class"
+        @noResultsText="No results"
         data-multiselect
       >
-        <:noResults>No results</:noResults>
-
         <:chip as |chip|>
           <chip.Chip>
             {{chip.option}}
@@ -411,10 +420,9 @@ module('Integration | Component | Multiselect', function (hooks) {
       <Multiselect
         @selected={{selected}}
         @options={{testColors}}
+        @noResultsText="No results"
         data-multiselect
       >
-        <:noResults>No results</:noResults>
-
         <:chip as |chip|>
           <chip.Chip>
             {{chip.option}}
@@ -444,9 +452,12 @@ module('Integration | Component | Multiselect', function (hooks) {
     let selected = [...options];
 
     await render(<template>
-      <Multiselect @selected={{selected}} @options={{options}} data-multiselect>
-        <:noResults>No results</:noResults>
-
+      <Multiselect
+        @selected={{selected}}
+        @options={{options}}
+        @noResultsText="No results"
+        data-multiselect
+      >
         <:chip as |chip|>
           <chip.Chip>
             {{chip.option}}
@@ -471,10 +482,9 @@ module('Integration | Component | Multiselect', function (hooks) {
       <Multiselect
         @selected={{selected}}
         @options={{testColors}}
+        @noResultsText="No results"
         data-multiselect
       >
-        <:noResults>No results</:noResults>
-
         <:chip as |chip|>
           <chip.Chip>
             {{chip.option}}
@@ -508,10 +518,9 @@ module('Integration | Component | Multiselect', function (hooks) {
       <Multiselect
         @selected={{selected}}
         @options={{testColors}}
+        @noResultsText="No results"
         data-multiselect
       >
-        <:noResults>No results</:noResults>
-
         <:chip as |chip|>
           <chip.Chip>
             {{chip.option}}
@@ -536,9 +545,11 @@ module('Integration | Component | Multiselect', function (hooks) {
 
   test('it provides default filtering', async function (assert) {
     await render(<template>
-      <Multiselect @options={{testColors}} data-multiselect>
-        <:noResults>No results</:noResults>
-
+      <Multiselect
+        @noResultsText="No results"
+        @options={{testColors}}
+        data-multiselect
+      >
         <:chip as |chip|>
           <chip.Chip>
             {{chip.option}}
@@ -569,11 +580,13 @@ module('Integration | Component | Multiselect', function (hooks) {
     assert.dom('[role="option"]').hasText('red');
   });
 
-  test('it renders the no results content into the `:noResults` block', async function (assert) {
+  test('it renders `@noResultsText`', async function (assert) {
     await render(<template>
-      <Multiselect @options={{testColors}} data-multiselect>
-        <:noResults>No items</:noResults>
-
+      <Multiselect
+        @noResultsText="No items"
+        @options={{testColors}}
+        data-multiselect
+      >
         <:chip as |chip|>
           <chip.Chip>
             {{chip.option}}
@@ -615,12 +628,11 @@ module('Integration | Component | Multiselect', function (hooks) {
 
     await render(<template>
       <Multiselect
+        @noResultsText="No results"
         @options={{testColors}}
         @onChange={{handleChange}}
         data-multiselect
       >
-        <:noResults>No results</:noResults>
-
         <:chip as |chip|>
           <chip.Chip>
             {{chip.option}}
@@ -658,12 +670,11 @@ module('Integration | Component | Multiselect', function (hooks) {
 
     await render(<template>
       <Multiselect
+        @noResultsText="No results"
         @options={{testColors}}
         @onChange={{handleChange}}
         data-multiselect
       >
-        <:noResults>No results</:noResults>
-
         <:chip as |chip|>
           <chip.Chip>
             {{chip.option}}
@@ -712,10 +723,9 @@ module('Integration | Component | Multiselect', function (hooks) {
         @selected={{selected}}
         @options={{options}}
         @onChange={{handleChange}}
+        @noResultsText="No results"
         data-multiselect
       >
-        <:noResults>No results</:noResults>
-
         <:chip as |chip|>
           <chip.Chip>
             {{chip.option}}
@@ -757,10 +767,9 @@ module('Integration | Component | Multiselect', function (hooks) {
         @selected={{selected}}
         @options={{options}}
         @onChange={{handleChange}}
+        @noResultsText="No results"
         data-multiselect
       >
-        <:noResults>No results</:noResults>
-
         <:chip as |chip|>
           <chip.Chip>
             {{chip.option}}
@@ -813,10 +822,9 @@ module('Integration | Component | Multiselect', function (hooks) {
         @selected={{selected}}
         @options={{options}}
         @onChange={{handleChange}}
+        @noResultsText="No results"
         data-multiselect
       >
-        <:noResults>No results</:noResults>
-
         <:chip as |chip|>
           <chip.Chip>
             {{chip.option}}
@@ -857,10 +865,9 @@ module('Integration | Component | Multiselect', function (hooks) {
         @selected={{selected}}
         @options={{options}}
         @onChange={{handleChange}}
+        @noResultsText="No results"
         data-multiselect
       >
-        <:noResults>No results</:noResults>
-
         <:chip as |chip|>
           <chip.Chip>
             {{chip.option}}
@@ -902,10 +909,9 @@ module('Integration | Component | Multiselect', function (hooks) {
         @selected={{selected}}
         @options={{options}}
         @onChange={{handleChange}}
+        @noResultsText="No results"
         data-multiselect
       >
-        <:noResults>No results</:noResults>
-
         <:chip as |chip|>
           <chip.Chip>
             {{chip.option}}
@@ -935,10 +941,9 @@ module('Integration | Component | Multiselect', function (hooks) {
         @selected={{selected}}
         @options={{options}}
         @isDisabled={{true}}
+        @noResultsText="No results"
         data-multiselect
       >
-        <:noResults>No results</:noResults>
-
         <:chip as |chip|>
           <chip.Chip>
             {{chip.option}}
@@ -965,10 +970,9 @@ module('Integration | Component | Multiselect', function (hooks) {
         @selected={{selected}}
         @options={{options}}
         @isReadOnly={{true}}
+        @noResultsText="No results"
         data-multiselect
       >
-        <:noResults>No results</:noResults>
-
         <:chip as |chip|>
           <chip.Chip>
             {{chip.option}}
@@ -1006,10 +1010,9 @@ module('Integration | Component | Multiselect', function (hooks) {
         @selected={{selected}}
         @options={{testColors}}
         @onFilter={{handleFilter}}
+        @noResultsText="No results"
         data-multiselect
       >
-        <:noResults>No results</:noResults>
-
         <:chip as |chip|>
           <chip.Chip>
             {{chip.option}}
@@ -1038,10 +1041,9 @@ module('Integration | Component | Multiselect', function (hooks) {
       <Multiselect
         @selected={{selected}}
         @options={{testColors}}
+        @noResultsText="No results"
         data-multiselect
       >
-        <:noResults>No results</:noResults>
-
         <:chip as |chip|>
           <chip.Chip>
             {{chip.option}}
@@ -1074,10 +1076,9 @@ module('Integration | Component | Multiselect', function (hooks) {
       <Multiselect
         @selected={{selected}}
         @options={{testColors}}
+        @noResultsText="No results"
         data-multiselect
       >
-        <:noResults>No results</:noResults>
-
         <:chip as |chip|>
           <chip.Chip>
             {{chip.option}}
@@ -1115,10 +1116,9 @@ module('Integration | Component | Multiselect', function (hooks) {
       <Multiselect
         @selected={{selected}}
         @options={{testColors}}
+        @noResultsText="No results"
         data-multiselect
       >
-        <:noResults>No results</:noResults>
-
         <:chip as |chip|>
           <chip.Chip>
             {{chip.option}}
@@ -1148,9 +1148,11 @@ module('Integration | Component | Multiselect', function (hooks) {
 
   test('it closes an open popover when the ESCAPE key is pressed', async function (assert) {
     await render(<template>
-      <Multiselect @options={{testColors}} data-multiselect>
-        <:noResults>No results</:noResults>
-
+      <Multiselect
+        @noResultsText="No results"
+        @options={{testColors}}
+        data-multiselect
+      >
         <:chip as |chip|>
           <chip.Chip>
             {{chip.option}}
@@ -1179,9 +1181,11 @@ module('Integration | Component | Multiselect', function (hooks) {
       {{! template-lint-disable require-input-label }}
       <input placeholder="test" data-input />
 
-      <Multiselect @options={{testColors}} data-multiselect>
-        <:noResults>No results</:noResults>
-
+      <Multiselect
+        @noResultsText="No results"
+        @options={{testColors}}
+        data-multiselect
+      >
         <:chip as |chip|>
           <chip.Chip>
             {{chip.option}}
@@ -1208,9 +1212,11 @@ module('Integration | Component | Multiselect', function (hooks) {
 
   test('it reopens the popover when any key is pressed if the popover is closed', async function (assert) {
     await render(<template>
-      <Multiselect @options={{testColors}} data-multiselect>
-        <:noResults>No results</:noResults>
-
+      <Multiselect
+        @noResultsText="No results"
+        @options={{testColors}}
+        data-multiselect
+      >
         <:chip as |chip|>
           <chip.Chip>
             {{chip.option}}
@@ -1241,9 +1247,12 @@ module('Integration | Component | Multiselect', function (hooks) {
 
     // NOTE: Our selected option is currently at the bottom of the list!
     await render(<template>
-      <Multiselect @selected={{selected}} @options={{options}} data-multiselect>
-        <:noResults>No results</:noResults>
-
+      <Multiselect
+        @selected={{selected}}
+        @options={{options}}
+        @noResultsText="No results"
+        data-multiselect
+      >
         <:chip as |chip|>
           <chip.Chip>
             {{chip.option}}
@@ -1279,9 +1288,12 @@ module('Integration | Component | Multiselect', function (hooks) {
 
     // NOTE: Our selected option is currently at the top of the list!
     await render(<template>
-      <Multiselect @selected={{selected}} @options={{options}} data-multiselect>
-        <:noResults>No results</:noResults>
-
+      <Multiselect
+        @selected={{selected}}
+        @options={{options}}
+        @noResultsText="No results"
+        data-multiselect
+      >
         <:chip as |chip|>
           <chip.Chip>
             {{chip.option}}
@@ -1318,9 +1330,12 @@ module('Integration | Component | Multiselect', function (hooks) {
 
     // NOTE: Our selected option is currently at the top of the list!
     await render(<template>
-      <Multiselect @selected={{selected}} @options={{options}} data-multiselect>
-        <:noResults>No results</:noResults>
-
+      <Multiselect
+        @selected={{selected}}
+        @options={{options}}
+        @noResultsText="No results"
+        data-multiselect
+      >
         <:chip as |chip|>
           <chip.Chip>
             {{chip.option}}
@@ -1355,9 +1370,12 @@ module('Integration | Component | Multiselect', function (hooks) {
 
     // NOTE: Our selected option is currently at the bottom of the list!
     await render(<template>
-      <Multiselect @selected={{selected}} @options={{options}} data-multiselect>
-        <:noResults>No results</:noResults>
-
+      <Multiselect
+        @selected={{selected}}
+        @options={{options}}
+        @noResultsText="No results"
+        data-multiselect
+      >
         <:chip as |chip|>
           <chip.Chip>
             {{chip.option}}
@@ -1391,9 +1409,12 @@ module('Integration | Component | Multiselect', function (hooks) {
 
     // NOTE: Our selected option is currently at the bottom of the list!
     await render(<template>
-      <Multiselect @selected={{selected}} @options={{options}} data-multiselect>
-        <:noResults>No results</:noResults>
-
+      <Multiselect
+        @selected={{selected}}
+        @options={{options}}
+        @noResultsText="No results"
+        data-multiselect
+      >
         <:chip as |chip|>
           <chip.Chip>
             {{chip.option}}
@@ -1438,10 +1459,9 @@ module('Integration | Component | Multiselect', function (hooks) {
         @selected={{selected}}
         @options={{testColors}}
         @onChange={{handleChange}}
+        @noResultsText="No results"
         data-multiselect
       >
-        <:noResults>No results</:noResults>
-
         <:chip as |chip|>
           <chip.Chip>
             {{chip.option}}
@@ -1492,9 +1512,11 @@ module('Integration | Component | Multiselect', function (hooks) {
     });
 
     await render(<template>
-      <Multiselect @options={{testColors}} data-multiselect>
-        <:noResults>No results</:noResults>
-
+      <Multiselect
+        @noResultsText="No results"
+        @options={{testColors}}
+        data-multiselect
+      >
         <:default as |multiselect|>
           <multiselect.Option>{{multiselect.option}}</multiselect.Option>
         </:default>
@@ -1518,40 +1540,13 @@ module('Integration | Component | Multiselect', function (hooks) {
       <Multiselect
         @options={{testColors}}
         @selected={{testColors}}
+        @noResultsText="No results"
         data-multiselect
       >
-        <:noResults>No results</:noResults>
-
         <:chip as |chip|>
           <chip.Chip>
             {{chip.option}}
             <chip.Remove />
-          </chip.Chip>
-        </:chip>
-
-        <:default as |multiselect|>
-          <multiselect.Option>{{multiselect.option}}</multiselect.Option>
-        </:default>
-      </Multiselect>
-    </template>);
-  });
-
-  test('it throws an assertion error if no `:noResults` block is provided', async function (assert) {
-    assert.expect(1);
-
-    setupOnerror((e: Error) => {
-      assert.ok(
-        e.message.includes('The `:noResults` block is required'),
-        'Expected assertion error message'
-      );
-    });
-
-    await render(<template>
-      <Multiselect @options={{testColors}} data-multiselect>
-        <:chip as |chip|>
-          <chip.Chip>
-            {{chip.option}}
-            <chip.Remove @label="Remove" />
           </chip.Chip>
         </:chip>
 

--- a/test-app/tests/integration/components/toucan-form/form-multiselect-test.gts
+++ b/test-app/tests/integration/components/toucan-form/form-multiselect-test.gts
@@ -24,11 +24,10 @@ module('Integration | Component | ToucanForm | Multiselect', function (hooks) {
           @label="Label"
           @hint="Hint"
           @name="selection"
+          @noResultsText="No results"
           @options={{options}}
           data-multiselect
         >
-          <:noResults>No results</:noResults>
-
           <:chip as |chip|>
             <chip.Chip>
               {{chip.option}}
@@ -57,12 +56,11 @@ module('Integration | Component | ToucanForm | Multiselect', function (hooks) {
         <form.Multiselect
           @hint="Hint"
           @name="selection"
+          @noResultsText="No results"
           @options={{options}}
           data-autocomplete
         >
           <:label><span data-label-block>Label</span></:label>
-
-          <:noResults>No results</:noResults>
 
           <:chip as |chip|>
             <chip.Chip>
@@ -75,7 +73,7 @@ module('Integration | Component | ToucanForm | Multiselect', function (hooks) {
           </:default>
         </form.Multiselect>
       </ToucanForm>
-    </template>);
+    </template> );
 
     assert.dom('[data-label-block]').exists();
 
@@ -94,12 +92,11 @@ module('Integration | Component | ToucanForm | Multiselect', function (hooks) {
         <form.Multiselect
           @label="Label"
           @name="selection"
+          @noResultsText="No results"
           @options={{options}}
           data-autocomplete
         >
           <:hint><span data-hint-block>Hint</span></:hint>
-
-          <:noResults>No results</:noResults>
 
           <:chip as |chip|>
             <chip.Chip>
@@ -131,13 +128,12 @@ module('Integration | Component | ToucanForm | Multiselect', function (hooks) {
       <ToucanForm @data={{data}} as |form|>
         <form.Multiselect
           @name="selection"
+          @noResultsText="No results"
           @options={{options}}
           data-autocomplete
         >
           <:label><span data-label-block>Label</span></:label>
           <:hint><span data-hint-block>Hint</span></:hint>
-
-          <:noResults>No results</:noResults>
 
           <:chip as |chip|>
             <chip.Chip>

--- a/test-app/tests/integration/components/toucan-form/toucan-form-test.gts
+++ b/test-app/tests/integration/components/toucan-form/toucan-form-test.gts
@@ -206,11 +206,10 @@ module('Integration | Component | ToucanForm', function (hooks) {
         <form.Multiselect
           @label="Multiselect"
           @name="multiselect"
+          @noResultsText="No results"
           @options={{options}}
           data-multiselect
         >
-          <:noResults>No results</:noResults>
-
           <:chip as |chip|>
             <chip.Chip>
               {{chip.option}}
@@ -486,12 +485,11 @@ module('Integration | Component | ToucanForm', function (hooks) {
         <form.Multiselect
           @label="Multiselect"
           @name="multiselect"
+          @noResultsText="No results"
           @options={{options}}
           @rootTestSelector="data-multiselect-wrapper"
           data-multiselect
         >
-          <:noResults>No results</:noResults>
-
           <:chip as |chip|>
             <chip.Chip>
               {{chip.option}}


### PR DESCRIPTION
## 🚀 Description

We want to increase consistency where we can. In the case of what's displayed when there are no results, we (@clintcs, @ynotdraw)—after some discussion—_think_ we can get away with being prescriptive and forgo a named block (`:noResults`) in favor of an argument (`@noResultsText`). This will also bring Multiselect in line with Autocomplete, which also supports `@noResultsText`.


## 🔬 How to Test

1. Navigate to the [preview URL](https://8a5dc82c.ember-toucan-core.pages.dev/docs/components/multiselect).
1. Filter a demo until there are no results.
1. Verify that "No results" is shown in the popover.
