### PR TITLE
fix: set value attribute on textarea instead of in content to ensure value and defaultValue stay in sync with changes

### DIFF
--- a/.changeset/spotty-lamps-shake.md
+++ b/.changeset/spotty-lamps-shake.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/ember-toucan-core': patch
+---
+
+Update Textarea to ensure underlying textarea value stays in sync with both typing and @value changes

--- a/.changeset/spotty-lamps-shake.md
+++ b/.changeset/spotty-lamps-shake.md
@@ -2,4 +2,4 @@
 '@crowdstrike/ember-toucan-core': patch
 ---
 
-Update Textarea to ensure underlying textarea value stays in sync with both typing and @value changes
+Update Textarea to ensure underlying <textarea> value stays in sync with both typing and @value changes

--- a/packages/ember-toucan-core/src/components/form/controls/textarea.gts
+++ b/packages/ember-toucan-core/src/components/form/controls/textarea.gts
@@ -80,7 +80,8 @@ export default class ToucanFormTextareaControlComponent extends Component<Toucan
         readonly={{@isReadOnly}}
         ...attributes
         {{on "input" this.handleInput}}
-      >{{@value}}</textarea>
+        value={{@value}}
+      ></textarea>
     </div>
   </template>
 }

--- a/test-app/tests/integration/components/textarea-test.gts
+++ b/test-app/tests/integration/components/textarea-test.gts
@@ -80,7 +80,7 @@ module('Integration | Component | Textarea', function (hooks) {
     assert.dom('[data-textarea]').hasValue('tony');
   });
 
-  test('it keeps the value in sync with external changes to `@value`', async function (assert) {
+  test('it keeps the <textarea> value in sync with external changes to `@value`', async function (assert) {
     class TestContext {
       @tracked testValue;
     }

--- a/test-app/tests/integration/components/textarea-test.gts
+++ b/test-app/tests/integration/components/textarea-test.gts
@@ -1,11 +1,11 @@
 /* eslint-disable no-undef -- Until https://github.com/ember-cli/eslint-plugin-ember/issues/1747 is resolved... */
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
 import { fillIn, render, settled } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 
 import TextareaControl from '@crowdstrike/ember-toucan-core/components/form/controls/textarea';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { tracked } from '@glimmer/tracking';
-import { action } from '@ember/object';
 
 module('Integration | Component | Textarea', function (hooks) {
   setupRenderingTest(hooks);
@@ -82,9 +82,11 @@ module('Integration | Component | Textarea', function (hooks) {
 
   test('it keeps the <textarea> value in sync with external changes to `@value`', async function (assert) {
     class TestContext {
-      @tracked testValue;
+      @tracked testValue = '';
     }
+
     const testContext = new TestContext();
+
     testContext.testValue = 'initial';
 
     await render(<template>
@@ -102,16 +104,18 @@ module('Integration | Component | Textarea', function (hooks) {
     assert.dom('[data-textarea]').hasValue('updated');
   });
 
-  test('it keeps the <textarea> value in sync with external changes to `@value` after the value is changed', async function (assert) { 
+  test('it keeps the <textarea> value in sync with external changes to `@value` after the value is changed', async function (assert) {
     class TestContext {
-      @tracked testValue;
+      @tracked testValue = '';
 
       @action
-      updateTestValue(value, e) {
+      updateTestValue(value: string) {
         this.testValue = value;
       }
     }
+
     const testContext = new TestContext();
+
     testContext.testValue = 'initial';
 
     await render(<template>

--- a/test-app/tests/integration/components/textarea-test.gts
+++ b/test-app/tests/integration/components/textarea-test.gts
@@ -102,7 +102,7 @@ module('Integration | Component | Textarea', function (hooks) {
     assert.dom('[data-textarea]').hasValue('updated');
   });
 
-  test('it keeps the value in sync with external changes to `@value` after the value is changed', async function (assert) {
+  test('it keeps the <textarea> value in sync with external changes to `@value` after the value is changed', async function (assert) { 
     class TestContext {
       @tracked testValue;
 


### PR DESCRIPTION
## 🚀 Description

Fixes issue #446 where the underlying `<textarea>` used in `Form::Controls::Textarea` gets out of sync with `@value` changes after typing in the `<textarea>`.

Also adds tests for both current working functionality of updating value before typing in the textarea and the previously broken case of typing in the textarea and then attempting an update of the value from outside the component.

---

## 🔬 How to Test

Added test cases should cover the functionality changing.

There's no external impact on existing examples to show.

Reversing the change in `textarea.gts` should result in one failed test case for the issue described in #446 
<!-- Please provide steps to test the functionality added/removed. Preview URLs are generated with each build.  We normally use the preview URLs and ask folks to review specific functionality based on them (e.g., "go to this page, view the new CSS changes"). -->
