### PR TITLE
Add event.preventDefault() when clicking on disabled button

### DIFF
--- a/.changeset/afraid-vans-attend.md
+++ b/.changeset/afraid-vans-attend.md
@@ -1,0 +1,5 @@
+---
+"@crowdstrike/ember-toucan-core": patch
+---
+
+Add event.preventDefault() when clicking on disabled button to prevent submitting a form

--- a/packages/ember-toucan-core/src/components/button.gts
+++ b/packages/ember-toucan-core/src/components/button.gts
@@ -110,6 +110,7 @@ export default class Button extends Component<ButtonSignature> {
   onClick(event: MouseEvent) {
     if (this.args.isDisabled) {
       event.stopImmediatePropagation();
+      event.preventDefault();
 
       return;
     }

--- a/test-app/tests/integration/components/button-test.gts
+++ b/test-app/tests/integration/components/button-test.gts
@@ -1,3 +1,4 @@
+import { on } from '@ember/modifier';
 import { click, render, setupOnerror } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 
@@ -120,13 +121,33 @@ module('Integration | Component | button', function (hooks) {
     assert.verifySteps(['clicked']);
   });
 
-  test('it does NOT call the provided `@onClick` if `@isDisabled={{true}}', async function (assert) {
+  test('it does NOT call the provided `@onClick` if `@isDisabled={{true}}`', async function (assert) {
     let handleClick = () => assert.step('clicked');
 
     await render(<template>
       <Button @isDisabled={{true}} @onClick={{handleClick}} data-button>
         button
       </Button>
+    </template>);
+
+    assert.verifySteps([]);
+
+    await click('[data-button]');
+
+    assert.verifySteps([]);
+  });
+
+  test('it does NOT submit the form if `@isDisabled={{true}}`', async function (assert) {
+    let handleSubmit = () => {
+      assert.step('submitted');
+    }
+
+    await render(<template>
+      <form {{on "submit" handleSubmit}}>
+        <Button @isDisabled={{true}} type="submit" data-button>
+          button
+        </Button>
+      </form>
     </template>);
 
     assert.verifySteps([]);


### PR DESCRIPTION
## 🚀 Description

When a type="submit" button has @isDisabled set, it does not prevent submitting the form, because the disabled state (for a11y reasons) does not add the disabled attribute.
Adding an `event.preventDefault()` prevent to send the submit event.

---

## 🔬 How to Test
Create a form with a submit action and add a `<Button @isDisabled={{true}} type="submit">button</Button>` inside the form and verify that the submit action is not fired when clicking the button.