### PR TITLE
chore: make Autocomplete `@noResultsText` required

### DIFF
--- a/.changeset/tough-planets-raise.md
+++ b/.changeset/tough-planets-raise.md
@@ -1,0 +1,6 @@
+---
+'@crowdstrike/ember-toucan-core': minor
+'@crowdstrike/ember-toucan-form': minor
+---
+
+Make Autocomplete `@noResultsText` required.

--- a/docs/components/autocomplete-field/index.md
+++ b/docs/components/autocomplete-field/index.md
@@ -42,6 +42,26 @@ Provide a string to the `@label` component argument or content to the `:label` n
 </Form::Fields::Autocomplete>
 ```
 
+## No results text
+
+Required.
+
+`@noResultsText` is shown when there are no results after filtering. 
+
+```hbs
+<Form::Fields::Autocomplete
+  @error={{this.errorMessage}}
+  @noResultsText='No results'
+  @onChange={{this.onChange}}
+  placeholder='Colors'
+  as |autocomplete|
+>
+  <:label>Here is a label <IconButton><Tooltip /><IconButton></:label>
+
+  <autocomplete.Option @label="Blue" @value="blue" />
+</Form::Fields::Autocomplete>
+```
+
 ## Hint
 
 Optional.
@@ -112,6 +132,8 @@ Provide a string or array of strings to `@error` to render the text into the Err
 
 ## `@onChange`
 
+Optional.
+
 Provide an `@onChange` callback to be notified when the user's selections have changed.
 `@onChange` will receive the value as its only argument.
 
@@ -142,9 +164,13 @@ export default class extends Component {
 
 ## Disabled State
 
+Optional.
+
 Set the `@isDisabled` argument to disable the input.
 
 ## Read Only State
+
+Optional.
 
 Set the `@isReadOnly` argument to put the input in the read only state.
 

--- a/docs/components/autocomplete-field/index.md
+++ b/docs/components/autocomplete-field/index.md
@@ -16,6 +16,7 @@ Provide a string to the `@label` component argument or content to the `:label` n
 <Form::Fields::Autocomplete
   @label='Label'
   @error={{this.errorMessage}}
+  @noResultsText='No results'
   @onChange={{this.onChange}}
   as |autocomplete|
 >
@@ -30,6 +31,7 @@ Provide a string to the `@label` component argument or content to the `:label` n
 ```hbs
 <Form::Fields::Autocomplete
   @error={{this.errorMessage}}
+  @noResultsText='No results'
   @onChange={{this.onChange}}
   placeholder='Colors'
   as |autocomplete|
@@ -55,6 +57,7 @@ Provide a string to the `@hint` component argument or content to `:hint` named b
   @label='Label'
   @hint='Here is a hint'
   @error={{this.errorMessage}}
+  @noResultsText='No results'
   @onChange={{this.onChange}}
   as |autocomplete|
 >
@@ -70,6 +73,7 @@ Provide a string to the `@hint` component argument or content to `:hint` named b
 <Form::Fields::Autocomplete
   @label='Label'
   @error={{this.errorMessage}}
+  @noResultsText='No results'
   @onChange={{this.onChange}}
   as |autocomplete|
 >
@@ -96,6 +100,7 @@ Provide a string or array of strings to `@error` to render the text into the Err
 <Form::Fields::Autocomplete
   @label='Label'
   @error={{(array 'Error 1' 'Error 2')}}
+  @noResultsText='No results'
   @onChange={{this.onChange}}
   as |autocomplete|
 >
@@ -113,6 +118,7 @@ Provide an `@onChange` callback to be notified when the user's selections have c
 ```hbs
 <Form::Fields::Autocomplete
   @label='Label'
+  @noResultsText='No results'
   @onChange={{this.onChange}}
   as |autocomplete|
 >
@@ -156,7 +162,7 @@ This test selector will be used as the value for the `data-root-field` attribute
 The Field can be targeted via:
 
 ```hbs
-<Form::Fields::Autocomplete @label='Label' @rootTestSelector='example' />
+<Form::Fields::Autocomplete @label='Label' @noResultsText='No results' @rootTestSelector='example' />
 ```
 
 ```js
@@ -182,7 +188,7 @@ Target the error block via `data-error`.
 ### autocompleteField with `@label`
 
 <div class='mb-4 w-64'>
-  <Form::Fields::Autocomplete @label='Label' placeholder='Colors' />
+  <Form::Fields::Autocomplete @noResultsText='No results' @label='Label' placeholder='Colors' />
 </div>
 
 ### autocompleteField with `@label` and `@hint`
@@ -191,6 +197,7 @@ Target the error block via `data-error`.
   <Form::Fields::Autocomplete
     @label='Label'
     @hint='With hint text'
