### PR TITLE
fix: add `disabled` attribute to buttons

### DIFF
--- a/packages/ember-toucan-core/src/components/button.gts
+++ b/packages/ember-toucan-core/src/components/button.gts
@@ -121,6 +121,7 @@ export default class Button extends Component<ButtonSignature> {
   <template>
     <button
       aria-disabled={{if @isDisabled "true"}}
+      disabled={{@isDisabled}}
       class={{this.styles}}
       type="button"
       {{on "click" this.onClick}}

--- a/test-app/tests/integration/components/button-test.gts
+++ b/test-app/tests/integration/components/button-test.gts
@@ -125,35 +125,67 @@ module('Integration | Component | button', function (hooks) {
     let handleClick = () => assert.step('clicked');
 
     await render(<template>
-      <Button @isDisabled={{true}} @onClick={{handleClick}} data-button>
-        button
-      </Button>
+        <Button @isDisabled={{true}} @onClick={{handleClick}} data-button>
+          button
+        </Button>
     </template>);
 
     assert.verifySteps([]);
 
-    await click('[data-button]');
+    // Verify the button is disabled
+    const buttonElement = document.querySelector('[data-button]');
+    assert.true(buttonElement.disabled, 'Button is correctly disabled');
 
+    // Try to click the button, but expect an error
+    try {
+      await click('[data-button]');
+      assert.ok(false, 'Should not be able to click a disabled button');
+    } catch (error) {
+      assert.ok(
+        error.message.includes('disabled'),
+        `Expected error about disabled button: ${error.message}`,
+      );
+    }
+
+    // Manually trigger the click event to verify the handler isn't called
+    // This bypasses the disabled check that the click helper performs
+    buttonElement.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    // Verify the click handler wasn't called
     assert.verifySteps([]);
   });
 
   test('it does NOT submit the form if `@isDisabled={{true}}`', async function (assert) {
     let handleSubmit = () => {
       assert.step('submitted');
-    }
+    };
 
     await render(<template>
-      <form {{on "submit" handleSubmit}}>
-        <Button @isDisabled={{true}} type="submit" data-button>
-          button
-        </Button>
-      </form>
+        <form {{on "submit" handleSubmit}}>
+          <Button @isDisabled={{true}} type="submit" data-button>
+            button
+          </Button>
+        </form>
     </template>);
 
     assert.verifySteps([]);
 
-    await click('[data-button]');
+    // Verify the button is disabled
+    const buttonElement = document.querySelector('[data-button]');
+    assert.true(buttonElement.disabled, 'Button is correctly disabled');
 
+    // Try to click the button, but expect an error
+    try {
+      await click('[data-button]');
+      assert.ok(false, 'Should not be able to click a disabled button');
+    } catch (error) {
+      assert.ok(
+        error.message.includes('disabled'),
+        `Expected error about disabled button: ${error.message}`,
+      );
+    }
+
+    // Verify the form wasn't submitted
     assert.verifySteps([]);
   });
 


### PR DESCRIPTION
# 🚀 Description

This PR adds the native HTML `disabled` attribute to our Button component when `@isDisabled` is true. Previously, we were only setting `aria-disabled="true"` which provides accessibility information but doesn't actually prevent interaction with the button.

Changes include:
- [x] Added: Native `disabled` HTML attribute to the Button component
- [x] Updated: Tests to properly verify disabled button behavior
- [x] Fixed: Potential accessibility issue where disabled buttons could still be clicked programmatically

This change ensures that disabled buttons are truly non-interactive, improving both accessibility and user experience.

---

## 🔬 How to Test

1. Navigate to any page with buttons in the preview URL
2. Find or create a disabled button (using `@isDisabled={{true}}`)
3. Verify that:
   - The button appears visually disabled
   - The button cannot be clicked (cursor should show as not-allowed)
   - Screen readers announce the button as disabled
4. Try to programmatically click the button via browser console and verify it doesn't trigger the action

---

## 📸 Images/Videos of Functionality

Before:
- Button appears disabled visually but could still be clicked programmatically
- Only had `aria-disabled="true"` attribute

![image](https://github.com/user-attachments/assets/dffd5ff9-dcf9-4100-b783-5ca17cebd6b5)

After:
- Button has both `aria-disabled="true"` and native `disabled` attributes
- Button is completely non-interactive when disabled
- Tests properly verify the disabled state and behavior

![image](https://github.com/user-attachments/assets/1948e1cd-2705-41da-9645-601b3b33b0c3)
