### PR TITLE
Add "Select all" functionality to multiselect

### DIFF
--- a/.changeset/two-pets-travel.md
+++ b/.changeset/two-pets-travel.md
@@ -1,0 +1,6 @@
+---
+'@crowdstrike/ember-toucan-core': patch
+'@crowdstrike/ember-toucan-form': patch
+---
+
+Adds "Select all" functionality to the `Multiselect` via a new component argument. Provide `@selectAllText` to opt-in to the functionality.

--- a/docs/components/multiselect-field/index.md
+++ b/docs/components/multiselect-field/index.md
@@ -53,7 +53,7 @@ Provide a string to the `@label` component argument or content to the `:label` n
 
 Required.
 
-A `:chip` block is required and is used for rendering each selected option. 
+A `:chip` block is required and is used for rendering each selected option.
 The block has the following block parameters:
 
 - `index`: The index of the current chip
@@ -72,8 +72,8 @@ The `Chip` component allows for slight customization to the underlying chip.
 </:chip>
 ```
 
-The `Remove` component contains the removal `X` on each selected chip. 
-Clicking the button will remove the item from the selected options array. 
+The `Remove` component contains the removal `X` on each selected chip.
+Clicking the button will remove the item from the selected options array.
 When the multiselect is disabled or in the readonly state, the button will not be available.
 
 A `@label` argument is **required** for accessibility reasons for the Remove component.
@@ -134,7 +134,7 @@ An example with translations may be something like:
 
 Required.
 
-`@noResultsText` is shown when there are no results after filtering. 
+`@noResultsText` is shown when there are no results after filtering.
 
 ```hbs
 <Form::Fields::Multiselect
@@ -298,6 +298,44 @@ import { tracked } from '@glimmer/tracking';
 export default class extends Component {
   @tracked selected;
 }