+    @noResultsText='No results'
     placeholder='Colors'
   />
 </div>
@@ -198,7 +205,7 @@ Target the error block via `data-error`.
 ### autocompleteField with `:label` and `:hint` blocks
 
 <div class='mb-4 w-64'>
-  <Form::Fields::Autocomplete placeholder='Colors'>
+  <Form::Fields::Autocomplete @noResultsText='No results' placeholder='Colors'>
     <:label>Label <svg class="inline w-4 h-4" xmlns="http://www.w3.org/2000/svg" width="24" height="24" stroke="currentColor" viewBox="0 0 24 24"><path d="M12 3a9 9 0 11-6.364 2.636A8.972 8.972 0 0112 3zm0 4.7v5.2m0 3.39v.01" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path></svg></:label>
     <:hint>Hint text <a href="https://www.crowdstrike.com/">link</a></:hint>
     <:default as |autocomplete|>
@@ -215,6 +222,7 @@ Target the error block via `data-error`.
   <Form::Fields::Autocomplete
     @label='Label'
     @error='With error text'
+    @noResultsText='No results'
     placeholder='Colors'
   />
 </div>
@@ -226,6 +234,7 @@ Target the error block via `data-error`.
     @label='Label'
     @hint='With hint text'
     @error='With error text'
+    @noResultsText='No results'
     placeholder='Colors'
   />
 </div>
@@ -236,6 +245,7 @@ Target the error block via `data-error`.
   <Form::Fields::Autocomplete
     @label='Label'
     @isDisabled={{true}}
+    @noResultsText='No results'
     placeholder='Colors'
   />
 </div>
@@ -248,6 +258,7 @@ Target the error block via `data-error`.
     @isDisabled={{true}}
     @selected="blue"
     @options={{(array 'blue' 'red')}}
+    @noResultsText='No results'
     placeholder='Colors'
   as |autocomplete|>
     <autocomplete.Option>
@@ -263,6 +274,7 @@ Target the error block via `data-error`.
     @label='Label'
     @options={{(array 'blue' 'red')}}
     @error={{(array 'With error 1' 'With error 2' 'With error 3')}}
+    @noResultsText='No results'
     placeholder='Colors'
   as |autocomplete|>
     <autocomplete.Option>
@@ -278,6 +290,7 @@ Target the error block via `data-error`.
     @label='Label'
     @hint='With hint text'
     @isReadOnly={{true}}
+    @noResultsText='No results'
   />
 </div>
 
@@ -289,6 +302,7 @@ Target the error block via `data-error`.
     @isReadOnly={{true}}
     @selected="blue"
     @options={{(array 'blue' 'red')}}
+    @noResultsText='No results'
     placeholder='Colors'
   as |autocomplete|>
     <autocomplete.Option>

--- a/docs/components/autocomplete/index.md
+++ b/docs/components/autocomplete/index.md
@@ -3,7 +3,29 @@
 Provides a Toucan-styled autocomplete with filtering.
 If you are building forms, you may be interested in the [AutocompleteField](./autocomplete-field) component instead.
 
+## No results text
+
+Required.
+
+`@noResultsText` is shown when there are no results after filtering. 
+
+```hbs
+<Form::Controls::Autocomplete
+  @noResultsText='No results'
+  @options={{this.options}}
+  @selected={{this.selected}}
+  as |autocomplete|
+>
+  <autocomplete.Option>
+    <!-- The content of each popover list item will be rendered here -->
+    {{autocomplete.option}}
+  </autocomplete.Option>
+</Form::Controls::Autocomplete>
+```
+
 ## Popover z-index
+
+Optional.
 
 A CSS class to add to this component's content container. Commonly used to specify a `z-index`.
 
@@ -12,6 +34,8 @@ A CSS class to add to this component's content container. Commonly used to speci
 ```
 
 ## Options
+
+Optional.
 
 `@options` forms the content of this component. 
 
@@ -30,6 +54,8 @@ A CSS class to add to this component's content container. Commonly used to speci
 ```
 
 ## Selected
+
+Optional.
 
 The currently selected option.
 
