### PR TITLE
Fix chevron colors in autocomplete/multiselect

### DIFF
--- a/packages/ember-toucan-core/src/components/form/controls/autocomplete.hbs
+++ b/packages/ember-toucan-core/src/components/form/controls/autocomplete.hbs
@@ -69,7 +69,7 @@
     />
 
     <this.Chevron
-      class="pointer-events-none absolute right-1 top-0 ml-auto h-full transform transition-transform duration-200
+      class="text-text-and-icons pointer-events-none absolute right-1 top-0 ml-auto h-full transform transition-transform duration-200
         {{if this.isPopoverOpen 'rotate-180'}}"
     />
   </div>

--- a/packages/ember-toucan-core/src/components/form/controls/multiselect.hbs
+++ b/packages/ember-toucan-core/src/components/form/controls/multiselect.hbs
@@ -106,7 +106,7 @@
       </div>
 
       <this.Chevron
-        class="min-w-6 min-h-6 right-1 top-0 h-6 w-6 transform-gpu transition-transform duration-300
+        class="min-w-6 min-h-6 text-text-and-icons right-1 top-0 h-6 w-6 transform-gpu transition-transform duration-300
           {{if this.isPopoverOpen 'rotate-180'}}"
       />
     </div>


### PR DESCRIPTION
## 🚀 Description

It's very subtle and I notice it more on my 5k monitor - the chevron color on the autocomplete and multiselect were not the same.  This PR adds an explicit class so that they are identical.

---

## 🔬 How to Test

- Verify the colors for the chevrons on the changeset demo are the same

---

## 📸 Images/Videos of Functionality

Once again, kind of hard to tell, but the bottom chevron (multiselect) is _slightly_ lighter than the top one (autocomplete) due to the classes on the containers since the SVG has `fill="currentColor"`.

| BEFORE  | AFTER |
| ------------- | ------------- |
| <img width="138" alt="Screenshot 2023-07-27 at 12 52 34 PM" src="https://github.com/CrowdStrike/ember-toucan-core/assets/8069555/df29f132-72c8-4374-8420-4452dbfce5fa">  | <img width="109" alt="Screenshot 2023-07-27 at 12 53 02 PM" src="https://github.com/CrowdStrike/ember-toucan-core/assets/8069555/a54882c7-8e63-4655-aaf2-3308490bf8d4">  |