+```
+
+## Select all
+
+Optional.
+
+"Select all" functionality can be opted into by providing the `@selectAllText` argument.
+
+By providing this argument, a checkbox will be rendered at the top of the list to allow users a convenient way to select all visible options. When clicking this item, all `@options` are returned to the `@onChange` handler. The "Select all" checkbox has the following state rules:
+
+- The checkbox only appears when filtering is not active.
+- The checkbox will be checked when all options are selected.
+- If no options are selected, the checkbox will be unchecked.
+- If more than one option is selected, but not all of them, then the checkbox will be in the indeterminate state.
+- When the checkbox is in the indeterminate state, clicking the checkbox re-selects all options.
+
+```hbs
+<Form::Fields::Multiselect
+  @contentClass='z-10'
+  @label='Label'
+  @onChange={{this.onChange}}
+  @options={{this.options}}
+  @selectAllText='Select all'
+  @selected={{this.selected}}
+>
+  <:chip as |chip|>
+    <chip.Chip>
+      {{chip.option}}
+      <chip.Remove @label={{(concat 'Remove' ' ' chip.option)}} />
+    </chip.Chip>
+  </:chip>
+
+  <:default as |multiselect|>
+    <multiselect.Option>
+      {{multiselect.option}}
+    </multiselect.Option>
+  </:default>
+</Form::Fields::Multiselect>
 ```
 
 ## onFilter

--- a/docs/components/multiselect/demo/base-demo.md
+++ b/docs/components/multiselect/demo/base-demo.md
@@ -2,7 +2,7 @@
 <div class='flex flex-col gap-4 w-96'>
   <Form::Controls::Multiselect
     @contentClass='z-10'
-    @noResultsText="No results"
+    @noResultsText='No results'
     @onChange={{this.onChange}}
     @options={{this.options}}
     @selected={{this.selected}}
@@ -24,7 +24,7 @@
 
   <Form::Controls::Multiselect
     @contentClass='z-10'
-    @noResultsText="No results"
+    @noResultsText='No results'
     @onChange={{this.onChange2}}
     @options={{this.options2}}
     @selected={{this.selected2}}
@@ -46,12 +46,35 @@
 
   <Form::Controls::Multiselect
     @contentClass='z-10'
-    @noResultsText="No results"
+    @noResultsText='No results'
     @onChange={{this.onChange3}}
     @onFilter={{this.onFilter}}
     @options={{this.options}}
     @selected={{this.selected3}}
     placeholder='Colors w/ Filtering'
+  >
+    <:chip as |chip|>
+      <chip.Chip>
+        {{chip.option}}
+        <chip.Remove @label={{(concat 'Remove' ' ' chip.option)}} />
+      </chip.Chip>
+    </:chip>
+
+    <:default as |multiselect|>
+      <multiselect.Option>
+        {{multiselect.option}}
+      </multiselect.Option>
+    </:default>
+  </Form::Controls::Multiselect>
+
+  <Form::Controls::Multiselect
+    @contentClass='z-10'
+    @noResultsText='No results'
+    @onChange={{this.onChange4}}
+    @options={{this.options}}
+    @selected={{this.selected4}}
+    @selectAllText='Select all'
+    placeholder='Colors w/ Select All'
   >
     <:chip as |chip|>
       <chip.Chip>
@@ -78,6 +101,7 @@ export default class extends Component {
   @tracked selected;
   @tracked selected2;
   @tracked selected3;
+  @tracked selected4;
 
   options = [
     {
@@ -145,6 +169,12 @@ export default class extends Component {
   @action
   onChange3(option) {
     this.selected3 = option;
+    console.log(option);
+  }
+
+  @action
+  onChange4(option) {
+    this.selected4 = option;
     console.log(option);
   }
 

--- a/docs/components/multiselect/index.md
+++ b/docs/components/multiselect/index.md
@@ -7,7 +7,7 @@ If you are building forms, you may be interested in the [MultiselectField](./mul
 
 Required.
 
-A `:chip` block is required and is used for rendering each selected option. 
+A `:chip` block is required and is used for rendering each selected option.
 The block returns the following:
 
 - `index`: The index of the current chip
@@ -26,8 +26,8 @@ The `Chip` component allows for slight customization to the underlying chip.
 </:chip>
 ```
 
-The `Remove` component contains the removal `X` on each selected chip. 
-Clicking the button will remove the item from the selected options array. 
+The `Remove` component contains the removal `X` on each selected chip.
+Clicking the button will remove the item from the selected options array.
 When the multiselect is disabled or in the readonly state, the button will not be available.
 
 A `@label` argument is **required** for accessibility reasons for the Remove component.
@@ -36,7 +36,7 @@ The `option` for that chip is yielded back to the consumer so that an appropriat
 
 ```hbs
 <Form::Controls::Multiselect
-  @noResultsText="No results"
+  @noResultsText='No results'
   @onChange={{this.onChange}}
   @options={{this.options}}
   @contentClass='z-10'
@@ -62,7 +62,7 @@ An example with translations may be something like:
 
 ```hbs
 <Form::Controls::Multiselect
-  @noResultsText="No results"
+  @noResultsText='No results'
   @onChange={{this.onChange}}
   @options={{this.options}}
   @contentClass='z-10'
@@ -88,12 +88,12 @@ An example with translations may be something like:
 
 Required.
 
-`@noResultsText` is shown when there are no results after filtering. 
+`@noResultsText` is shown when there are no results after filtering.
 
 ```hbs
 <Form::Controls::Multiselect
   @contentClass='z-10'
-  @noResultsText="No results"
+  @noResultsText='No results'
   @onChange={{this.onChange}}
   @options={{this.options}}
   @selected={{this.selected}}
@@ -205,6 +205,43 @@ export default class extends Component {
 }
 ```
 
