### PR TITLE
fix(autocomplete): assert nulls

### DIFF
--- a/.changeset/breezy-rings-shave.md
+++ b/.changeset/breezy-rings-shave.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/ember-toucan-form': patch
+---
+
+fix(autocomplete): fix assertion to accept null

--- a/packages/ember-toucan-form/src/-private/autocomplete-field.gts
+++ b/packages/ember-toucan-form/src/-private/autocomplete-field.gts
@@ -51,10 +51,10 @@ export default class ToucanFormAutocompleteFieldComponent<
   @action
   assertSelected(value: unknown) {
     assert(
-      `A string or \`undefined\` is expected for ${String(
+      `A string or \`undefined\` or \`null\` is expected for ${String(
         this.args.name,
       )}, but you passed ${typeof value}`,
-      typeof value === 'string' || value === undefined,
+      typeof value === 'string' || value === undefined || value === null,
     );
 
     return value;


### PR DESCRIPTION
<!-- Hello! This template is automatically added to help write up your pull request. Feel free to delete these comments, although they won't show up in the rendered markdown! This is only a template, feel free to adjust as you please! -->

## 🚀 Description

In development builds, deleting a value from autocomplete within a toucan form causes the value to be set to null. This causes the assertion to throw and the autocomplete to fail to render without a page refresh. This behavior does not occur in production builds.

---

## 🔬 How to Test

1. Use a development build
1. Render an autocomplete in a toucan form
2. Select a value
3. Delete the value
4. Collapse the autocomplete
5. Expand the autocomplete
6. Old behavior: empty container renders, New behavior: container renders as expected

---

## 📸 Images/Videos of Functionality

<!-- For visual changes, it's extremely helpful to include screenshots, gifs, or videos of what has changed.  Before and After images are also super helpful! -->

https://github.com/user-attachments/assets/f497f665-5785-4c9e-95be-e0513a7c92ef


