### PR TITLE
fix(multiselect): scope chevron clicks to the correct container

### DIFF
--- a/.changeset/red-kiwis-eat.md
+++ b/.changeset/red-kiwis-eat.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/ember-toucan-core': patch
+---
+
+Fixed multiselect container click handler to properly focus the correct input element when multiple components are present

--- a/packages/ember-toucan-core/src/components/form/controls/multiselect.gts
+++ b/packages/ember-toucan-core/src/components/form/controls/multiselect.gts
@@ -692,10 +692,10 @@ export default class ToucanFormMultiselectControlComponent extends Component<Tou
       this.args.options && this.args.onFilter
         ? this.args.onFilter(value)
         : this.args.options
-        ? this.args.options.filter((option) => {
-            return option.toLowerCase().startsWith(value.toLowerCase());
-          })
-        : [];
+          ? this.args.options.filter((option) => {
+              return option.toLowerCase().startsWith(value.toLowerCase());
+            })
+          : [];
 
     if (this.filteredOptions?.length > 0) {
       this.activeIndex = 0;
@@ -717,9 +717,10 @@ export default class ToucanFormMultiselectControlComponent extends Component<Tou
    * directly on the input tag itself.
    */
   @action
-  handleContainerClick() {
+  handleContainerClick(event: MouseEvent) {
     if (!this.isPopoverOpen) {
-      const inputElement = document.querySelector(
+      const container = event.currentTarget as HTMLElement;
+      const inputElement = container.querySelector(
         '[data-toucan-multiselect-input]',
       );
 
@@ -768,7 +769,7 @@ export default class ToucanFormMultiselectControlComponent extends Component<Tou
         @placement="bottom-start"
         as |velcro|
       >
-      <div data-multiselect>
+        <div data-multiselect>
           {{! Disabling this rule as the user interacts with the input directly. The click on the div is simply for convenience. }}
           {{! template-lint-disable no-invalid-interactive }}
           <div
@@ -902,14 +903,18 @@ export default class ToucanFormMultiselectControlComponent extends Component<Tou
                       (hash
                         Option=(component
                           this.Option
-                          isActive=(this.isEqual generatedIndex this.activeIndex)
+                          isActive=(this.isEqual
+                            generatedIndex this.activeIndex
+                          )
                           isDisabled=@isDisabled
                           isSelected=(this.isSelected option)
                           isReadOnly=@isReadOnly
                           onClick=this.onChange
                           onMouseover=(fn this.onOptionMouseover generatedIndex)
                           popoverId=this.popoverId
-                          index=(if this.isSelectAllEnabled generatedIndex index)
+                          index=(if
+                            this.isSelectAllEnabled generatedIndex index
+                          )
                         )
                         option=option
                       )

--- a/test-app/tests/integration/components/multiselect-test.gts
+++ b/test-app/tests/integration/components/multiselect-test.gts
@@ -1959,9 +1959,92 @@ module('Integration | Component | Multiselect', function (hooks) {
         </:chip>
 
         <:default as |multiselect|>
-          <multiselect.Option>{{multiselect.option}}</multiselect.Option>
-        </:default>
-      </Multiselect>
+            <multiselect.Option>{{multiselect.option}}</multiselect.Option>
+          </:default>
+        </Multiselect>
     </template>);
+  });
+
+  test('when multiple multiselect controls are on a page, clicking on a container opens the correct popover', async function (assert) {
+    await render(
+      <template>
+        <div class="first-multiselect">
+          <Multiselect
+            @noResultsText="No results"
+            @options={{testColors}}
+            data-input="first"
+          >
+            <:chip as |chip|>
+              <chip.Chip>
+                {{chip.option}}
+                <chip.Remove @label="Remove" />
+              </chip.Chip>
+            </:chip>
+
+            <:default as |multiselect|>
+              <multiselect.Option>{{multiselect.option}}</multiselect.Option>
+            </:default>
+          </Multiselect>
+        </div>
+
+        <div class="second-multiselect">
+          <Multiselect
+            @noResultsText="No results"
+            @options={{testColors}}
+            data-input="second"
+          >
+            <:chip as |chip|>
+              <chip.Chip>
+                {{chip.option}}
+                <chip.Remove @label="Remove" />
+              </chip.Chip>
+            </:chip>
+
+            <:default as |multiselect|>
+              <multiselect.Option>{{multiselect.option}}</multiselect.Option>
+            </:default>
+          </Multiselect>
+        </div>
+      </template>,
+    );
+
+    // Create page objects for both multiselects
+    let firstMultiselect = new MultiselectPageObject('[data-input="first"]');
+    let secondMultiselect = new MultiselectPageObject('[data-input="second"]');
+
+    // Initially, both popovers should be closed
+    assert.dom(firstMultiselect.list).doesNotExist();
+    assert.dom(secondMultiselect.list).doesNotExist();
+
+    // Click on the container of the second multiselect
+    await click(secondMultiselect.container as Element);
+
+    // The second multiselect's popover should be open
+    assert.dom(secondMultiselect.list).exists();
+
+    // The first multiselect's popover should remain closed
+    assert.dom(firstMultiselect.list).doesNotExist();
+
+    // The second multiselect's input should be focused
+    assert.dom(secondMultiselect.element).isFocused();
+
+    // Close the second multiselect's popover
+    await triggerKeyEvent(
+      secondMultiselect.element as Element,
+      'keydown',
+      'Escape',
+    );
+
+    // Now click on the container of the first multiselect
+    await click(firstMultiselect.container as Element);
+
+    // The first multiselect's popover should be open
+    assert.dom(firstMultiselect.list).exists();
+
+    // The second multiselect's popover should remain closed
+    assert.dom(secondMultiselect.list).doesNotExist();
+
+    // The first multiselect's input should be focused
+    assert.dom(firstMultiselect.element).isFocused();
   });
 });


### PR DESCRIPTION
# Pull Request Template

## 🚀 Description

This PR fixes an issue with multiple multiselect components on the same page. Previously, when clicking on a multiselect container, the code would use `document.querySelector` to find the input element, which could incorrectly target the first multiselect on the page rather than the one that was clicked. 

The fix modifies the `handleContainerClick` method to:
- Accept a MouseEvent parameter
- Use the event's currentTarget to scope the querySelector to the specific container that was clicked
- This ensures each multiselect component correctly focuses its own input when clicked

Added a comprehensive test case that verifies multiple multiselect components work correctly when placed on the same page.

---

## 🔬 How to Test

1. Add multiple multiselect components to a page
2. Click on each multiselect container
3. Verify that the correct popover opens for the clicked multiselect
4. Verify that the input for the clicked multiselect receives focus
5. Run the new test case to confirm the fix works as expected

---

## 📸 Images/Videos of Functionality

No visual changes to the component's appearance - this is a behavioral fix that ensures the correct multiselect responds when clicked. Here's a before & after of the docs that show the bad behavior.

https://github.com/user-attachments/assets/9d856d51-2292-463b-8e22-a4d18c5be1b2


https://github.com/user-attachments/assets/7822090b-e692-469a-815e-d9d84d4c0d40