+## Select all
+
+Optional.
+
+"Select all" functionality can be opted into by providing the `@selectAllText` argument.
+
+By providing this argument, a checkbox will be rendered at the top of the list to allow users a convenient way to select all visible options. When clicking this item, all `@options` are returned to the `@onChange` handler. The "Select all" checkbox has the following state rules:
+
+- The checkbox only appears when filtering is not active.
+- The checkbox will be checked when all options are selected.
+- If no options are selected, the checkbox will be unchecked.
+- If more than one option is selected, but not all of them, then the checkbox will be in the indeterminate state.
+- When the checkbox is in the indeterminate state, clicking the checkbox re-selects all options.
+
+```hbs
+<Form::Controls::Multiselect
+  @contentClass='z-10'
+  @onChange={{this.onChange}}
+  @options={{this.options}}
+  @selectAllText='Select all'
+  @selected={{this.selected}}
+>
+  <:chip as |chip|>
+    <chip.Chip>
+      {{chip.option}}
+      <chip.Remove @label={{(concat 'Remove' ' ' chip.option)}} />
+    </chip.Chip>
+  </:chip>
+
+  <:default as |multiselect|>
+    <multiselect.Option>
+      {{multiselect.option}}
+    </multiselect.Option>
+  </:default>
+</Form::Controls::Multiselect>
+```
+
 ## onFilter
 
 Optional.