@@ -57,6 +83,8 @@ export default class extends Component {
 ```
 
 ## onChange
+
+Optional.
 
 Called when the user makes a selection. It is called with the selected option (derived from `@options`) as its only argument. You'll want to update `@selected` with the new value in your on change handler.
 
@@ -167,6 +195,8 @@ export default class extends Component {
 
 ## Disabled State
 
+Optional.
+
 Set the `@isDisabled` argument to disable the input.
 
 ```hbs
@@ -175,6 +205,8 @@ Set the `@isDisabled` argument to disable the input.
 
 ## Read Only State
 
+Optional.
+
 Set the `@isReadOnly` argument to put the input in the read only state.
 
 ```hbs
@@ -182,6 +214,8 @@ Set the `@isReadOnly` argument to put the input in the read only state.
 ```
 
 ## Error State
+
+Optional.
 
 Set the `@hasError` argument to apply an error box shadow to the `<input>`.
 

--- a/docs/components/autocomplete/index.md
+++ b/docs/components/autocomplete/index.md
@@ -17,6 +17,7 @@ A CSS class to add to this component's content container. Commonly used to speci
 
 ```hbs
 <Form::Controls::Autocomplete
+  @noResultsText='No results'
   @options={{this.options}}
   @selected={{this.selected}}
   as |autocomplete|
@@ -34,6 +35,7 @@ The currently selected option.
 
 ```hbs
 <Form::Controls::Autocomplete
+  @noResultsText='No results'
   @options={{this.options}}
   @selected={{this.selected}}
   as |autocomplete|
@@ -60,7 +62,8 @@ Called when the user makes a selection. It is called with the selected option (d
 
 ```hbs
 <Form::Controls::Autocomplete
-  @onChange={{this.handleChange}}
+  @noResultsText='No results'
+  @onChange={{this.onChange}}
   @options={{this.options}}
   @selected={{this.selected}}
   as |autocomplete|
@@ -82,7 +85,7 @@ export default class extends Component {
   options = ['Blue', 'Red', 'Yellow'];
 
   @action
-  handleChange(option) {
+  onChange(option) {
     this.selected = option;
   }
 }
@@ -92,12 +95,15 @@ export default class extends Component {
 
 Optional.
 
-By default, when `@options` are an array of strings, the built-in filtering does simple `startsWith` filtering. When `@options` are an array of objects, the same filtering logic applies, but the key of each object is determined by the provided `@optionKey`. There may be cases where you need to write your own filtering logic completely that is more complex than the built-in `startsWith` filtering described. To do so, leverage `@onFilter` instead. This function should return an array of items that will then be used to populate the dropdown results.
+By default, when `@options` are an array of strings, the built-in filtering does simple `String.prototype.startsWith` filtering. 
+There may be cases where you need to write your own filtering logic completely that is more complex than the built-in `String.prototype.startsWith` filtering described. 
+To do so, leverage `@onFilter` instead. This function should return an array of items that will then be used to populate the dropdown results.
 
 ```hbs
 <Form::Controls::Autocomplete
-  @onFilter={{this.handleFilter}}
-  @onChange={{this.handleChange}}
+  @noResultsText='No results'
+  @onFilter={{this.onFilter}}
+  @onChange={{this.onChange}}
   @options={{this.options}}
   @selected={{this.selected}}
   as |autocomplete|
@@ -148,12 +154,12 @@ export default class extends Component {
   ];
 
   @action
-  handleChange(option) {
+  onChange(option) {
     this.selected = option;
   }
 
   @action
-  handleFilter(value) {
+  onFilter(value) {
     return this.options.filter((option) => option === value);
   }
 }

--- a/docs/components/multiselect-field/index.md
+++ b/docs/components/multiselect-field/index.md
@@ -49,54 +49,6 @@ Provide a string to the `@label` component argument or content to the `:label` n
 </Form::Controls::Multiselect>
 ```
 
-## Hint
-
-Optional.
-
-Use either the `@hint` component argument or the `:hint` named block.
-
-Provide a string to the `@hint` component argument or content to `:hint` named block to render into the Hint section of the Field.
-
-### @hint
-
-```hbs
-<Form::Controls::Multiselect
-  @contentClass='z-10'
-  @noResultsText='No results'
-  @hint='Here is a hint'
-  @onChange={{this.onChange}}
-  @options={{this.options}}
-  @selected={{this.selected}}
->
-  <:default as |multiselect|>
-    <multiselect.Option>
-      {{multiselect.option}}
-    </multiselect.Option>
-  </:default>
-</Form::Controls::Multiselect>
-```
-
-### `:hint`
-
-```hbs
-<Form::Controls::Multiselect
-  @contentClass='z-10'
-  @label='Label'
-  @noResultsText='No results'
-  @onChange={{this.onChange}}
-  @options={{this.options}}
-  @selected={{this.selected}}
->
-  <:hint>Here is a hint <Link to='somewhere'>Link</Link></:hint>
-
-  <:default as |multiselect|>
-    <multiselect.Option>
-      {{multiselect.option}}
-    </multiselect.Option>
-  </:default>
-</Form::Controls::Multiselect>
-```
-
 ## Chip Block
 
 Required.
@@ -196,6 +148,54 @@ Required.
     </multiselect.Option>
   </:default>
 </Form::Fields::Multiselect>
+```
+
+## Hint
+
+Optional.
+
+Use either the `@hint` component argument or the `:hint` named block.
+
+Provide a string to the `@hint` component argument or content to `:hint` named block to render into the Hint section of the Field.
+
+### @hint
+
+```hbs
+<Form::Controls::Multiselect
+  @contentClass='z-10'
+  @noResultsText='No results'
+  @hint='Here is a hint'
+  @onChange={{this.onChange}}
+  @options={{this.options}}
+  @selected={{this.selected}}
+>
+  <:default as |multiselect|>
+    <multiselect.Option>
+      {{multiselect.option}}
+    </multiselect.Option>
+  </:default>
+</Form::Controls::Multiselect>
+```
+
+### `:hint`
+
+```hbs
+<Form::Controls::Multiselect
+  @contentClass='z-10'
+  @label='Label'
+  @noResultsText='No results'
+  @onChange={{this.onChange}}
+  @options={{this.options}}
+  @selected={{this.selected}}
+>
+  <:hint>Here is a hint <Link to='somewhere'>Link</Link></:hint>
+
+  <:default as |multiselect|>
+    <multiselect.Option>
+      {{multiselect.option}}
+    </multiselect.Option>
+  </:default>
+</Form::Controls::Multiselect>
 ```
 
 ## Error
@@ -370,9 +370,13 @@ export default class extends Component {
 
 ## Disabled State
 
+Optional.
+
 Set the `@isDisabled` argument to disable the input.
 
 ## Read Only State
+
+Optional.
 
 Set the `@isReadOnly` argument to put the input in the read only state.
 

--- a/docs/components/multiselect/index.md
+++ b/docs/components/multiselect/index.md
@@ -3,14 +3,6 @@
 Provides a Toucan-styled multiselect with filtering.
 If you are building forms, you may be interested in the [MultiselectField](./multiselect-field) component instead.
 
-## Popover z-index
-
-A CSS class to add to this component's content container. Commonly used to specify a `z-index`.
-
-```hbs
-<Form::Controls::Multiselect @contentClass='z-50' />
-```
-
 ## Chip Block
 
 Required.
@@ -119,7 +111,19 @@ Required.
 </Form::Controls::Multiselect>
 ```
 
+## Popover z-index
+
+Optional.
+
+A CSS class to add to this component's content container. Commonly used to specify a `z-index`.
+
+```hbs
+<Form::Controls::Multiselect @contentClass='z-50' />
+```
+
 ## Options
+
+Optional.
 
 `@options` forms the content of this component.
 
@@ -135,6 +139,8 @@ Required.
 ```
 
 ## Selected
+
+Optional.
 
 The currently selected option.
 
@@ -161,6 +167,8 @@ export default class extends Component {
 ```
 
 ## onChange
+
+Optional.
 
 Called when the user makes a selection. It is called with the entire array of selected options (derived from `@options`) as its only argument. You'll want to update `@selected` with the new value in your on change handler.
 
@@ -270,6 +278,8 @@ export default class extends Component {
 
 ## Disabled State
 
+Optional.
+
 Set the `@isDisabled` argument to disable the input.
 
 ```hbs
@@ -278,6 +288,8 @@ Set the `@isDisabled` argument to disable the input.
 
 ## Read Only State
 
+Optional.
+
 Set the `@isReadOnly` argument to put the input in the read only state.
 
 ```hbs
@@ -285,6 +297,8 @@ Set the `@isReadOnly` argument to put the input in the read only state.
 ```
 
 ## Error State
+
+Optional.
 
 Set the `@hasError` argument to apply an error box shadow to the `<input>`.
 

--- a/packages/ember-toucan-core/src/components/form/controls/autocomplete.ts
+++ b/packages/ember-toucan-core/src/components/form/controls/autocomplete.ts
@@ -42,7 +42,7 @@ export interface ToucanFormAutocompleteControlComponentSignature {
     /**
      * A string to display when there are no results after filtering.
      */
-    noResultsText?: string;
+    noResultsText: string;
 
     /**
      * Called when the user makes a selection.

--- a/packages/ember-toucan-core/src/components/form/fields/autocomplete.ts
+++ b/packages/ember-toucan-core/src/components/form/fields/autocomplete.ts
@@ -44,7 +44,7 @@ export interface ToucanFormAutocompleteFieldComponentSignature {
     /**
      * A string to display when there are no results after filtering.
      */
-  noResultsText?: string;
+  noResultsText: string;
 
     /**
      * The function called when a new selection is made.

--- a/test-app/tests/integration/components/autocomplete-field-test.gts
+++ b/test-app/tests/integration/components/autocomplete-field-test.gts
@@ -9,7 +9,7 @@ module('Integration | Component | Fields | Autocomplete', function (hooks) {
 
   test('it renders', async function (assert) {
     await render(<template>
-      <Autocomplete @label="Label" data-autocomplete />
+      <Autocomplete @noResultsText="No results" @label="Label" data-autocomplete />
     </template>);
 
     assert.dom('[data-label]').hasText('Label');
@@ -35,7 +35,12 @@ module('Integration | Component | Fields | Autocomplete', function (hooks) {
 
   test('it renders with a hint', async function (assert) {
     await render(<template>
-      <Autocomplete @label="Label" @hint="Hint text" data-autocomplete />
+      <Autocomplete
+        @noResultsText="No results"
+        @label="Label"
+        @hint="Hint text"
+        data-autocomplete
+      />
     </template>);
 
     let hint = find('[data-hint]');
@@ -58,7 +63,7 @@ module('Integration | Component | Fields | Autocomplete', function (hooks) {
 
   test('it renders with a hint and label block', async function (assert) {
     await render(<template>
-      <Autocomplete data-autocomplete>
+      <Autocomplete @noResultsText="No results" data-autocomplete>
         <:label><span data-label>label block content</span></:label>
         <:hint><span data-hint>hint block content</span></:hint>
       </Autocomplete>
@@ -70,7 +75,12 @@ module('Integration | Component | Fields | Autocomplete', function (hooks) {
 
   test('it renders with an error', async function (assert) {
     await render(<template>
-      <Autocomplete @label="Label" @error="Error text" data-autocomplete />
+      <Autocomplete
+        @label="Label"
+        @error="Error text"
+        @noResultsText="No results"
+        data-autocomplete
+      />
     </template>);
 
     let error = find('[data-error]');
@@ -107,6 +117,7 @@ module('Integration | Component | Fields | Autocomplete', function (hooks) {
         @label="Label"
         @error="Error text"
         @hint="Hint text"
+        @noResultsText="No results"
         data-autocomplete
       />
     </template>);
@@ -126,7 +137,12 @@ module('Integration | Component | Fields | Autocomplete', function (hooks) {
 
   test('it disables the input using `@isDisabled` and renders a lock icon', async function (assert) {
     await render(<template>
-      <Autocomplete @label="Label" @isDisabled={{true}} data-autocomplete />
+      <Autocomplete
+        @label="Label"
+        @isDisabled={{true}}
+        @noResultsText="No results"
+        data-autocomplete
+      />
     </template>);
 
     assert.dom('[data-autocomplete]').isDisabled();
@@ -137,7 +153,12 @@ module('Integration | Component | Fields | Autocomplete', function (hooks) {
 
   test('it sets readonly on the input using `@isReadOnly` and renders a lock icon', async function (assert) {
     await render(<template>
-      <Autocomplete @label="Label" @isReadOnly={{true}} data-autocomplete />
+      <Autocomplete
+        @label="Label"
+        @isReadOnly={{true}}
+        @noResultsText="No results"
+        data-autocomplete
+      />
     </template>);
 
     assert.dom('[data-autocomplete]').hasAttribute('readonly');
@@ -149,6 +170,7 @@ module('Integration | Component | Fields | Autocomplete', function (hooks) {
     await render(<template>
       <Autocomplete
         @label="Label"
+        @noResultsText="No results"
         placeholder="Placeholder text"
         data-autocomplete
       />
@@ -161,7 +183,12 @@ module('Integration | Component | Fields | Autocomplete', function (hooks) {
 
   test('it sets the value attribute via `@selected`', async function (assert) {
     await render(<template>
-      <Autocomplete @label="Label" @selected="blue" data-autocomplete />
+      <Autocomplete
+        @label="Label"
+        @noResultsText="No results"
+        @selected="blue"
+        data-autocomplete
+      />
     </template>);
 
     assert.dom('[data-autocomplete]').hasValue('blue');
@@ -183,6 +210,7 @@ module('Integration | Component | Fields | Autocomplete', function (hooks) {
     await render(<template>
       <Autocomplete
         @label="Label"
+        @noResultsText="No results"
         @options={{options}}
         @onChange={{handleChange}}
         data-autocomplete
@@ -207,6 +235,7 @@ module('Integration | Component | Fields | Autocomplete', function (hooks) {
     await render(<template>
       <Autocomplete
         @label="Label"
+        @noResultsText="No results"
         @rootTestSelector="selector"
         data-autocomplete
       />
@@ -227,7 +256,7 @@ module('Integration | Component | Fields | Autocomplete', function (hooks) {
       );
     });
 
-    await render(<template><Autocomplete /></template>);
+    await render(<template><Autocomplete @noResultsText="No results" /></template>);
   });
 
   test('it throws an assertion error if a `@label` and :label are provided', async function (assert) {
@@ -243,7 +272,7 @@ module('Integration | Component | Fields | Autocomplete', function (hooks) {
     });
 
     await render(<template>
-      <Autocomplete @label="Label">
+      <Autocomplete @label="Label" @noResultsText="No results">
         <:label>Label</:label>
       </Autocomplete>
     </template>);

--- a/test-app/tests/integration/components/autocomplete-test.gts
+++ b/test-app/tests/integration/components/autocomplete-test.gts
@@ -10,7 +10,7 @@ module('Integration | Component | Autocomplete', function (hooks) {
   setupRenderingTest(hooks);
 
   test('it renders', async function (assert) {
-    await render(<template><Autocomplete data-autocomplete /></template>);
+    await render(<template><Autocomplete @noResultsText="No results" data-autocomplete /></template>);
 
     assert.dom('[data-autocomplete]').hasTagName('input');
     assert.dom('[data-autocomplete]').hasClass('text-titles-and-attributes');
@@ -33,7 +33,7 @@ module('Integration | Component | Autocomplete', function (hooks) {
 
   test('it disables the autocomplete using `@isDisabled`', async function (assert) {
     await render(<template>
-      <Autocomplete @isDisabled={{true}} data-autocomplete />
+      <Autocomplete @isDisabled={{true}} @noResultsText="No results"data-autocomplete />
     </template>);
 
     assert.dom('[data-autocomplete]').isDisabled();
@@ -45,7 +45,7 @@ module('Integration | Component | Autocomplete', function (hooks) {
 
   test('it sets readonly on the autocomplete using `@isReadOnly`', async function (assert) {
     await render(<template>
-      <Autocomplete @isReadOnly={{true}} data-autocomplete />
+      <Autocomplete @isReadOnly={{true}} @noResultsText="No results" data-autocomplete />
     </template>);
 
     assert.dom('[data-autocomplete]').hasAttribute('readonly');
@@ -60,7 +60,7 @@ module('Integration | Component | Autocomplete', function (hooks) {
 
   test('it spreads attributes to the underlying autocomplete', async function (assert) {
     await render(<template>
-      <Autocomplete placeholder="Placeholder text" data-autocomplete />
+      <Autocomplete @noResultsText="No results" placeholder="Placeholder text" data-autocomplete />
     </template>);
 
     assert
@@ -70,7 +70,7 @@ module('Integration | Component | Autocomplete', function (hooks) {
 
   test('it applies the error shadow when `@hasError={{true}}`', async function (assert) {
     await render(<template>
-      <Autocomplete @hasError={{true}} data-autocomplete />
+      <Autocomplete @hasError={{true}} @noResultsText="No results" data-autocomplete />
     </template>);
 
     assert.dom('[data-autocomplete]').hasClass('shadow-error-outline');
@@ -84,7 +84,7 @@ module('Integration | Component | Autocomplete', function (hooks) {
 
   test('it opens the popover on click', async function (assert) {
     await render(<template>
-      <Autocomplete @options={{testColors}} data-autocomplete />
+      <Autocomplete @noResultsText="No results" @options={{testColors}} data-autocomplete />
     </template>);
 
     assert.dom('[role="listbox"]').doesNotExist();
@@ -96,7 +96,7 @@ module('Integration | Component | Autocomplete', function (hooks) {
 
   test('it opens the popover when the input receives input', async function (assert) {
     await render(<template>
-      <Autocomplete @options={{testColors}} data-autocomplete />
+      <Autocomplete @noResultsText="No results" @options={{testColors}} data-autocomplete />
     </template>);
 
     assert.dom('[role="listbox"]').doesNotExist();
@@ -108,7 +108,7 @@ module('Integration | Component | Autocomplete', function (hooks) {
 
   test('it sets `aria-expanded` based on the popover state', async function (assert) {
     await render(<template>
-      <Autocomplete @options={{testColors}} data-autocomplete as |autocomplete|>
+      <Autocomplete @noResultsText="No results" @options={{testColors}} data-autocomplete as |autocomplete|>
         <autocomplete.Option data-option>
           {{autocomplete.option}}
         </autocomplete.Option>
@@ -126,7 +126,7 @@ module('Integration | Component | Autocomplete', function (hooks) {
 
   test('it sets `aria-controls`', async function (assert) {
     await render(<template>
-      <Autocomplete @options={{testColors}} data-autocomplete as |autocomplete|>
+      <Autocomplete @noResultsText="No results" @options={{testColors}} data-autocomplete as |autocomplete|>
         <autocomplete.Option data-option>
           {{autocomplete.option}}
         </autocomplete.Option>
@@ -141,6 +141,7 @@ module('Integration | Component | Autocomplete', function (hooks) {
       <Autocomplete
         @options={{testColors}}
         @contentClass="test-class"
+        @noResultsText="No results"
         data-autocomplete
       />
     </template>);
@@ -156,6 +157,7 @@ module('Integration | Component | Autocomplete', function (hooks) {
       <Autocomplete
         @options={{testColors}}
         @contentClass="test-class"
+        @noResultsText="No results"
         data-autocomplete
         as |autocomplete|
       >
@@ -176,6 +178,7 @@ module('Integration | Component | Autocomplete', function (hooks) {
       <Autocomplete
         @selected="blue"
         @options={{testColors}}
+        @noResultsText="No results"
         data-autocomplete
         as |autocomplete|
       >
@@ -193,6 +196,7 @@ module('Integration | Component | Autocomplete', function (hooks) {
       <Autocomplete
         @selected="blue"
         @options={{testColors}}
+        @noResultsText="No results"
         data-autocomplete
         as |autocomplete|
       >
@@ -215,7 +219,7 @@ module('Integration | Component | Autocomplete', function (hooks) {
 
   test('it provides default filtering', async function (assert) {
     await render(<template>
-      <Autocomplete @options={{testColors}} data-autocomplete as |autocomplete|>
+      <Autocomplete @noResultsText="No results" @options={{testColors}} data-autocomplete as |autocomplete|>
         <autocomplete.Option>{{autocomplete.option}}</autocomplete.Option>
       </Autocomplete>
     </template>);
@@ -277,6 +281,7 @@ module('Integration | Component | Autocomplete', function (hooks) {
 
     await render(<template>
       <Autocomplete
+        @noResultsText="No results"
         @options={{testColors}}
         @onChange={{handleChange}}
         data-autocomplete
@@ -309,6 +314,7 @@ module('Integration | Component | Autocomplete', function (hooks) {
 
     await render(<template>
       <Autocomplete
+        @noResultsText="No results"
         @options={{testColors}}
         @onChange={{handleChange}}
         data-autocomplete
@@ -350,6 +356,7 @@ module('Integration | Component | Autocomplete', function (hooks) {
         @selected="blue"
         @options={{testColors}}
         @onFilter={{handleFilter}}
+        @noResultsText="No results"
         data-autocomplete
         as |autocomplete|
       >
@@ -369,6 +376,7 @@ module('Integration | Component | Autocomplete', function (hooks) {
       <Autocomplete
         @selected="blue"
         @options={{testColors}}
+        @noResultsText="No results"
         data-autocomplete
         as |autocomplete|
       >
@@ -393,6 +401,7 @@ module('Integration | Component | Autocomplete', function (hooks) {
       <Autocomplete
         @selected="blue"
         @options={{testColors}}
+        @noResultsText="No results"
         data-autocomplete
         as |autocomplete|
       >
@@ -422,6 +431,7 @@ module('Integration | Component | Autocomplete', function (hooks) {
       <Autocomplete
         @selected="red"
         @options={{testColors}}
+        @noResultsText="No results"
         data-autocomplete
         as |autocomplete|
       >
@@ -445,7 +455,7 @@ module('Integration | Component | Autocomplete', function (hooks) {
 
   test('it closes an open popover when the ESCAPE key is pressed', async function (assert) {
     await render(<template>
-      <Autocomplete @options={{testColors}} data-autocomplete as |autocomplete|>
+      <Autocomplete @noResultsText="No results" @options={{testColors}} data-autocomplete as |autocomplete|>
         <autocomplete.Option>{{autocomplete.option}}</autocomplete.Option>
       </Autocomplete>
     </template>);
@@ -464,7 +474,7 @@ module('Integration | Component | Autocomplete', function (hooks) {
       {{! template-lint-disable require-input-label }}
       <input placeholder="test" data-input />
 
-      <Autocomplete @options={{testColors}} data-autocomplete as |autocomplete|>
+      <Autocomplete @noResultsText="No results" @options={{testColors}} data-autocomplete as |autocomplete|>
         <autocomplete.Option>{{autocomplete.option}}</autocomplete.Option>
       </Autocomplete>
     </template>);
@@ -482,7 +492,7 @@ module('Integration | Component | Autocomplete', function (hooks) {
 
   test('it reopens the popover when any key is pressed if the popover is closed', async function (assert) {
     await render(<template>
-      <Autocomplete @options={{testColors}} data-autocomplete as |autocomplete|>
+      <Autocomplete @noResultsText="No results" @options={{testColors}} data-autocomplete as |autocomplete|>
         <autocomplete.Option>{{autocomplete.option}}</autocomplete.Option>
       </Autocomplete>
     </template>);
@@ -506,6 +516,7 @@ module('Integration | Component | Autocomplete', function (hooks) {
       <Autocomplete
         @selected="f"
         @options={{options}}
+        @noResultsText="No results"
         data-autocomplete
         as |autocomplete|
       >
@@ -537,6 +548,7 @@ module('Integration | Component | Autocomplete', function (hooks) {
       <Autocomplete
         @selected="a"
         @options={{options}}
+        @noResultsText="No results"
         data-autocomplete
         as |autocomplete|
       >
@@ -569,6 +581,7 @@ module('Integration | Component | Autocomplete', function (hooks) {
       <Autocomplete
         @selected="a"
         @options={{options}}
+        @noResultsText="No results"
         data-autocomplete
         as |autocomplete|
       >
@@ -599,6 +612,7 @@ module('Integration | Component | Autocomplete', function (hooks) {
       <Autocomplete
         @selected="f"
         @options={{options}}
+        @noResultsText="No results"
         data-autocomplete
         as |autocomplete|
       >
@@ -628,6 +642,7 @@ module('Integration | Component | Autocomplete', function (hooks) {
       <Autocomplete
         @selected="f"
         @options={{options}}
+        @noResultsText="No results"
         data-autocomplete
         as |autocomplete|
       >
@@ -670,6 +685,7 @@ module('Integration | Component | Autocomplete', function (hooks) {
         @selected="blue"
         @options={{testColors}}
         @onChange={{handleChange}}
+        @noResultsText="No results"
         data-autocomplete
         as |autocomplete|
       >
@@ -706,6 +722,7 @@ module('Integration | Component | Autocomplete', function (hooks) {
         @selected="blue"
         @options={{testColors}}
         @onChange={{handleChange}}
+        @noResultsText="No results"
         data-autocomplete
         as |autocomplete|
       >
@@ -744,6 +761,7 @@ module('Integration | Component | Autocomplete', function (hooks) {
       <Autocomplete
         @selected="blue"
         @options={{testColors}}
+        @noResultsText="No results"
         data-autocomplete
         as |autocomplete|
       >

--- a/test-app/tests/integration/components/toucan-form/form-autocomplete-test.gts
+++ b/test-app/tests/integration/components/toucan-form/form-autocomplete-test.gts
@@ -24,6 +24,7 @@ module('Integration | Component | ToucanForm | Autocomplete', function (hooks) {
           @label="Label"
           @hint="Hint"
           @name="selection"
+          @noResultsText="No results"
           @options={{options}}
           data-autocomplete
           as |autocomplete|
@@ -49,6 +50,7 @@ module('Integration | Component | ToucanForm | Autocomplete', function (hooks) {
         <form.Autocomplete
           @hint="Hint"
           @name="selection"
+          @noResultsText="No results"
           @options={{options}}
           data-autocomplete
         >
@@ -79,6 +81,7 @@ module('Integration | Component | ToucanForm | Autocomplete', function (hooks) {
         <form.Autocomplete
           @label="Label"
           @name="selection"
+          @noResultsText="No results"
           @options={{options}}
           data-autocomplete
         >
@@ -108,6 +111,7 @@ module('Integration | Component | ToucanForm | Autocomplete', function (hooks) {
       <ToucanForm @data={{data}} as |form|>
         <form.Autocomplete
           @name="selection"
+          @noResultsText="No results"
           @options={{options}}
           data-autocomplete
         >

--- a/test-app/tests/integration/components/toucan-form/toucan-form-test.gts
+++ b/test-app/tests/integration/components/toucan-form/toucan-form-test.gts
@@ -194,6 +194,7 @@ module('Integration | Component | ToucanForm', function (hooks) {
         <form.Autocomplete
           @label="Autocomplete"
           @name="autocomplete"
+          @noResultsText="No results"
           @options={{options}}
           data-autocomplete
           as |autocomplete|
@@ -473,6 +474,7 @@ module('Integration | Component | ToucanForm', function (hooks) {
           @label="Autocomplete"
           @name="autocomplete"
           @options={{options}}
+          @noResultsText="No results"
           @rootTestSelector="data-autocomplete-wrapper"
           data-autocomplete
           as |autocomplete|


### PR DESCRIPTION
<!-- Hello! This template is automatically added to help write up your pull request. Feel free to delete these comments, although they won't show up in the rendered markdown! This is only a template, feel free to adjust as you please! -->

## 🚀 Description

Makes `@noResultsText` required as a followup to [this discussion](https://github.com/CrowdStrike/ember-toucan-core/pull/238#discussion_r1276486527).

- Makes Autocomplete `@noResultsText` required
- Adds "Optional" descriptors to Autocomplete's arguments documentation
- Add "No results text" to Autocomplete Field documentation
- Moves Multiselect's `@noResultsText` documentation to the top because it's required

## 🔬 How to Test

We're good as long as the build is green.