@@ -214,7 +251,7 @@ Specify `onFilter` if you want to do something different.
 
 ```hbs
 <Form::Controls::Multiselect
-  @noResultsText="No results"
+  @noResultsText='No results'
   @onFilter={{this.onFilter}}
   @onChange={{this.onChange}}
   @options={{this.options}}

--- a/packages/ember-toucan-core/src/-private/components/form/controls/multiselect/select-all.hbs
+++ b/packages/ember-toucan-core/src/-private/components/form/controls/multiselect/select-all.hbs
@@ -1,0 +1,47 @@
+{{! template-lint-disable require-presentational-children }}
+{{#let (unique-id) as |uniqueId|}}
+  <li
+    aria-selected={{if @isSelected "true" "false"}}
+    class="my-0 cursor-default px-2 leading-4
+      {{this.styles}}
+      {{this.className}}
+      "
+    data-active={{if @isActive "true" "false"}}
+    data-multiselect-select-all-option
+    id="{{@popoverId}}-{{@index}}"
+    role="option"
+    {{on "click" this.onClick}}
+    {{! template-lint-disable no-pointer-down-event-binding }}
+    {{on "mousedown" this.onMousedown}}
+    {{on "mouseover" @onMouseover}}
+    ...attributes
+  >
+    <div class="border-lines-dark flex w-full items-center gap-2 border-b py-2">
+      {{!
+          We set `tabindex="-1"` here to remove the checkbox from the tab order.
+          Instead, we allow the user to use the keyboard arrows to "focus" and
+          make options active.  If we remove this line, you'll notice that the
+          focus returns to the body when tabbing out of the multiautocomplete
+          component, which is a strange user experience.
+
+          Template lint doesn't like us setting tabindex, but we need it here
+          as we don't want these elements focusable!
+      }}
+      {{! template-lint-disable no-nested-interactive }}
+      <Form::Controls::Checkbox
+        data-multiselect-select-all-checkbox
+        id={{uniqueId}}
+        tabindex="-1"
+        @isChecked={{@isSelected}}
+        @isDisabled={{@isDisabled}}
+        @isIndeterminate={{@isIndeterminate}}
+        @isReadOnly={{@isReadOnly}}
+        @value={{@value}}
+      />
+
+      <span>
+        {{yield}}
+      </span>
+    </div>
+  </li>
+{{/let}}

--- a/packages/ember-toucan-core/src/-private/components/form/controls/multiselect/select-all.ts
+++ b/packages/ember-toucan-core/src/-private/components/form/controls/multiselect/select-all.ts
@@ -1,7 +1,9 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 
-interface ToucanFormMultiselectOptionControlComponentSignature {
+import { className } from './option';
+
+interface ToucanFormMultiselectSelectAllControlComponentSignature {
   Args: {
     /**
      * When true, means that the option is currently hovered over with a mouse
@@ -13,6 +15,11 @@ interface ToucanFormMultiselectOptionControlComponentSignature {
      * Sets the underlying checkbox element to disabled.
      */
     isDisabled?: boolean;
+
+    /**
+     * Sets the undelrying checkbox to the indeterminate state.
+     */
+    isIndeterminate?: boolean;
 
     /**
      * Sets the underlying checkbox element to readonly.
@@ -56,11 +63,9 @@ interface ToucanFormMultiselectOptionControlComponentSignature {
   Element: HTMLLIElement;
 }
 
-export const className = 'toucan-form-select-option-control';
-
-export const selector = `.${className}`;
-
-export default class ToucanFormMultiselectOptionControlComponent extends Component<ToucanFormMultiselectOptionControlComponentSignature> {
+export default class ToucanFormMultiselectSelectAllControlComponent extends Component<ToucanFormMultiselectSelectAllControlComponentSignature> {
+  // NOTE: This shares the className with the option component
+  //       so that both listbox items have a common selector.
   className = className;
 
   get styles() {

--- a/packages/ember-toucan-core/src/components/form/controls/multiselect.hbs
+++ b/packages/ember-toucan-core/src/components/form/controls/multiselect.hbs
@@ -1,9 +1,5 @@
 {{#if
-  (this.assertRequiredBlocksExist
-    (hash
-      chipBlockExists=(has-block "chip")
-    )
-  )
+  (this.assertRequiredBlocksExist (hash chipBlockExists=(has-block "chip")))
 }}
   <Velcro
     @middleware={{this.velcroMiddleware}}
@@ -120,23 +116,40 @@
         {{velcro.loop}}
       >
         {{#if this.options}}
+          {{#if this.isSelectAllVisible}}
+            <this.SelectAllComponent
+              @index={{0}}
+              @isActive={{(this.isEqual 0 this.activeIndex)}}
+              @isDisabled={{@isDisabled}}
+              @isSelected={{this.isSelectAllChecked}}
+              @isIndeterminate={{this.isSelectAllIndeterminate}}
+              @onClick={{this.onChange}}
+              @onMouseover={{(fn this.onOptionMouseover 0)}}
+              @popoverId={{this.popoverId}}
+            >
+              {{@selectAllText}}
+            </this.SelectAllComponent>
+          {{/if}}
+
           {{#each this.options as |option index|}}
-            {{yield
-              (hash
-                Option=(component
-                  (ensure-safe-component this.Option)
-                  isActive=(this.isEqual index this.activeIndex)
-                  isDisabled=@isDisabled
-                  isSelected=(this.isSelected option)
-                  isReadOnly=@isReadOnly
-                  onClick=(fn this.onChange index)
-                  onMouseover=(fn this.onOptionMouseover index)
-                  popoverId=this.popoverId
-                  index=index
+            {{#let (this.generateIndex index) as |generatedIndex|}}
+              {{yield
+                (hash
+                  Option=(component
+                    (ensure-safe-component this.Option)
+                    isActive=(this.isEqual generatedIndex this.activeIndex)
+                    isDisabled=@isDisabled
+                    isSelected=(this.isSelected option)
+                    isReadOnly=@isReadOnly
+                    onClick=this.onChange
+                    onMouseover=(fn this.onOptionMouseover generatedIndex)
+                    popoverId=this.popoverId
+                    index=(if this.isSelectAllEnabled generatedIndex index)
+                  )
+                  option=option
                 )
-                option=option
-              )
-            }}
+              }}
+            {{/let}}
           {{/each}}
         {{else}}
           <li

--- a/packages/ember-toucan-core/src/components/form/fields/multiselect.hbs
+++ b/packages/ember-toucan-core/src/components/form/fields/multiselect.hbs
@@ -57,6 +57,7 @@
         @onChange={{@onChange}}
         @onFilter={{@onFilter}}
         @options={{@options}}
+        @selectAllText={{@selectAllText}}
         @selected={{@selected}}
         ...attributes
       >

--- a/packages/ember-toucan-core/src/components/form/fields/multiselect.ts
+++ b/packages/ember-toucan-core/src/components/form/fields/multiselect.ts
@@ -71,6 +71,19 @@ export interface ToucanFormMultiselectFieldComponentSignature {
     rootTestSelector?: string;
 
     /**
+     * A string to render as the "Select all" option label.  By providing this argument,
+     * you are opting into the "Select all" functionality and the checkbox will be rendered
+     * at the top of the popover.
+     *
+     * - The checkbox only appears when filtering is not active.
+     * - The checkbox will be checked when all options are selected.
+     * - If no options are selected, the checkbox will be unchecked.
+     * - If more than one option is selected, but not all of them, then the checkbox will be in the indeterminate state.
+     * - When the checkbox is in the indeterminate state, clicking the checkbox re-selects all options.
+     */
+    selectAllText?: string;
+
+    /**
      * The currently selected option.
      */
     selected?: ToucanFormMultiselectControlComponentSignature['Args']['selected'];

--- a/packages/ember-toucan-form/src/-private/multiselect-field.hbs
+++ b/packages/ember-toucan-form/src/-private/multiselect-field.hbs
@@ -31,6 +31,7 @@
       @onFilter={{@onFilter}}
       @options={{@options}}
       @rootTestSelector={{@rootTestSelector}}
+      @selectAllText={{@selectAllText}}
       @selected={{this.assertSelected field.value}}
       name={{@name}}
       ...attributes
@@ -73,6 +74,7 @@
       @onFilter={{@onFilter}}
       @options={{@options}}
       @rootTestSelector={{@rootTestSelector}}
+      @selectAllText={{@selectAllText}}
       @selected={{this.assertSelected field.value}}
       name={{@name}}
       ...attributes
@@ -115,6 +117,7 @@
       @onFilter={{@onFilter}}
       @options={{@options}}
       @rootTestSelector={{@rootTestSelector}}
+      @selectAllText={{@selectAllText}}
       @selected={{this.assertSelected field.value}}
       name={{@name}}
       ...attributes
@@ -157,6 +160,7 @@
       @onFilter={{@onFilter}}
       @options={{@options}}
       @rootTestSelector={{@rootTestSelector}}
+      @selectAllText={{@selectAllText}}
       @selected={{this.assertSelected field.value}}
       name={{@name}}
       ...attributes

--- a/test-app/tests/integration/components/multiselect-field-test.gts
+++ b/test-app/tests/integration/components/multiselect-field-test.gts
@@ -376,6 +376,37 @@ module('Integration | Component | Fields | Multiselect', function (hooks) {
     assert.verifySteps(['handleChange']);
   });
 
+  // NOTE: This functionality is tested more in-depth via the control component
+  // integration test.  We simply want to ensure the component argument gets
+  // passed through in this test.
+  test('it renders the `Select all` option', async function (assert) {
+    await render(<template>
+      <Multiselect
+        @label="Label"
+        @noResultsText="No results"
+        @selectAllText="Select all"
+        @options={{testColors}}
+        data-multiselect
+      >
+        <:chip as |chip|>
+          <chip.Chip>
+            {{chip.option}}
+            <chip.Remove @label="Remove" />
+          </chip.Chip>
+        </:chip>
+
+        <:default as |multiselect|>
+          <multiselect.Option>{{multiselect.option}}</multiselect.Option>
+        </:default>
+      </Multiselect>
+    </template>);
+
+    await click('[data-multiselect]');
+
+    assert.dom('[data-multiselect-select-all-option]').exists();
+    assert.dom('[data-multiselect-select-all-option]').hasText('Select all');
+  });
+
   test('it throws an assertion error if no `@label` is provided', async function (assert) {
     assert.expect(1);
 

--- a/test-app/tests/integration/components/toucan-form/form-multiselect-test.gts
+++ b/test-app/tests/integration/components/toucan-form/form-multiselect-test.gts
@@ -1,4 +1,4 @@
-import { render } from '@ember/test-helpers';
+import { click, render } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 
 import ToucanForm from '@crowdstrike/ember-toucan-form/components/toucan-form';
@@ -152,5 +152,41 @@ module('Integration | Component | ToucanForm | Multiselect', function (hooks) {
 
     assert.dom('[data-label-block]').exists();
     assert.dom('[data-hint-block]').exists();
+  });
+
+  test('it renders the `Select all` option', async function (assert) {
+    const data: TestData = {
+      selection: undefined,
+    };
+
+    await render(<template>
+      <ToucanForm @data={{data}} as |form|>
+        <form.Multiselect
+          @label="Label"
+          @hint="Hint"
+          @name="selection"
+          @noResultsText="No results"
+          @options={{options}}
+          @selectAllText="Select all"
+          data-multiselect
+        >
+          <:chip as |chip|>
+            <chip.Chip>
+              {{chip.option}}
+              <chip.Remove @label="Remove" />
+            </chip.Chip>
+          </:chip>
+
+          <:default as |multiselect|>
+            <multiselect.Option>{{multiselect.option}}</multiselect.Option>
+          </:default>
+        </form.Multiselect>
+      </ToucanForm>
+    </template>);
+
+    await click('[data-multiselect]');
+
+    assert.dom('[data-multiselect-select-all-option]').exists();
+    assert.dom('[data-multiselect-select-all-option]').hasText('Select all');
   });
 });


### PR DESCRIPTION
## 🚀 Description

Adds "Select all" functionality to multiselect.

---

## 🔬 How to Test

- Visit https://8b4676f3.ember-toucan-core.pages.dev/docs/components/multiselect
- For this section, use the bottom multiselect ( "With Select All" )

**Select all states**
- Click the multiselect
- Click "Select all"
  - Verify the checkbox is checked
  - Verify all items in the popover are also checked
- Click "Orange"
  - Verify "Orange" is removed from the list
  - Verify the "Select all" checkbox is now in the indeterminate state
- Click "Select all" again
  - Verify all items are selected again and "Orange", in particular, is re-added
- Click "Select all" again
  - Verify all items are unselected
  - Verify the "Select all" checkbox is unchecked

**Filtering**
- Click the multiselect
- Type into the multiselect to trigger filtering.  For example type "b" to filter down to "Blue"
- Verify "Select all" is no longer visible
- Select "Blue"
- Upon selecting, verify the filter clears and the "Select all" checkbox is now in the indeterminate state

Feel free to play more with this functionality!
---

## 📸 Images/Videos of Functionality

**Select all option**

<img width="432" alt="Screenshot 2023-08-02 at 8 17 05 AM" src="https://github.com/CrowdStrike/ember-toucan-core/assets/8069555/f3b2f464-d33d-49f4-b5e9-7d32e475c8c9">

**Indeterminate state**

<img width="413" alt="Screenshot 2023-08-02 at 8 17 57 AM" src="https://github.com/CrowdStrike/ember-toucan-core/assets/8069555/e44e29c2-c964-4232-a28f-91e79271cece">

**Select all not visible when filtering**

<img width="418" alt="Screenshot 2023-08-02 at 8 18 20 AM" src="https://github.com/CrowdStrike/ember-toucan-core/assets/8069555/a7dbab8d-3756-4399-a51b-74227158f44b">


**With a screenreader**

https://github.com/CrowdStrike/ember-toucan-core/assets/8069555/1df36b41-9885-47ce-8b10-817406755158


